### PR TITLE
Panel behavior on navigation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(gh api:*)",
-      "Bash(npm run test:unit:*)",
+      "Bash(npm run test*)",
       "Bash(.specify/scripts/powershell*)",
       "Bash(gh pr view:*)",
       "WebFetch(domain:github.com)",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,6 @@ Each strategy implements `match()` and `compile()` methods. First matching strat
 Multi-project Vitest configuration with three test suites:
 
 - `npm test` - Run all test projects (~2-3 seconds)
-- `npm run test:unit` - Node.js unit tests (`src/**/*.{test,spec}.ts`)
 - `npm run test:watch` - Unit tests in watch mode
 - `npm run test:storybook` - Storybook component tests with Playwright (requires browsers)
 - `npm run test:e2e` - End-to-end Playwright tests
@@ -82,7 +81,7 @@ Multi-project Vitest configuration with three test suites:
    - Verify build completes without errors and creates `storybook-static/` directory
 
 3. **Unit Test Regression**:
-   - Run `npm run test:unit`
+   - Run `npm run test`
    - Ensure no NEW test failures are introduced
    - Accept existing 4 module failures and 1 integration test failure as baseline
 
@@ -92,7 +91,7 @@ Multi-project Vitest configuration with three test suites:
 - `npm install`: ~15 seconds
 - `npm run storybook`: ~2 seconds to start
 - `npm run build-storybook`: ~30 seconds (NEVER CANCEL - set timeout to 60+ minutes)
-- `npm run test:unit`: ~2-3 seconds
+- `npm run test`: ~2-3 seconds
 - `npm run setup`: ~30 seconds (may fail on Playwright download - expected)
 
 ## Project Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,6 @@ WOD Wiki is a React component library for parsing, displaying, and executing wor
 ## Build/Lint/Test Commands
 
 - `npm test` - Run all tests using Vitest (~2-3 seconds)
-- `npm run test:unit` - Run unit tests only (~2-3 seconds)
 - `npm run test:watch` - Run unit tests in watch mode
 - `npm run test:storybook` - Run Storybook component tests (requires Playwright)
 - `npm run test:e2e` - Run end-to-end tests with Playwright
@@ -145,7 +144,7 @@ After making changes, always validate:
    - Verify build completes without errors and creates `storybook-static/` directory
 
 3. **Unit Test Regression**:
-   - Run `npm run test:unit`
+   - Run `npm run test`
    - Ensure no NEW test failures are introduced
    - Accept existing 4 module failures and 1 integration test failure as baseline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,6 @@ WOD Wiki is a React component library for parsing, displaying, and executing wor
 
 ### Testing Commands
 - `npm test` - Run all tests using Vitest (~2-3 seconds)
-- `npm run test:unit` - Run unit tests only (~2-3 seconds)
 - `npm run test:storybook` - Run Storybook component tests (requires Playwright)
 - `npm run test:watch` - Run unit tests in watch mode
 - `npm run test:e2e` - Run end-to-end tests with Playwright
@@ -111,7 +110,7 @@ After making changes, always validate:
    - Verify build completes without errors and creates `storybook-static/` directory
 
 3. **Unit Test Regression**:
-   - Run `npm run test:unit`
+   - Run `npm run test`
    - Ensure no NEW test failures are introduced
    - Accept existing 4 module failures and 1 integration test failure as baseline
 

