### PR TITLE
feat: Implement Chromecast clock controls

### DIFF
--- a/src/cast/CastReceiver.test.tsx
+++ b/src/cast/CastReceiver.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Subject } from 'rxjs';
+import { CastReceiver } from './CastReceiver';
+import { OutputEvent } from '@/core/OutputEvent';
+import { OutputEventType } from '@/core/OutputEventType';
+import { StartClockPayload } from './types/chromecast-events';
+
+// Mock WodTimer and WodTimerRef
+const mockWodTimerRef = {
+  start: jest.fn(),
+  stop: jest.fn(),
+  reset: jest.fn(),
+};
+
+jest.mock('@/components/clock/WodTimer', () => ({
+  WodTimer: jest.fn().mockImplementation(React.forwardRef((props, ref) => {
+    if (ref) {
+      (ref as React.MutableRefObject<typeof mockWodTimerRef>).current = mockWodTimerRef;
+    }
+    // Render a placeholder or null, as WodTimer's internals are not tested here
+    return <div data-testid="mock-wod-timer">Mock WodTimer Display: {JSON.stringify(props.display)}</div>;
+  })),
+}));
+
+describe('CastReceiver', () => {
+  let event$: Subject<OutputEvent>;
+
+  beforeEach(() => {
+    event$ = new Subject<OutputEvent>();
+    mockWodTimerRef.start.mockClear();
+    mockWodTimerRef.stop.mockClear();
+    mockWodTimerRef.reset.mockClear();
+  });
+
+  it('should call WodTimerRef.start when START_CLOCK event is received', () => {
+    render(<CastReceiver event$={event$} className="test-class" />);
+    
+    const payload: StartClockPayload = { startTime: 300 }; // 5 minutes
+    const startEvent: OutputEvent = {
+      eventType: 'START_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: payload,
+    };
+    event$.next(startEvent);
+
+    expect(mockWodTimerRef.start).toHaveBeenCalledTimes(1);
+    expect(mockWodTimerRef.start).toHaveBeenCalledWith(payload.startTime);
+  });
+
+  it('should call WodTimerRef.start with undefined if no startTime in payload for START_CLOCK', () => {
+    render(<CastReceiver event$={event$} />);
+    
+    const startEvent: OutputEvent = {
+      eventType: 'START_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {}, // No startTime
+    };
+    event$.next(startEvent);
+
+    expect(mockWodTimerRef.start).toHaveBeenCalledTimes(1);
+    expect(mockWodTimerRef.start).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should call WodTimerRef.stop when STOP_CLOCK event is received', () => {
+    render(<CastReceiver event$={event$} />);
+    
+    const stopEvent: OutputEvent = {
+      eventType: 'STOP_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    event$.next(stopEvent);
+
+    expect(mockWodTimerRef.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call WodTimerRef.reset when RESET_CLOCK event is received', () => {
+    render(<CastReceiver event$={event$} />);
+    
+    const resetEvent: OutputEvent = {
+      eventType: 'RESET_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    event$.next(resetEvent);
+
+    expect(mockWodTimerRef.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should update debug messages when events are received', () => {
+    render(<CastReceiver event$={event$} />);
+    
+    const payload: StartClockPayload = { startTime: 10 };
+    const startEvent: OutputEvent = {
+      eventType: 'START_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: payload,
+    };
+    event$.next(startEvent);
+
+    // Check if the debug message for START_CLOCK is rendered
+    // This relies on the internal implementation detail of how messages are shown,
+    // which is okay for testing the component's own output.
+    expect(screen.getByText(/Start clock at 10/i)).toBeInTheDocument();
+
+    const stopEvent: OutputEvent = {
+      eventType: 'STOP_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    event$.next(stopEvent);
+    expect(screen.getByText(/Stop clock/i)).toBeInTheDocument();
+    
+    const resetEvent: OutputEvent = {
+      eventType: 'RESET_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    event$.next(resetEvent);
+    expect(screen.getByText(/Reset clock/i)).toBeInTheDocument();
+  });
+
+  it('should handle SET_DISPLAY events for completeness', () => {
+    render(<CastReceiver event$={event$} />);
+    const displayPayload = {
+      spans: [{ hours: 0, minutes: 1, seconds: 30, milliseconds: 0 }],
+      totalTime: { hours: 0, minutes: 10, seconds: 0, milliseconds: 0 },
+    };
+    const setDisplayEvent: OutputEvent = {
+      eventType: 'SET_DISPLAY' as OutputEventType,
+      timestamp: new Date(),
+      bag: displayPayload,
+    };
+    event$.next(setDisplayEvent);
+    // We are mocking WodTimer, so we can check the props passed to it.
+    // The mock WodTimer renders props.display as JSON string.
+    expect(screen.getByTestId('mock-wod-timer')).toHaveTextContent(
+      JSON.stringify({
+        primary: displayPayload.spans[0],
+        label: 'Timer', // Default label in CastReceiver
+        bag: { totalTime: displayPayload.totalTime },
+      })
+    );
+  });
+
+});

--- a/src/cast/components/ChromecastButton.tsx
+++ b/src/cast/components/ChromecastButton.tsx
@@ -47,9 +47,13 @@ export const ChromecastButton: React.FC<UseCastSenderResult> = (props) => {
     return baseStyle + "bg-white text-gray-800 hover:bg-gray-50 border-gray-300";
   };
 
-  const controlButtonBaseStyle = "px-3 py-1 rounded-md text-sm font-medium transition-colors ";
-  const activeControlButtonstyle = controlButtonBaseStyle + "bg-green-500 hover:bg-green-600 text-white border border-green-700";
-  const disabledControlButtonstyle = controlButtonBaseStyle + "bg-gray-300 text-gray-500 cursor-not-allowed border border-gray-400";
+  const controlButtonBaseStyle = "px-3 py-1 rounded-md text-sm font-medium transition-colors border "; // Added base border for consistency
+
+  // Define specific styles for each control button
+  const startButtonStyle = controlButtonBaseStyle + "bg-green-500 hover:bg-green-600 text-white border-green-700";
+  const stopButtonStyle = controlButtonBaseStyle + "bg-red-500 hover:bg-red-600 text-white border-red-700";
+  const resetButtonStyle = controlButtonBaseStyle + "bg-yellow-500 hover:bg-yellow-600 text-white border-yellow-700";
+  // const disabledControlButtonstyle = controlButtonBaseStyle + "bg-gray-300 text-gray-500 cursor-not-allowed border-gray-400"; // This was unused, can be removed or kept for future use
 
 
   return (
@@ -81,21 +85,21 @@ export const ChromecastButton: React.FC<UseCastSenderResult> = (props) => {
           <div className="flex items-center space-x-2 ml-2">
             <button
               onClick={() => sendStartClock()}
-              className={activeControlButtonstyle}
+              className={startButtonStyle}
               aria-label="Start Clock"
             >
               Start
             </button>
             <button
               onClick={() => sendStopClock()}
-              className={activeControlButtonstyle.replace("bg-green-500 hover:bg-green-600 border-green-700", "bg-red-500 hover:bg-red-600 border-red-700")} // Quick style change for Stop
+              className={stopButtonStyle}
               aria-label="Stop Clock"
             >
               Stop
             </button>
             <button
               onClick={() => sendResetClock()}
-              className={activeControlButtonstyle.replace("bg-green-500 hover:bg-green-600 border-green-700", "bg-yellow-500 hover:bg-yellow-600 border-yellow-700")} // Quick style change for Reset
+              className={resetButtonStyle}
               aria-label="Reset Clock"
             >
               Reset

--- a/src/cast/components/ChromecastButton.tsx
+++ b/src/cast/components/ChromecastButton.tsx
@@ -1,8 +1,17 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react'; // Added useState
 import { UseCastSenderResult } from '../hooks/useCastSender';
 
-export const ChromecastButton: React.FC<UseCastSenderResult> = ({ state$, connect, disconnect }) => {  
-  const [state, setState] = React.useState(state$.getValue());
+// Make all props from UseCastSenderResult available
+export const ChromecastButton: React.FC<UseCastSenderResult> = (props) => {  
+  const { 
+    state$, 
+    connect, 
+    disconnect, 
+    sendStartClock, 
+    sendStopClock, 
+    sendResetClock 
+  } = props;
+  const [state, setState] = useState(state$.getValue());
   
   useEffect(() => {
     const sub = state$.subscribe(setState);
@@ -25,40 +34,81 @@ export const ChromecastButton: React.FC<UseCastSenderResult> = ({ state$, connec
   }
 
   const getButtonStyle = () => {
-    const baseStyle = "flex items-center px-3 py-1 rounded-full transition-all border border-blue-200 ";
+    const baseStyle = "flex items-center px-3 py-1 rounded-full transition-all border "; // Removed border-blue-200 for individual styling
     if (state.isConnected) {
-      return baseStyle + "bg-blue-600 text-white hover:bg-blue-700 shadow-lg";
+      return baseStyle + "bg-blue-600 text-white hover:bg-blue-700 shadow-lg border-blue-500";
     }
     if (state.isConnecting) {
-      return baseStyle + "bg-blue-400 text-white animate-pulse";
+      return baseStyle + "bg-blue-400 text-white animate-pulse border-blue-300";
     }
     if (!state.isAvailable) {
-      return baseStyle + "bg-white text-gray-400 opacity-50";
+      return baseStyle + "bg-gray-200 text-gray-400 opacity-50 border-gray-300"; // Adjusted for disabled look
     }
-    return baseStyle + "bg-white text-gray-800 hover:bg-gray-50";
+    return baseStyle + "bg-white text-gray-800 hover:bg-gray-50 border-gray-300";
   };
 
+  const controlButtonBaseStyle = "px-3 py-1 rounded-md text-sm font-medium transition-colors ";
+  const activeControlButtonstyle = controlButtonBaseStyle + "bg-green-500 hover:bg-green-600 text-white border border-green-700";
+  const disabledControlButtonstyle = controlButtonBaseStyle + "bg-gray-300 text-gray-500 cursor-not-allowed border border-gray-400";
+
+
   return (
-    <div className="flex items-center">
-      <button
-        className={getButtonStyle()}
-        onClick={handleClick}
-        disabled={!state.isAvailable || state.isConnecting}
-        aria-label={state.isConnected ? 'Disconnect Chromecast' : 'Connect Chromecast'}
-      >
-        <div className="w-4 h-4 mr-1">
-          <svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
-            <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-              <g id="ic_cast_black_24dp">
-                <g id="ic_remove_circle_white_24dp">
-                  <path d="M1,18 L1,21 L4,21 C4,19.34 2.66,18 1,18 L1,18 Z M1,14 L1,16 C3.76,16 6,18.24 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z M1,10 L1,12 C5.97,12 10,16.03 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z" id="cast" fill="currentColor"></path>
-                  <rect id="bounds" x="0" y="0" width="24" height="24"></rect>
+    <div className="flex flex-col space-y-2 items-start"> {/* Changed to flex-col and items-start */}
+      <div className="flex items-center space-x-2"> {/* Group for connect and control buttons */}
+        <button
+          className={getButtonStyle()}
+          onClick={handleClick}
+          disabled={!state.isAvailable || state.isConnecting}
+          aria-label={state.isConnected ? 'Disconnect Chromecast' : 'Connect Chromecast'}
+        >
+          <div className="w-4 h-4 mr-1"> {/* SVG remains the same */}
+            <svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+              <g id="Page-1" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+                <g id="ic_cast_black_24dp">
+                  <g id="ic_remove_circle_white_24dp">
+                    <path d="M1,18 L1,21 L4,21 C4,19.34 2.66,18 1,18 L1,18 Z M1,14 L1,16 C3.76,16 6,18.24 6,21 L8,21 C8,17.13 4.87,14 1,14 L1,14 Z M1,10 L1,12 C5.97,12 10,16.03 10,21 L12,21 C12,14.92 7.07,10 1,10 L1,10 Z M21,3 L3,3 C1.9,3 1,3.9 1,5 L1,8 L3,8 L3,5 L21,5 L21,19 L14,19 L14,21 L21,21 C22.1,21 23,20.1 23,19 L23,5 C23,3.9 22.1,3 21,3 L21,3 Z" id="cast" fill="currentColor"></path>
+                    <rect id="bounds" x="0" y="0" width="24" height="24"></rect>
+                  </g>
                 </g>
               </g>
-            </g>
-          </svg>
-        </div>       
-      </button>      
+            </svg>
+          </div>       
+          <span>{state.isConnected ? (state.deviceName || 'Disconnect') : 'Connect'}</span>
+        </button>
+
+        {/* New Control Buttons */}
+        {state.isConnected && sendStartClock && sendStopClock && sendResetClock && (
+          <div className="flex items-center space-x-2 ml-2">
+            <button
+              onClick={() => sendStartClock()}
+              className={activeControlButtonstyle}
+              aria-label="Start Clock"
+            >
+              Start
+            </button>
+            <button
+              onClick={() => sendStopClock()}
+              className={activeControlButtonstyle.replace("bg-green-500 hover:bg-green-600 border-green-700", "bg-red-500 hover:bg-red-600 border-red-700")} // Quick style change for Stop
+              aria-label="Stop Clock"
+            >
+              Stop
+            </button>
+            <button
+              onClick={() => sendResetClock()}
+              className={activeControlButtonstyle.replace("bg-green-500 hover:bg-green-600 border-green-700", "bg-yellow-500 hover:bg-yellow-600 border-yellow-700")} // Quick style change for Reset
+              aria-label="Reset Clock"
+            >
+              Reset
+            </button>
+          </div>
+        )}
+      </div>
+      {/* Display device name when connected */}
+      {state.isConnected && state.deviceName && (
+        <div className="text-xs text-gray-600 mt-1">
+          Connected to: {state.deviceName}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/cast/hooks/useCastSender.ts
+++ b/src/cast/hooks/useCastSender.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { BehaviorSubject } from 'rxjs';
-import { CAST_NAMESPACE } from '../types/chromecast-events';
+import { CAST_NAMESPACE, StartClockPayload } from '../types/chromecast-events';
 import { OutputEvent } from "@/core/OutputEvent";
+import { OutputEventType } from '@/core/OutputEventType';
 
 export interface ChromecastState {
   isAvailable: boolean;
@@ -16,6 +17,9 @@ export interface UseCastSenderResult {
   connect: () => Promise<void>;
   disconnect: () => Promise<void>;
   sendMessage: (event: OutputEvent) => Promise<void>;
+  sendStartClock: (payload?: StartClockPayload) => Promise<void>;
+  sendStopClock: () => Promise<void>;
+  sendResetClock: () => Promise<void>;
 }
 
 /**
@@ -126,5 +130,32 @@ export function useCastSender(): UseCastSenderResult {
     }
   }, [state.isConnected]);
 
-  return { state$, connect, disconnect, sendMessage };
+  const sendStartClock = useCallback(async (payload?: StartClockPayload) => {
+    const event: OutputEvent = {
+      eventType: 'START_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: payload || {},
+    };
+    await sendMessage(event);
+  }, [sendMessage]);
+
+  const sendStopClock = useCallback(async () => {
+    const event: OutputEvent = {
+      eventType: 'STOP_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    await sendMessage(event);
+  }, [sendMessage]);
+
+  const sendResetClock = useCallback(async () => {
+    const event: OutputEvent = {
+      eventType: 'RESET_CLOCK' as OutputEventType,
+      timestamp: new Date(),
+      bag: {},
+    };
+    await sendMessage(event);
+  }, [sendMessage]);
+
+  return { state$, connect, disconnect, sendMessage, sendStartClock, sendStopClock, sendResetClock };
 }

--- a/src/cast/types/chromecast-events.ts
+++ b/src/cast/types/chromecast-events.ts
@@ -34,3 +34,7 @@ export interface ChromecastReceiverEvent
     message: OutputEvent;
     timestamp: Date;
 }
+
+export interface StartClockPayload {
+  startTime?: number; // Optional start time in seconds
+}

--- a/src/components/clock/WodTimer.test.tsx
+++ b/src/components/clock/WodTimer.test.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { WodTimer, WodTimerRef, WodTimerProps } from './WodTimer';
+import { Duration } from '@/core/Duration';
+import { ISpanDuration } from '@/core/ISpanDuration';
+import { IDuration } from '@/core/IDuration';
+
+// Mock ISpanDuration for passive mode testing
+const mockSpanDuration = (elapsedMs: number, remainingMs?: number, sign: '+' | '-' = '+'): ISpanDuration => ({
+  elapsed: jest.fn(() => new Duration(elapsedMs)),
+  remaining: jest.fn(() => (remainingMs !== undefined ? new Duration(remainingMs) : undefined)),
+  sign: sign,
+  spans: [], // Not used by WodTimer directly for display
+  // IDuration parts
+  days: new Duration(elapsedMs).days,
+  hours: new Duration(elapsedMs).hours,
+  minutes: new Duration(elapsedMs).minutes,
+  seconds: new Duration(elapsedMs).seconds,
+  milliseconds: new Duration(elapsedMs).milliseconds,
+  isZero: new Duration(elapsedMs).isZero,
+  toMilliseconds: jest.fn(() => elapsedMs),
+  toString: jest.fn(() => new Duration(elapsedMs).toString()),
+  abs: jest.fn(() => new Duration(Math.abs(elapsedMs))),
+  original: elapsedMs,
+});
+
+
+describe('WodTimer', () => {
+  let wodTimerRef: React.RefObject<WodTimerRef>;
+
+  beforeEach(() => {
+    wodTimerRef = React.createRef<WodTimerRef>();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  const renderWodTimer = (props?: Partial<WodTimerProps>) => {
+    render(<WodTimer ref={wodTimerRef} {...props} />);
+  };
+
+  // Helper to get displayed time (expects format MM:SS.m)
+  const getDisplayedTime = ()  => {
+    const timeText = screen.getByText(/(\d{2}:\d{2})\.\d/); // Matches "MM:SS.m"
+    // Extract MM:SS part for easier comparison in most tests
+    const match = timeText.textContent?.match(/(\d{2}:\d{2})/);
+    return match ? match[1] : null;
+  };
+   // Helper to get displayed milliseconds (the digit after dot)
+   const getDisplayedMsTenth = (): string | null => {
+    const timeText = screen.getByText(/\d{2}:\d{2}\.(\d)/); // Matches "MM:SS.m" and captures "m"
+    const match = timeText.textContent?.match(/\.(\d)$/);
+    return match ? match[1] : null;
+  };
+
+
+  test('should initialize to 00:00.0 when no props are given', () => {
+    renderWodTimer();
+    expect(getDisplayedTime()).toBe('00:00');
+    expect(getDisplayedMsTenth()).toBe('0');
+  });
+
+  describe('Active Mode - Count Up', () => {
+    test('start() should count up from 00:00.0', () => {
+      renderWodTimer();
+      act(() => {
+        wodTimerRef.current?.start();
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      act(() => {
+        jest.advanceTimersByTime(1000); // 1 second
+      });
+      expect(getDisplayedTime()).toBe('00:01');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      act(() => {
+        jest.advanceTimersByTime(500); // 0.5 seconds
+      });
+      expect(getDisplayedTime()).toBe('00:01');
+      expect(getDisplayedMsTenth()).toBe('5');
+    });
+
+    test('start(startTimeInSeconds) should count up from specified time', () => {
+      renderWodTimer();
+      act(() => {
+        wodTimerRef.current?.start(5); // Start at 00:05.0
+      });
+      expect(getDisplayedTime()).toBe('00:05');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:06');
+      expect(getDisplayedMsTenth()).toBe('0');
+    });
+
+    test('stop() should freeze the timer', () => {
+      renderWodTimer();
+      act(() => {
+        wodTimerRef.current?.start();
+        jest.advanceTimersByTime(1200); // 00:01.2
+      });
+      expect(getDisplayedTime()).toBe('00:01');
+      expect(getDisplayedMsTenth()).toBe('2');
+
+      act(() => {
+        wodTimerRef.current?.stop();
+        jest.advanceTimersByTime(1000); // Try to advance time
+      });
+      // Time should remain frozen
+      expect(getDisplayedTime()).toBe('00:01');
+      expect(getDisplayedMsTenth()).toBe('2');
+    });
+
+    test('reset() should reset to 00:00.0 and stop', () => {
+      renderWodTimer();
+      act(() => {
+        wodTimerRef.current?.start();
+        jest.advanceTimersByTime(1500); // 00:01.5
+      });
+      expect(getDisplayedTime()).toBe('00:01');
+      expect(getDisplayedMsTenth()).toBe('5');
+
+      act(() => {
+        wodTimerRef.current?.reset();
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      // Ensure it's stopped
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+      expect(getDisplayedMsTenth()).toBe('0');
+    });
+  });
+
+  describe('Active Mode - Count Down', () => {
+    test('start() with countdownFrom prop should count down', () => {
+      renderWodTimer({ countdownFrom: 3 }); // 3 seconds
+      act(() => {
+        wodTimerRef.current?.start();
+      });
+      expect(getDisplayedTime()).toBe('00:03'); // Initial display
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      act(() => {
+        jest.advanceTimersByTime(1000); // 1 second
+      });
+      expect(getDisplayedTime()).toBe('00:02');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      act(() => {
+        jest.advanceTimersByTime(1900); // 1.9 seconds (total 2.9s)
+      });
+      expect(getDisplayedTime()).toBe('00:00'); // Should be 00:00.1
+      expect(getDisplayedMsTenth()).toBe('1');
+      
+      act(() => {
+        jest.advanceTimersByTime(100); // total 3s, reaches 0
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+      expect(getDisplayedMsTenth()).toBe('0');
+       // Timer should stop at 0
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+      expect(getDisplayedMsTenth()).toBe('0');
+    });
+
+    test('start(startTimeInSeconds) with countdownFrom prop should ignore startTime and use countdownFrom', () => {
+      renderWodTimer({ countdownFrom: 3 });
+      act(() => {
+        wodTimerRef.current?.start(10); // This startTime should be ignored for countdown
+      });
+      expect(getDisplayedTime()).toBe('00:03');
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:02');
+    });
+
+    test('reset() with countdownFrom prop should reset to countdownFrom value and stop', () => {
+      renderWodTimer({ countdownFrom: 5 });
+      act(() => {
+        wodTimerRef.current?.start();
+        jest.advanceTimersByTime(2000); // Counts down to 00:03.0
+      });
+      expect(getDisplayedTime()).toBe('00:03');
+
+      act(() => {
+        wodTimerRef.current?.reset();
+      });
+      expect(getDisplayedTime()).toBe('00:05'); // Resets to initial countdown value
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      // Ensure it's stopped
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:05');
+    });
+  });
+
+  describe('Passive Mode (prop-driven)', () => {
+    test('should display time from `primary` prop when not running', () => {
+      const initialPrimary = mockSpanDuration(123000); // 02:03.0
+      renderWodTimer({ primary: initialPrimary });
+      expect(getDisplayedTime()).toBe('02:03');
+      expect(getDisplayedMsTenth()).toBe('0');
+
+      // Simulate prop update (e.g. parent re-renders with new prop)
+      act(() => {
+        // This requires re-rendering with new props or ensuring the mock's methods are called by the interval in WodTimer
+        // For simplicity here, we'll assume the interval within WodTimer calls elapsed() again.
+        // If WodTimer's internal passive interval is running:
+        initialPrimary.elapsed.mockReturnValue(new Duration(124000)); // 02:04.0
+        jest.advanceTimersByTime(100); // Trigger WodTimer's internal passive update
+      });
+       expect(getDisplayedTime()).toBe('02:04');
+       expect(getDisplayedMsTenth()).toBe('0');
+    });
+
+    test('should switch from passive to active mode and back', () => {
+      const initialPrimary = mockSpanDuration(60000); // 01:00.0
+      renderWodTimer({ primary: initialPrimary });
+      expect(getDisplayedTime()).toBe('01:00'); // Passive
+
+      // Start active timer
+      act(() => {
+        wodTimerRef.current?.start(0); // Start from 00:00.0
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getDisplayedTime()).toBe('00:01'); // Active
+
+      // Stop active timer - should remain on active time
+      act(() => {
+        wodTimerRef.current?.stop();
+        jest.advanceTimersByTime(1000); // Should not advance
+      });
+      expect(getDisplayedTime()).toBe('00:01');
+
+      // Reset - should reset active timer and remain stopped (showing active timer's reset state)
+      act(() => {
+        wodTimerRef.current?.reset();
+      });
+      expect(getDisplayedTime()).toBe('00:00');
+
+      // If we were to re-enable passive mode, it might involve removing the `isRunning` flag
+      // and letting the prop-driven useEffect take over. The current design has `isRunning`
+      // only set to false on stop/reset. If `primary` prop changes while stopped,
+      // the passive useEffect should update `propPrimaryDisplay`.
+      // This test case focuses on the switch to active and its controls.
+    });
+  });
+});

--- a/src/components/clock/WodTimer.tsx
+++ b/src/components/clock/WodTimer.tsx
@@ -1,51 +1,55 @@
 /** @jsxImportSource react */
+/** @jsxImportSource react */
 import { ISpanDuration } from "@/core/ISpanDuration";
 import { Duration } from "@/core/Duration";
 import { IDuration } from "@/core/IDuration";
-import { TimeSpanDuration } from "@/core/TimeSpanDuration";
-import React, { useState, useEffect } from "react";
+// TimeSpanDuration might not be directly needed here if ISpanDuration methods are sufficient for props
+import React, { useState, useEffect, useImperativeHandle, forwardRef, useRef } from "react";
 
 export interface WodTimerProps {
-  label: string;
-  primary: ISpanDuration;
-  total: ISpanDuration;
+  label?: string; // Made optional if timer can run independently
+  primary?: ISpanDuration; // Made optional
+  total?: ISpanDuration;   // Made optional
+  // Configuration for active mode, e.g., countdown total time
+  countdownFrom?: number; // in seconds
+  countUpLimit?: number; // in seconds, for future use
+}
+
+export interface WodTimerRef {
+  start: (startTime?: number) => void; // startTime in seconds
+  stop: () => void;
+  reset: () => void;
 }
 
 export const ClockDisplay: React.FC<{ duration: IDuration | undefined }> = ({
   duration,
 }) => {
-  // Implementation of ClockDisplay
+  const pad = (n: number): string => n.toString().padStart(2, "0");
 
-  const pad = (n: number) => n.toString().padStart(2, "0");
+  const days = Math.floor(duration?.days || 0);
+  const hours = Math.floor(duration?.hours || 0);
+  const minutes = Math.floor(duration?.minutes || 0);
+  const seconds = Math.floor(duration?.seconds || 0);
+  const milliseconds = Math.floor(duration?.milliseconds || 0);
 
-  const days = duration?.days || 0;
-  const hours = duration?.hours || 0;
-  const minutes = duration?.minutes || 0;
-  const seconds = duration?.seconds || 0;
-  const milliseconds = duration?.milliseconds || 0;
+  const clock: string[] = [];
 
-  const clock = [];
-
-  if (days && days > 0) {
-    clock.push(`${days}`);
+  if (days > 0) {
+    clock.push(pad(days));
   }
 
-  if ((hours && hours > 0) || clock.length > 0) {
-    clock.push(`${pad(hours)}`);
+  if (hours > 0 || clock.length > 0) {
+    clock.push(pad(hours));
   }
 
-  if (clock.length > 0) {
-    clock.push(`${pad(minutes)}`);
-  } else {
-    clock.push(`${minutes}`);
-  }
+  clock.push(pad(minutes));
+  clock.push(pad(seconds));
 
-  clock.push(`${pad(seconds)}`);
-
-  if (!clock) { 
+  if (clock.length === 0) {
     return (
       <div className="mx-auto flex items-center">
-        <span className="text-5xl md:text-6xl">--:--.-</span>
+        <span className="text-5xl md:text-6xl">00:00</span>
+        <span className="text-gray-600 text-4xl">.0</span>
       </div>
     );
   }
@@ -58,61 +62,125 @@ export const ClockDisplay: React.FC<{ duration: IDuration | undefined }> = ({
   );
 };
 
-export const WodTimer: React.FC<WodTimerProps> = ({
-  label,
-  primary,
-  total,
-}) => {
-  const [primaryDisplay, setPrimaryDisplay] = useState<IDuration | undefined>();
-  const [totalDisplay, setTotalDisplay] = useState<IDuration | undefined>();
+export const WodTimer = forwardRef<WodTimerRef, WodTimerProps>((props, ref) => {
+  const { label = "Timer", primary, total, countdownFrom } = props;
 
+  // State for prop-driven display (passive mode)
+  const [propPrimaryDisplay, setPropPrimaryDisplay] = useState<IDuration | undefined>();
+  const [propTotalDisplay, setPropTotalDisplay] = useState<IDuration | undefined>();
+
+  // State for active internal timer
+  const [activeCurrentTime, setActiveCurrentTime] = useState<IDuration>(new Duration(0));
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const directionRef = useRef<"up" | "down">("up"); // 'up' or 'down' for countdown
+  const targetTimeRef = useRef<number>(0); // For countdown, target time in ms
+
+  // Effect for prop-driven display (passive mode)
   useEffect(() => {
-    if (primary) {
+    if (!isRunning && primary) {
+      setPropPrimaryDisplay(
+        primary.sign === "+" || primary.sign === undefined ? primary.elapsed() : primary.remaining()
+      );
+    }
+    if (!isRunning && total) {
+      setPropTotalDisplay(total.elapsed());
+    }
+
+    if (!isRunning && (primary || total)) {
+      const passiveIntervalId = setInterval(() => {
+        if (primary) {
+          setPropPrimaryDisplay(
+            primary.sign === "+" || primary.sign === undefined ? primary.elapsed() : primary.remaining()
+          );
+        }
+        if (total) {
+          setPropTotalDisplay(total.elapsed());
+        }
+      }, 100);
+      return () => clearInterval(passiveIntervalId);
+    }
+  }, [primary, total, isRunning]);
+
+  useImperativeHandle(ref, () => ({
+    start: (startTimeInSeconds?: number) => {
+      clearInterval(intervalRef.current!);
+      setIsRunning(true);
+
+      let initialMs = 0;
+      if (startTimeInSeconds !== undefined) {
+        initialMs = startTimeInSeconds * 1000;
+      } else if (countdownFrom !== undefined) {
+        initialMs = countdownFrom * 1000;
+      }
       
-      setPrimaryDisplay(
-        primary.sign === "+" || primary.sign === undefined ? primary.elapsed() : primary.remaining());
-    }
-    if (total) {
-      setTotalDisplay(total.elapsed());
-    }
-
-    // Set up interval to continuously update
-    const intervalId = setInterval(() => {
-      if (primary) {
-        setPrimaryDisplay(primary.sign === "+" || primary.sign === undefined ? primary.elapsed() : primary.remaining());
+      if (countdownFrom !== undefined) {
+        directionRef.current = "down";
+        setActiveCurrentTime(new Duration(initialMs));
+        targetTimeRef.current = 0; // Target is 0 for countdown
+      } else {
+        directionRef.current = "up";
+        setActiveCurrentTime(new Duration(initialMs));
+        // For count up, targetTime could be used for an "up to" limit if needed
       }
-      if (total) {
-        setTotalDisplay(total.elapsed());
-      }
-    }, 100); // Update every 100ms for smooth display
 
-    // Cleanup function to clear the interval
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [primary, total]); // Re-run effect when primary or total props change
+      intervalRef.current = setInterval(() => {
+        setActiveCurrentTime(prevTime => {
+          const currentMs = prevTime.toMilliseconds();
+          let nextMs;
+          if (directionRef.current === "down") {
+            nextMs = Math.max(0, currentMs - 100);
+            if (nextMs === 0) {
+              clearInterval(intervalRef.current!);
+              setIsRunning(false);
+              // Potentially emit a 'finished' event here
+            }
+          } else { // count up
+            nextMs = currentMs + 100;
+            // Add limit logic here if countUpLimit is implemented
+          }
+          return new Duration(nextMs);
+        });
+      }, 100);
+    },
+    stop: () => {
+      clearInterval(intervalRef.current!);
+      setIsRunning(false);
+    },
+    reset: () => {
+      clearInterval(intervalRef.current!);
+      setIsRunning(false);
+      let initialMs = 0;
+      if (countdownFrom !== undefined) {
+        initialMs = countdownFrom * 1000;
+        directionRef.current = "down";
+      } else {
+        directionRef.current = "up";
+      }
+      setActiveCurrentTime(new Duration(initialMs));
+    },
+  }));
+
+  const displayDuration = isRunning ? activeCurrentTime : propPrimaryDisplay;
 
   return (
     <div className="w-full flex flex-col items-center justify-center py-2 pb-2 px-1 bg-white">
-      <div className="grid md:grid-cols-3 gap-1 md:gap-4">
-        {/* Left section - Rounds */}
+      <div className="grid md:grid-cols-3 gap-1 md:gap-4 items-center">
         <div className="bg-gray-50/20 p-1 md:p-4">
           <div className="text-2xl font-semibold text-gray-700">{label}</div>
         </div>
-
-        {/* Middle section - Main Timer */}
         <div className="bg-white p-2 md:p-4 rounded-lg flex items-center justify-center">
           <div className="text-5xl md:text-8xl font-mono font-bold text-gray-800 tracking-wider">
-            <ClockDisplay duration={primaryDisplay} />
+            <ClockDisplay duration={displayDuration} />
           </div>
         </div>
-
         <div className="bg-gray-50/20 p-4">
           <div className="space-y-2 md:space-y-4">
             <div className="text-gray-600">
               <div className="text-sm uppercase tracking-wide">Total Time</div>
               <div className="text-xl font-mono">
-                <ClockDisplay duration={totalDisplay} />
+                {/* Total display might need its own logic if active timer affects it */}
+                <ClockDisplay duration={isRunning ? undefined : propTotalDisplay} />
               </div>
             </div>
           </div>
@@ -120,4 +188,6 @@ export const WodTimer: React.FC<WodTimerProps> = ({
       </div>
     </div>
   );
-};
+});
+
+WodTimer.displayName = "WodTimer";

--- a/src/core/OutputEventType.ts
+++ b/src/core/OutputEventType.ts
@@ -10,4 +10,7 @@ export type OutputEventType = 'SYSTEM' |
   'SET_SOUND' |
   'SET_DEBUG' |
   'SET_ERROR' |
-  'SET_IDLE';
+  'SET_IDLE' |
+  'START_CLOCK' |
+  'STOP_CLOCK' |
+  'RESET_CLOCK';


### PR DESCRIPTION
This feature allows you to control the timer running on a Chromecast device from the sender application.

Key changes:

- **Event System:** I added new event types (`START_CLOCK`, `STOP_CLOCK`, `RESET_CLOCK`) and associated payloads to `src/cast/types/chromecast-events.ts` and `src/core/OutputEventType.ts`.
- **Sender Logic:** I updated `src/cast/hooks/useCastSender.ts` with `sendStartClock`, `sendStopClock`, and `sendResetClock` methods to send control commands.
- **Receiver Logic:** I modified `src/cast/CastReceiver.tsx` to handle these new control events. It now uses a ref to call `start`, `stop`, and `reset` methods on the `WodTimer` component.
- **Timer Component:** I enhanced `src/components/clock/WodTimer.tsx` to expose `start`, `stop`, and `reset` methods via `React.forwardRef` and `useImperativeHandle`. The component can now manage its own timer state.
- **UI Controls:** I added "Start", "Stop", and "Reset" buttons to `src/cast/components/ChromecastButton.tsx`, which are visible when connected to a Chromecast device.
- **Testing:** I added unit tests for `CastReceiver.tsx` and `WodTimer.tsx` to cover the new control logic. (Note: I encountered some problems while running the tests).
- **Documentation:** I updated `docs/Notes/Chromecast.md` to reflect the new architecture, event types, communication flow, and UI controls.