### PR TITLE
Fix: Make rollup-win32-x64-msvc an optional dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@playwright/test": "^1.53.1",
-        "@rollup/rollup-win32-x64-msvc": "^4.43.0",
         "chevrotain": "^11.0.3"
       },
       "devDependencies": {
@@ -35,6 +34,9 @@
         "typescript": "^5.0.0",
         "vite": "^6.3.5",
         "vitest": "^3.2.4"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-win32-x64-msvc": "^4.43.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1326,6 +1328,7 @@
         "x64"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ]

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@playwright/test": "^1.53.1",
-    "@rollup/rollup-win32-x64-msvc": "^4.43.0",
     "chevrotain": "^11.0.3"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-win32-x64-msvc": "^4.43.0"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^9.0.12",


### PR DESCRIPTION
Moved @rollup/rollup-win32-x64-msvc from the main dependencies to optionalDependencies in package.json. This resolves an EBADPLATFORM error in CI environments that are not Windows-based, while still allowing the package to be installed for local Windows development.