--- a/docs/runtime-metrics-gap-analysis.md
+++ b/docs/runtime-metrics-gap-analysis.md
@@ -1,0 +1,99 @@
+# Runtime Metrics Gap Analysis
+
+## 1. Current State
+
+The current runtime metrics implementation relies on real-time memory queries to visualize execution progress. The `RuntimeLayout` component specifically queries for `MemoryTypeEnum.TIMER_TIME_SPANS` to construct the `GitTreeSidebar` visualization.
+
+### Data Flow
+1.  **Allocation**: `TimerBlock` (via `TimerBehavior`) allocates a public memory reference for `TIMER_TIME_SPANS`.
+2.  **Tracking**: `TimerBehavior` updates this memory with `TimeSpan` objects (start/stop timestamps) as the timer runs.
+3.  **Visualization**: `RuntimeLayout` queries the memory system for all references of type `TIMER_TIME_SPANS` and maps them to `Segment` objects for the timeline.
+4.  **Cleanup**: When a block completes, it is popped from the stack. The consumer (usually the parent block or the runtime loop) is responsible for calling `dispose()`, which releases all memory references associated with that block.
+
+## 2. Missing Capabilities
+
+### A. Data Persistence (The "Disappearing History" Problem)
+**Issue**: The runtime memory is designed for *active execution state*, not *historical reporting*.
+*   When a block finishes (e.g., a round is completed), it is popped from the stack.
+*   The `dispose()` method is called to prevent memory leaks.
+*   `RuntimeMemory.release()` **deletes** the data from the `_references` array.
+*   **Result**: As soon as a block finishes, it vanishes from the timeline. The user cannot see what they have already completed.
+
+### B. Universal Time Tracking
+**Issue**: Only `TimerBlock` tracks time.
+*   `TimerBehavior` is the only component that writes to `TIMER_TIME_SPANS`.
+*   `RoundsBlock` (used for "3 rounds of...") and `EffortBlock` (used for "10 push-ups") do not use `TimerBehavior`.
+*   These blocks track their own specific state (reps, rounds) but do not record *when* they started or stopped.
+*   **Result**: The timeline only shows timer-based segments. A workout like "3 Rounds of 10 Push-ups" might show nothing or only the top-level timer, missing the internal structure.
+
+### C. Hierarchy Reconstruction
+**Issue**: The parent-child relationship is implicit in the runtime stack but not explicitly stored in memory.
+*   Memory references have an `ownerId` (the block ID).
+*   They do not store a `parentId`.
+*   **Result**: Even if we persisted the data, we would have a flat list of segments without knowing which round belonged to which timer. The `GitTreeSidebar` requires a tree structure to display nested segments correctly.
+
+## 3. Proposed Solution
+
+To fix these issues, we need to introduce a persistent **Execution History** system that sits alongside the transient Runtime Memory.
+
+### Core Components
+
+1.  **`ExecutionLog` in `ScriptRuntime`**
+    *   A persistent array that stores completed block metrics.
+    *   Survives block disposal.
+    *   Accessible to the UI for rendering history.
+
+2.  **`HistoryBehavior`**
+    *   A new behavior attached to *all* blocks (Timer, Rounds, Effort).
+    *   **On Mount**: Records `startTime` and `parentId` (from the current stack).
+    *   **On Dispose**: Records `endTime` and flushes the record to the `ExecutionLog`.
+
+3.  **Unified `ExecutionRecord` Interface**
+    ```typescript
+    interface ExecutionRecord {
+        blockId: string;
+        parentId: string | null;
+        type: 'timer' | 'rounds' | 'effort';
+        label: string; // e.g., "Round 1", "Push-ups"
+        startTime: number;
+        endTime: number;
+        metrics: {
+            reps?: number;
+            weight?: number;
+            // ... other specific metrics
+        };
+    }
+    ```
+
+## 4. Implementation Plan
+
+### Phase 1: The Execution Log
+1.  Define the `ExecutionRecord` interface in `src/runtime/models/ExecutionRecord.ts`.
+2.  Add `executionLog: ExecutionRecord[]` to `ScriptRuntime`.
+3.  Add a method `logExecution(record: ExecutionRecord)` to `ScriptRuntime`.
+
+### Phase 2: Universal History Behavior
+1.  Create `src/runtime/behaviors/HistoryBehavior.ts`.
+2.  Implement `onPush`:
+    *   Capture `startTime = Date.now()`.
+    *   Capture `parentId` by peeking at the `runtime.stack` (the block below the current one is the parent).
+3.  Implement `dispose` (or a new `onDispose` hook in `IRuntimeBehavior`):
+    *   Capture `endTime = Date.now()`.
+    *   Construct `ExecutionRecord`.
+    *   Call `runtime.logExecution()`.
+
+### Phase 3: Integrate with Blocks
+1.  Update `JitCompiler` or specific strategies (`TimerStrategy`, `RoundsStrategy`, `EffortStrategy`) to attach `HistoryBehavior` to every block.
+2.  Ensure `RuntimeBlock.dispose()` iterates behaviors and calls the new disposal hook.
+
+### Phase 4: Update Visualization
+1.  Modify `RuntimeLayout.tsx` to merge data from two sources:
+    *   **History**: `runtime.executionLog` (for completed blocks).
+    *   **Active**: `runtime.memory` (for the currently running block).
+2.  Map both sources to the `Segment` format required by `GitTreeSidebar`.
+3.  Use `parentId` to reconstruct the tree structure.
+
+## 5. Immediate Next Steps
+1.  Create the `ExecutionRecord` interface.
+2.  Implement `HistoryBehavior`.
+3.  Attach it to `TimerBlock` as a proof of concept.

--- a/gemini.md
+++ b/gemini.md
@@ -22,8 +22,7 @@ WOD Wiki is a React component library for parsing, displaying, and executing wor
 
 ### Testing Commands
 - `npm test` - Run all tests using Vitest (~2-3 seconds)
-- `npm run test:unit` - Run unit tests only (~2-3 seconds)
-- `npm run test:storybook` - Run Storybook component tests (requires Playwright)
+- - `npm run test:storybook` - Run Storybook component tests (requires Playwright)
 - `npm run test:watch` - Run unit tests in watch mode
 - `npm run test:e2e` - Run end-to-end tests with Playwright
 
@@ -145,7 +144,7 @@ After making changes, always validate:
    - Verify build completes without errors and creates `storybook-static/` directory
 
 3. **Unit Test Regression**:
-   - Run `npm run test:unit`
+   - Run `npm run test`
    - Ensure no NEW test failures are introduced
    - Accept existing 4 module failures and 1 integration test failure as baseline
 

--- a/setup-testing.js
+++ b/setup-testing.js
@@ -43,7 +43,6 @@ for (const file of configFiles) {
 }
 
 console.log('\n🎉 Setup complete! You can now run:');
-console.log('  npm test              # Run all tests');
-console.log('  npm run test:unit     # Run unit tests only');
+console.log('  npm run test          # Run unit tests only');
 console.log('  npm run test:storybook # Run Storybook tests only');
 console.log('  npm run storybook     # Start Storybook dev server');

--- a/src/components/layout/WodWorkbench.tsx
+++ b/src/components/layout/WodWorkbench.tsx
@@ -14,7 +14,6 @@ import { WodIndexPanel } from './WodIndexPanel';
 import { parseDocumentStructure, DocumentItem } from '../../markdown-editor/utils/documentStructure';
 import { MetricsProvider } from '../../services/MetricsContext';
 import { RuntimeLayout } from '../../views/runtime/RuntimeLayout';
-import { AnalyticsLayout } from '../../views/analytics/AnalyticsLayout';
 
 export interface WodWorkbenchProps extends Omit<MarkdownEditorProps, 'onMount' | 'onBlocksChange' | 'onActiveBlockChange' | 'onCursorPositionChange' | 'highlightedLine'> {
   initialContent?: string;
@@ -270,9 +269,9 @@ const WodWorkbenchContent: React.FC<WodWorkbenchProps> = ({
             )}
           </div>
 
-          {/* Panel 3: Runtime (Visible in Run Mode) */}
+          {/* Panel 3: Runtime (Visible in Run or Analyze Mode) */}
           <div
-            className={`h-full border-r border-border transition-all duration-500 ease-in-out ${viewMode === 'run' ? 'w-full opacity-100' : 'w-0 opacity-0 overflow-hidden border-none'
+            className={`h-full border-r border-border transition-all duration-500 ease-in-out ${viewMode === 'run' || viewMode === 'analyze' ? 'w-full opacity-100' : 'w-0 opacity-0 overflow-hidden border-none'
               }`}
           >
             <RuntimeLayout 
@@ -281,19 +280,7 @@ const WodWorkbenchContent: React.FC<WodWorkbenchProps> = ({
               onBlockClick={handleBlockClick}
               onComplete={handleComplete} 
               onBack={handleClearSelection}
-            />
-          </div>
-
-          {/* Panel 4: Analytics (Visible in Analyze Mode) */}
-          <div
-            className={`h-full border-r border-border transition-all duration-500 ease-in-out ${viewMode === 'analyze' ? 'w-full opacity-100' : 'w-0 opacity-0 overflow-hidden border-none'
-              }`}
-          >
-            <AnalyticsLayout 
-              activeBlock={selectedBlock} 
-              documentItems={documentItems}
-              onBlockClick={handleBlockClick}
-              onBack={handleClearSelection}
+              viewMode={viewMode === 'analyze' ? 'analyze' : 'run'}
             />
           </div>
 

--- a/src/components/layout/WodWorkbench.tsx
+++ b/src/components/layout/WodWorkbench.tsx
@@ -276,7 +276,7 @@ const WodWorkbenchContent: React.FC<WodWorkbenchProps> = ({
               }`}
           >
             <RuntimeLayout 
-              activeBlock={selectedBlock || activeBlock} 
+              activeBlock={selectedBlock} 
               documentItems={documentItems}
               onBlockClick={handleBlockClick}
               onComplete={handleComplete} 
@@ -290,7 +290,7 @@ const WodWorkbenchContent: React.FC<WodWorkbenchProps> = ({
               }`}
           >
             <AnalyticsLayout 
-              activeBlock={selectedBlock || activeBlock} 
+              activeBlock={selectedBlock} 
               documentItems={documentItems}
               onBlockClick={handleBlockClick}
               onBack={handleClearSelection}

--- a/src/runtime-test-bench/services/testbench-services.ts
+++ b/src/runtime-test-bench/services/testbench-services.ts
@@ -1,3 +1,14 @@
+import { MdTimerRuntime } from '../../parser/md-timer';
+import { JitCompiler } from '../../runtime/JitCompiler';
+import { 
+  TimeBoundRoundsStrategy,
+  IntervalStrategy,
+  TimerStrategy,
+  RoundsStrategy,
+  GroupStrategy,
+  EffortStrategy
+} from '../../runtime/strategies';
+
 /**
  * Module-Level Services for RuntimeTestBench
  * This singleton is created once when the module loads and shared

--- a/src/runtime/IRuntimeBehavior.ts
+++ b/src/runtime/IRuntimeBehavior.ts
@@ -22,4 +22,7 @@ export interface IRuntimeBehavior {
 
   /** Called right before the owning block is popped from the stack. */
   onPop?(runtime: IScriptRuntime, block: IRuntimeBlock): IRuntimeAction[];
+
+  /** Called when the block is being disposed. Use this to clean up resources or log final metrics. */
+  onDispose?(runtime: IScriptRuntime, block: IRuntimeBlock): void;
 }

--- a/src/runtime/IScriptRuntime.ts
+++ b/src/runtime/IScriptRuntime.ts
@@ -18,5 +18,11 @@ export interface IScriptRuntime {
     /** Metrics collection subsystem for workout analytics */
     readonly metrics?: IMetricCollector;
     
+    /**
+     * Checks if the runtime execution has completed.
+     * Returns true if the stack is empty and execution has finished.
+     */
+    isComplete(): boolean;
+
     handle(event: IEvent): void;
 }

--- a/src/runtime/IScriptRuntime.ts
+++ b/src/runtime/IScriptRuntime.ts
@@ -5,6 +5,7 @@ import { IEvent } from "./IEvent";
 import { IRuntimeMemory } from './IRuntimeMemory';
 import { RuntimeError } from './actions/ErrorAction';
 import { IMetricCollector } from './MetricCollector';
+import { ExecutionRecord } from './models/ExecutionRecord';
 
 export interface IScriptRuntime {
     readonly script: WodScript;
@@ -17,6 +18,9 @@ export interface IScriptRuntime {
     
     /** Metrics collection subsystem for workout analytics */
     readonly metrics?: IMetricCollector;
+
+    /** Persistent log of executed blocks */
+    readonly executionLog: ExecutionRecord[];
     
     /**
      * Checks if the runtime execution has completed.

--- a/src/runtime/MemoryTypeEnum.ts
+++ b/src/runtime/MemoryTypeEnum.ts
@@ -76,6 +76,11 @@ export enum MemoryTypeEnum {
   METRIC_RESISTANCE = 'metric:resistance',
   
   /**
+   * Start time timestamp (ms) for the block execution
+   */
+  METRIC_START_TIME = 'metric:start-time',
+  
+  /**
    * Anchor reference - a stable pointer to dynamically resolved memory references
    * Used for UI data binding without tight coupling to specific data sources
    */

--- a/src/runtime/ScriptRuntime.ts
+++ b/src/runtime/ScriptRuntime.ts
@@ -9,6 +9,7 @@ import { IRuntimeMemory } from './IRuntimeMemory';
 import { RuntimeMemory } from './RuntimeMemory';
 import type { RuntimeError } from './actions/ErrorAction';
 import { IMetricCollector, MetricCollector } from './MetricCollector';
+import { ExecutionRecord } from './models/ExecutionRecord';
 
 export type RuntimeState = 'idle' | 'running' | 'compiling' | 'completed';
 
@@ -18,6 +19,7 @@ export class ScriptRuntime implements IScriptRuntime {
     public readonly memory: IRuntimeMemory;
     public readonly metrics: IMetricCollector;
     public readonly errors: RuntimeError[] = [];
+    public readonly executionLog: ExecutionRecord[] = [];
     private _lastUpdatedBlocks: Set<string> = new Set();
     
     constructor(public readonly script: WodScript, compiler: JitCompiler) {

--- a/src/runtime/ScriptRuntime.ts
+++ b/src/runtime/ScriptRuntime.ts
@@ -129,6 +129,17 @@ export class ScriptRuntime implements IScriptRuntime {
     }
 
     /**
+     * Checks if the runtime execution has completed.
+     * Returns true if the stack is empty.
+     * Note: A fresh runtime starts with an empty stack, so this will return true
+     * until a block is pushed. Consumers should ensure the runtime is initialized
+     * with a root block before checking completion.
+     */
+    public isComplete(): boolean {
+        return this.stack.blocks.length === 0;
+    }
+
+    /**
      * Helper method to safely pop and dispose a block following the new lifecycle pattern.
      * This demonstrates the consumer-managed dispose pattern.
      */

--- a/src/runtime/behaviors/HistoryBehavior.ts
+++ b/src/runtime/behaviors/HistoryBehavior.ts
@@ -1,0 +1,72 @@
+import { IRuntimeBehavior } from "../IRuntimeBehavior";
+import { IRuntimeAction } from "../IRuntimeAction";
+import { IScriptRuntime } from "../IScriptRuntime";
+import { IRuntimeBlock } from "../IRuntimeBlock";
+import { ExecutionRecord } from "../models/ExecutionRecord";
+import { MemoryTypeEnum } from "../MemoryTypeEnum";
+
+/**
+ * Behavior that tracks the execution history of a block.
+ * Records start time, end time, parent ID, and metrics, then logs to runtime.executionLog.
+ */
+export class HistoryBehavior implements IRuntimeBehavior {
+    private startTime: number = 0;
+    private parentId: string | null = null;
+    private label: string;
+
+    constructor(label?: string) {
+        this.label = label || "Block";
+    }
+
+    onPush(runtime: IScriptRuntime, block: IRuntimeBlock): IRuntimeAction[] {
+        this.startTime = Date.now();
+        
+        // Allocate start time in memory for UI visibility
+        // Cast to any to access context (RuntimeBlock has it, but IRuntimeBlock interface might not expose it yet)
+        const blockWithContext = block as any;
+        if (blockWithContext.context) {
+            blockWithContext.context.allocate(
+                MemoryTypeEnum.METRIC_START_TIME,
+                this.startTime,
+                'public'
+            );
+        }
+        
+        // Determine parent ID from stack
+        // The block is already on the stack, so parent is at index length - 2
+        const stack = runtime.stack.blocks;
+        if (stack.length >= 2) {
+            this.parentId = stack[stack.length - 2].key.toString();
+        } else {
+            this.parentId = null;
+        }
+
+        // If label wasn't provided, try to derive it from block type or context
+        if (this.label === "Block" && block.blockType) {
+            this.label = block.blockType;
+        }
+
+        return [];
+    }
+
+    onDispose(runtime: IScriptRuntime, block: IRuntimeBlock): void {
+        const endTime = Date.now();
+        
+        // Collect metrics (placeholder for now - could query memory for specific metrics)
+        const metrics: any = {};
+        if ((block as any).reps !== undefined) metrics.reps = (block as any).reps;
+        
+        const record: ExecutionRecord = {
+            blockId: block.key.toString(),
+            parentId: this.parentId,
+            type: block.blockType || 'unknown',
+            label: this.label,
+            startTime: this.startTime,
+            endTime: endTime,
+            metrics: metrics
+        };
+
+        runtime.executionLog.push(record);
+        console.log(`📜 HistoryBehavior: Logged execution for ${block.key.toString()} (${this.label})`);
+    }
+}

--- a/src/runtime/blocks/RoundsBlock.ts
+++ b/src/runtime/blocks/RoundsBlock.ts
@@ -8,6 +8,7 @@ import { LoopCoordinatorBehavior, LoopType } from '../behaviors/LoopCoordinatorB
 import { IRuntimeBehavior } from '../IRuntimeBehavior';
 import { MemoryTypeEnum } from '../MemoryTypeEnum';
 import { TypedMemoryReference } from '../IMemoryReference';
+import { HistoryBehavior } from '../behaviors/HistoryBehavior';
 
 /**
  * RoundsBlock Configuration
@@ -82,7 +83,8 @@ export class RoundsBlock extends RuntimeBlock {
       new CompletionBehavior(
         () => loopCoordinator.isComplete(runtime),
         ['rounds:complete']
-      )
+      ),
+      new HistoryBehavior("Rounds")
     ];
 
     // Initialize RuntimeBlock with behaviors

--- a/src/runtime/blocks/TimerBlock.ts
+++ b/src/runtime/blocks/TimerBlock.ts
@@ -7,6 +7,7 @@ import { IRuntimeBehavior } from '../IRuntimeBehavior';
 import { TimerBehavior } from '../behaviors/TimerBehavior';
 import { CompletionBehavior } from '../behaviors/CompletionBehavior';
 import { LoopCoordinatorBehavior, LoopType } from '../behaviors/LoopCoordinatorBehavior';
+import { HistoryBehavior } from '../behaviors/HistoryBehavior';
 
 /**
  * TimerBlock Configuration
@@ -57,7 +58,10 @@ export class TimerBlock extends RuntimeBlock {
     const timerBehavior = new TimerBehavior(config.direction, config.durationMs);
 
     // Create behaviors array
-    const behaviors: IRuntimeBehavior[] = [timerBehavior];
+    const behaviors: IRuntimeBehavior[] = [
+        timerBehavior,
+        new HistoryBehavior("Timer")
+    ];
 
     // If TimerBlock has children, add LoopCoordinatorBehavior for child management
     let loopCoordinator: LoopCoordinatorBehavior | undefined;

--- a/src/runtime/models/ExecutionRecord.ts
+++ b/src/runtime/models/ExecutionRecord.ts
@@ -1,0 +1,14 @@
+export interface ExecutionRecord {
+    blockId: string;
+    parentId: string | null;
+    type: string; // 'timer' | 'rounds' | 'effort' | 'group' etc.
+    label: string; // e.g., "Round 1", "Push-ups"
+    startTime: number;
+    endTime: number;
+    metrics: {
+        reps?: number;
+        weight?: number;
+        duration?: number;
+        [key: string]: any;
+    };
+}

--- a/src/runtime/strategies.ts
+++ b/src/runtime/strategies.ts
@@ -13,7 +13,7 @@ import { TimerBlock } from "./blocks/TimerBlock";
 import { RoundsBlock } from "./blocks/RoundsBlock";
 import { MemoryTypeEnum } from "./MemoryTypeEnum";
 
-/**
+
 export class EffortStrategy implements IRuntimeBlockStrategy {
     match(statements: ICodeStatement[], _runtime: IScriptRuntime): boolean {
         if (!statements || statements.length === 0) return false;

--- a/src/runtime/strategies.ts
+++ b/src/runtime/strategies.ts
@@ -12,6 +12,7 @@ import { CompletionBehavior } from "./behaviors/CompletionBehavior";
 import { TimerBlock } from "./blocks/TimerBlock";
 import { RoundsBlock } from "./blocks/RoundsBlock";
 import { MemoryTypeEnum } from "./MemoryTypeEnum";
+import { HistoryBehavior } from "./behaviors/HistoryBehavior";
 
 
 export class EffortStrategy implements IRuntimeBlockStrategy {

--- a/src/timeline/GitTreeSidebar.tsx
+++ b/src/timeline/GitTreeSidebar.tsx
@@ -96,15 +96,7 @@ export const GitTreeSidebar: React.FC<GitTreeSidebarProps> = ({
 
   return (
     <div className={`flex flex-col bg-background w-full ${disableScroll ? '' : 'h-full'}`}>
-      {!hideHeader && (
-        <div className="p-4 border-b border-border bg-muted/30">
-          <h2 className="text-sm font-bold text-foreground flex items-center gap-2">
-            <GitBranch className="w-4 h-4 text-primary" />
-            Segment Topology
-          </h2>
-        </div>
-      )}
-      
+    
       <div 
         className={`relative ${disableScroll ? '' : 'flex-1 overflow-y-auto custom-scrollbar'}`} 
         ref={scrollContainerRef}

--- a/src/views/runtime/RuntimeLayout.tsx
+++ b/src/views/runtime/RuntimeLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
-import { ChevronLeft, Bug, Play, Pause, Square, X } from 'lucide-react';
+import { ChevronLeft, Bug, Play, Pause, Square, X, SkipForward } from 'lucide-react';
 import { WodBlock } from '../../markdown-editor/types';
 import { RuntimeStackPanel } from '../../runtime-test-bench/components/RuntimeStackPanel';
 import { MemoryPanel } from '../../runtime-test-bench/components/MemoryPanel';
@@ -142,6 +142,11 @@ export const RuntimeLayout: React.FC<RuntimeLayoutProps> = ({
     onComplete();
   };
 
+  const handleNext = () => {
+    // TODO: Trigger actual runtime next event
+    console.log('Next event triggered');
+  };
+
   // Mock data for Debug View
   const mockBlocks = [
     { key: '1', label: 'Timer 10:00', status: 'active', depth: 0, children: ['2', '3'], blockType: 'Timer' },
@@ -254,6 +259,10 @@ export const RuntimeLayout: React.FC<RuntimeLayoutProps> = ({
                </Button>
              )}
              
+             <Button onClick={handleNext} size="lg" className="h-16 w-16 rounded-full bg-blue-600 hover:bg-blue-700 p-0">
+               <SkipForward className="h-8 w-8 fill-current" />
+             </Button>
+
              <Button onClick={handleStop} size="lg" variant="destructive" className="h-16 w-16 rounded-full p-0">
                <Square className="h-6 w-6 fill-current" />
              </Button>


### PR DESCRIPTION
This pull request introduces a unified execution history system to the runtime, enabling persistent tracking of block execution for improved analytics and visualization. It also standardizes test commands across documentation and configuration files, and refactors the UI to simplify runtime and analytics panel logic. The most important changes are grouped below:

**Execution History System**

* Added a new `ExecutionRecord` interface and persistent `executionLog` array to `ScriptRuntime` and `IScriptRuntime`, allowing completed block metrics to be logged and accessed after disposal. [[1]](diffhunk://#diff-01ce7d3153f9218ee4c1f35bac6315ebc5d33002d3beb14a0d283bef8b6dcc35R8) [[2]](diffhunk://#diff-01ce7d3153f9218ee4c1f35bac6315ebc5d33002d3beb14a0d283bef8b6dcc35R22-R30) [[3]](diffhunk://#diff-d64902fc3aaa90a3a36d87f1f77b2eeec6048e3c1271d208e6b0b733f9926eb1R12) [[4]](diffhunk://#diff-d64902fc3aaa90a3a36d87f1f77b2eeec6048e3c1271d208e6b0b733f9926eb1R22)
* Implemented a `HistoryBehavior` class that records start/end times, parent relationships, and metrics for every block, and logs them to `executionLog` on disposal.
* Extended the runtime behavior lifecycle with an `onDispose` hook for proper cleanup and logging.
* Updated `MemoryTypeEnum` to include `METRIC_START_TIME` for tracking block execution start times.
* Added an `isComplete()` method to `ScriptRuntime` and `IScriptRuntime` to check if execution has finished. [[1]](diffhunk://#diff-01ce7d3153f9218ee4c1f35bac6315ebc5d33002d3beb14a0d283bef8b6dcc35R22-R30) [[2]](diffhunk://#diff-d64902fc3aaa90a3a36d87f1f77b2eeec6048e3c1271d208e6b0b733f9926eb1R133-R143)

**Documentation and Test Command Standardization**

* Updated all documentation (`AGENTS.md`, `CLAUDE.md`, `gemini.md`, `.github/copilot-instructions.md`) to standardize test commands, replacing `npm run test:unit` with `npm run test` for unit tests, and clarifying usage instructions. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L26) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L148-R147) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L27) [[4]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L114-R113) [[5]](diffhunk://#diff-38f7cf0b4ff37a008fbb79d2f153f9b854944b52fa50c97c0d4b0edc47426bc3L25-R25) [[6]](diffhunk://#diff-38f7cf0b4ff37a008fbb79d2f153f9b854944b52fa50c97c0d4b0edc47426bc3L148-R147) [[7]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L58) [[8]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L85-R84) [[9]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L95-R94) [[10]](diffhunk://#diff-b56a87083070022d440782889c6dfb3f885859c94fd34dcf72f12cd4f5673d1cL46-R46)
* Broadened permissions in `.claude/settings.local.json` to allow all `npm run test*` commands.

**UI Refactoring**

* Refactored `WodWorkbench.tsx` to merge runtime and analytics panels, showing `RuntimeLayout` in both run and analyze modes and removing the separate `AnalyticsLayout` panel for a simpler, unified experience. [[1]](diffhunk://#diff-735c787989bb6aada31bb44f182a8a761f9f6de1392a4ef1597892ac63234dbcL17) [[2]](diffhunk://#diff-735c787989bb6aada31bb44f182a8a761f9f6de1392a4ef1597892ac63234dbcL273-R283)

**Infrastructure and Imports**

* Added missing imports for runtime strategies and timer runtime in `testbench-services.ts` to support new runtime features.

**Technical Documentation**

* Added a comprehensive `runtime-metrics-gap-analysis.md` documenting the current state, missing capabilities, and proposed solution for runtime metrics and execution history.