### PR TITLE
Add refactoring execution plan

### DIFF
--- a/docs/plan/cleanup-refactor.md
+++ b/docs/plan/cleanup-refactor.md
@@ -1,0 +1,207 @@
+# Codebase Cleanup and Refactoring Plan
+
+This document outlines a plan to refactor files in the codebase that have grown too large (> 80 lines) or complex. The goal is to improve maintainability, readability, and testability.
+
+## File Analysis and Refactoring Proposals
+
+### 1. `src/editor/WodWiki.tsx` (592 lines)
+
+**Analysis:**
+This is the main editor component. It handles Monaco initialization, syntax highlighting, suggestion engine setup, theming, content resizing, and cursor tracking. It has a lot of `useEffect` hooks and refs managing different aspects of the editor lifecycle.
+
+**Refactoring Proposal:**
+- **Extract Hooks:** Move logic for specific features into custom hooks:
+    - `useMonacoEditor(props)`: Initialize editor, handle mount/unmount.
+    - `useEditorTheme(theme)`: Handle theme application.
+    - `useEditorResize(editorRef)`: Handle content size changes.
+    - `useCursorHighlighting(editorRef, cursor, highlightedLine)`: Handle decorations for cursor/line highlighting.
+- **Separate Initializers:** The `WodWikiSyntaxInitializer` is already separate, but instantiation and setup inside the component is verbose. Create a helper or hook `useSyntaxInitializer`.
+- **Component Composition:** Split the render into smaller components if possible, though it's mostly a wrapper around `Editor`.
+
+### 2. `src/runtime/behaviors/TimerBehavior.ts` (485 lines)
+
+**Analysis:**
+This class manages timer logic (start, stop, pause, tick), memory interaction, and event emission. It handles both count-up and count-down (AMRAP) logic. It also deals with legacy vs. new memory references.
+
+**Refactoring Proposal:**
+- **Extract State Management:** Move the `TimerState` management (updating spans, start/stop logic) into a separate `TimerStateManager` or `TimerMemoryService` class. The behavior should only orchestrate actions.
+- **Strategy Pattern:** Split `count-up` and `count-down` logic into separate strategies (`CountUpStrategy`, `CountDownStrategy`) or subclasses if they diverge significantly.
+- **Utility Functions:** Extract time calculation (elapsed, display time) into a utility helper `TimeCalculator`.
+
+### 3. `src/markdown-editor/MarkdownEditor.tsx` (363 lines)
+
+**Analysis:**
+Similar to `WodWiki.tsx`, this component initializes a full-page Markdown editor with custom features like WOD blocks, context overlay, command palette, and rich markdown (cards). It has grown large due to feature accumulation.
+
+**Refactoring Proposal:**
+- **Custom Hooks:**
+    - `useMarkdownEditorSetup()`: Handle Monaco mount and configuration.
+    - `useThemeManager(monaco, theme)`: Handle custom theme definitions.
+    - `useFoldingManager(editor)`: Encapsulate folding logic.
+- **Sub-components:**
+    - `MarkdownToolbar`: Extract the toolbar JSX and logic.
+- **Event Handlers:** Move complex event handlers (like card actions) to a separate `EditorActionHandler` class or hook.
+
+### 4. `src/runtime/ScriptRuntime.ts` (338 lines)
+
+**Analysis:**
+This is the core runtime engine. It manages the stack, memory, event handling loop, and execution logging. The `_setupMemoryAwareStack` method is particularly complex and monkey-patches the stack.
+
+**Refactoring Proposal:**
+- **Extract Stack Logic:** Move the "memory-aware stack" logic into a subclass of `RuntimeStack` (e.g., `MemoryAwareRuntimeStack`) or a decorator/middleware pattern, instead of monkey-patching in the runtime constructor.
+- **Event Loop Extraction:** Move the `handle()` loop logic into a `RuntimeEventLoop` or `ExecutionEngine` class.
+- **Metrics/Logging:** Move execution logging (`ExecutionRecord` creation/updates) into a dedicated `ExecutionLogger` service that subscribes to runtime events.
+
+### 5. `src/editor/inline-cards/RowBasedCardManager.ts` (333 lines)
+
+**Analysis:**
+Manages inline cards (widgets) within the editor. It handles parsing, rendering, resizing, and cursor interactions. It has complex state management for preventing layout thrashing (debouncing).
+
+**Refactoring Proposal:**
+- **Separate Parsing Logic:** `CardParser` is already separate, but the manager still does a lot of coordination. Move the "diffing" logic (updating only changed cards) into a `CardReconciler`.
+- **Event Handling:** Extract event listeners (cursor, content changes) into a `EditorSubscriptionManager`.
+- **Rendering Logic:** The `RowRuleRenderer` is separate, but the manager's `updateEditingState` and `handleInternalAction` methods are complex. Simplify state updates, perhaps using a reducer pattern for card state.
+
+### 6. `src/editor/inline-cards/CardParser.ts` (268 lines)
+
+**Analysis:**
+Parses text content into card objects. It contains logic for multiple card types (heading, blockquote, media, frontmatter, wod-block) in one file.
+
+**Refactoring Proposal:**
+- **Parser Strategy Pattern:** Create an interface `ICardTypeParser` and implement separate parsers for each type (`HeadingParser`, `MediaParser`, `WodBlockParser`).
+- **Composite Parser:** `CardParser` should just iterate through registered parsers. This removes the monolithic `parseAllCards` method and makes adding new card types easier.
+
+### 7. `src/views/runtime/RuntimeLayout.tsx` (376 lines)
+
+**Analysis:**
+Large layout component coordinating multiple panels (history, context, debug, timer, analytics). It also handles mock data generation (which is very large) and runtime initialization.
+
+**Refactoring Proposal:**
+- **Remove Mock Data:** Move `generateSessionData` and related logic to a separate `MockDataService` or `data/mocks.ts` file.
+- **Extract Sub-panels:** `TimerDisplay` is defined inline; move it to `src/components/runtime/TimerDisplay.tsx`.
+- **Hooks for Logic:** Move runtime initialization and event handling (start/stop/pause) into a `useRuntimeController` hook.
+
+### 8. `src/runtime-test-bench/TestBench.tsx` (230 lines)
+
+**Analysis:**
+The main entry point for the test bench UI. It manages state for the script, runtime, and layout.
+
+**Refactoring Proposal:**
+- **State Management:** Use a reducer or a context provider (`TestBenchContext`) to manage the complex state (script, output, runtime, memory).
+- **Component Extraction:** Extract the layout structure into a `TestBenchLayout` component, keeping `TestBench` as the container/controller.
+
+### 9. `src/runtime/strategies.ts` (containing multiple strategies)
+
+**Analysis:**
+This file contains multiple strategy classes (`EffortStrategy`, `TimerStrategy`, `RoundsStrategy`, `IntervalStrategy`, `TimeBoundRoundsStrategy`, `GroupStrategy`) and deprecated code. It's a "god file" for strategies.
+
+**Refactoring Proposal:**
+- **Split Files:** Create a directory `src/runtime/strategies/` and move each strategy into its own file (`TimerStrategy.ts`, `RoundsStrategy.ts`, etc.).
+- **Remove Deprecated Code:** Delete the commented-out/deprecated strategies.
+- **Shared Helpers:** If strategies share logic (like `BlockContext` creation), extract it to a helper.
+
+### 10. `src/editor/inline-cards/RowBasedCardSystem.tsx` (207 lines)
+
+**Analysis:**
+React wrapper around `RowBasedCardManager`. It handles lifecycle and integration with the Monaco editor instance.
+
+**Refactoring Proposal:**
+- **Simplify Lifecycle:** The `useEffect` that initializes the manager is long. Extract the setup logic into a function or hook.
+- **Props Interface:** The interface is simple, but the component does a lot of "glue" work. Ensure it only focuses on React-Monaco integration.
+
+### 11. `src/components/layout/UnifiedWorkbench.tsx` (761 lines)
+
+**Analysis:**
+Massive component handling the entire app layout, responsive behavior, runtime integration, analytics transformation, and view switching. It's doing too much.
+
+**Refactoring Proposal:**
+- **Extract Analytics Logic:** The `transformRuntimeToAnalytics` function is huge. Move it to `src/services/AnalyticsTransformer.ts`.
+- **Extract Panels:** The definition of panels (`trackIndexPanel`, `timerDisplay`, etc.) clutters the render method. Move these to separate component files or render methods.
+- **Custom Hooks:**
+    - `useWorkbenchNavigation()`: Handle view modes and mobile checks.
+    - `useWorkbenchRuntime()`: Handle runtime integration and event bus subscriptions.
+
+### 12. `src/markdown-editor/widgets/TimerWidget.tsx` (181 lines)
+
+**Analysis:**
+Visual widget for timers in the editor.
+
+**Refactoring Proposal:**
+- **Sub-components:** Split into `TimerDisplay`, `TimerControls`, and `TimerSettings`.
+- **Logic Extraction:** Move timer calculation logic to `useTimer` hook if not already done.
+
+### 13. `src/runtime-test-bench/services/TestBenchExecutionService.ts` (179 lines)
+
+**Analysis:**
+Service to manage execution in the test bench.
+
+**Refactoring Proposal:**
+- **Single Responsibility:** Ensure it only handles execution. If it handles UI state, move that out.
+- **Simplify Methods:** Break down large methods like `executeStep` or `runFull` into smaller, testable steps.
+
+### 14. `src/runtime/strategies/IntervalStrategy.ts` & `RoundsStrategy.ts`
+
+**Analysis:**
+These are currently part of `src/runtime/strategies.ts` (as found in analysis). If they were separate, they would be candidates for cleanup.
+- **Cleanup:** As mentioned in step 9, separate them into files. Ensure `match` and `compile` logic is clean.
+
+### 15. `src/clock/TimerMemoryVisualization.tsx` (162 lines)
+
+**Analysis:**
+Visualizes timer memory state.
+
+**Refactoring Proposal:**
+- **Sub-components:** Extract `TimeSpanList` and `TimerStatus` components.
+- **Formatting:** Move date formatting to a shared utility.
+
+### 16. `src/runtime-test-bench/components/RuntimeStackPanel.tsx` (161 lines)
+
+**Analysis:**
+Displays the runtime stack.
+
+**Refactoring Proposal:**
+- **Recursive Component:** The recursive `renderBlockTree` is fine, but could be its own component `BlockTreeItem`.
+- **Styles:** Move tailwind class strings to a constants file or use a cleaner styling solution (like `class-variance-authority` if available, or just helper functions).
+
+### 17. `src/clock/hooks/useDisplayStack.ts` (151 lines)
+
+**Analysis:**
+A file containing multiple hooks (`useDisplayStack`, `useCurrentTimer`, etc.).
+
+**Refactoring Proposal:**
+- **Split Hooks:** Move each hook to its own file if they are used independently often, or keep them grouped but ensure they share common logic efficiently.
+- **Refine Types:** Ensure return types are strict.
+
+### 18. `src/runtime/BlockContext.ts` (148 lines)
+
+**Analysis:**
+Manages memory allocation context.
+
+**Refactoring Proposal:**
+- **Logic Simplification:** The `getOrCreateAnchor` method is complex. Extract it or simplify the searching logic.
+- **Validation:** Add more robust validation for released contexts.
+
+### 19. `src/markdown-editor/components/SmartStatementInput.tsx` (147 lines)
+
+**Analysis:**
+Input component with autocomplete suggestions.
+
+**Refactoring Proposal:**
+- **Custom Hook:** Extract the suggestion fetching logic into `useExerciseSuggestions(value)`.
+- **Component Split:** Separate the `SuggestionList` into its own component.
+
+## General Recommendations
+
+1.  **Directory Structure:**
+    - Create `src/hooks` subdirectories for domain-specific hooks (e.g., `src/hooks/editor`, `src/hooks/runtime`).
+    - Enforce one component per file rule more strictly.
+
+2.  **State Management:**
+    - For complex components like `UnifiedWorkbench` and `ScriptRuntime`, consider using a state machine (like XState) or a more robust reducer pattern to manage transitions and states explicitly.
+
+3.  **Testing:**
+    - Large files are hard to test. Refactoring them into smaller functions/classes will make unit testing significantly easier.
+    - Write tests for the extracted logic (e.g., `CountUpStrategy`, `TimeCalculator`) immediately after refactoring.
+
+4.  **Dead Code:**
+    - Aggressively remove commented-out code and deprecated classes (found in `strategies.ts`).

--- a/docs/plan/refactoring-execution-plan.md
+++ b/docs/plan/refactoring-execution-plan.md
@@ -1,0 +1,148 @@
+# Refactoring Execution Plan
+
+This document outlines the step-by-step plan to execute the codebase cleanup and refactoring identified in `docs/plan/cleanup-refactor.md`. It focuses on creating common abstractions, separating concerns, and ensuring test coverage.
+
+## Goals
+1.  **Reduce Component Bloat:** Shrink large files (`UnifiedWorkbench`, `ScriptRuntime`, `WodWiki`) by extracting logic.
+2.  **Promote Reusability:** Create shared hooks and services for common patterns (Editor, Runtime, Timer).
+3.  **Improve Testability:** Isolate complex logic into pure functions/classes that are easier to test.
+
+---
+
+## Phase 1: Foundation & Utilities
+*Focus: Extract pure logic and shared utilities. Low risk, high value.*
+
+### Step 1.1: Time Utilities
+- **Objective:** Extract time formatting and calculation logic from `TimerBehavior`, `TimerDisplay`, and `TimerMemoryVisualization`.
+- **Action:**
+    - Create `src/lib/timeUtils.ts`.
+    - Move `formatTimestamp`, `formatTime` (HH:MM:SS), and elapsed time calculations here.
+- **Verification:**
+    - Create `src/lib/timeUtils.test.ts`.
+    - Update `TimerBehavior.ts` and `TimerMemoryVisualization.tsx` to use new utils.
+
+### Step 1.2: Analytics Transformation Service
+- **Objective:** Extract the massive `transformRuntimeToAnalytics` function from `UnifiedWorkbench.tsx`.
+- **Action:**
+    - Create `src/services/AnalyticsTransformer.ts`.
+    - Move `transformRuntimeToAnalytics` and helper interfaces there.
+- **Verification:**
+    - Create `src/services/AnalyticsTransformer.test.ts` (Move any relevant logic tests from `UnifiedWorkbench` context if they exist, or create new ones).
+    - Update `UnifiedWorkbench.tsx` to import the service.
+
+### Step 1.3: Runtime Types & Interfaces
+- **Objective:** Ensure all strategies and behaviors use consistent interfaces, removing deprecated `RuntimeMetric` references.
+- **Action:**
+    - Audit `src/runtime/IRuntimeBlockStrategy.ts`.
+    - Clean up `src/runtime/strategies.ts` (remove commented out code) *before* splitting it.
+
+---
+
+## Phase 2: Runtime Core & Strategies
+*Focus: Refactor the execution engine and strategy pattern. Critical path.*
+
+### Step 2.1: Split Strategies
+- **Objective:** Break `src/runtime/strategies.ts` into individual files.
+- **Action:**
+    - Create directory `src/runtime/strategies/`.
+    - Move `TimerStrategy` to `src/runtime/strategies/TimerStrategy.ts`.
+    - Move `RoundsStrategy` to `src/runtime/strategies/RoundsStrategy.ts`.
+    - Move `EffortStrategy` to `src/runtime/strategies/EffortStrategy.ts`.
+    - Move `IntervalStrategy` to `src/runtime/strategies/IntervalStrategy.ts`.
+    - Move `TimeBoundRoundsStrategy` to `src/runtime/strategies/TimeBoundRoundsStrategy.ts`.
+    - Move `GroupStrategy` to `src/runtime/strategies/GroupStrategy.ts`.
+    - Update imports in `src/runtime-test-bench/services/testbench-services.ts` and other consumers.
+- **Verification:**
+    - Run existing runtime tests (`npm test src/runtime`).
+
+### Step 2.2: Extract Block Context Logic
+- **Objective:** Simplify `BlockContext.ts` and potentially abstract common context creation logic used by strategies.
+- **Action:**
+    - Refactor `getOrCreateAnchor` in `BlockContext.ts` for readability.
+    - Create `BlockContextFactory` if strategy context creation code is repetitive.
+
+### Step 2.3: Refactor ScriptRuntime
+- **Objective:** De-clutter `ScriptRuntime.ts` by extracting the stack monkey-patching and event loop.
+- **Action:**
+    - Create `src/runtime/MemoryAwareRuntimeStack.ts` (extends `RuntimeStack`) to encapsulate the "pop/dispose" logic.
+    - Create `src/runtime/ExecutionLogger.ts` to handle `ExecutionRecord` logic (observer pattern).
+    - Update `ScriptRuntime` to use these new classes instead of inline logic.
+- **Verification:**
+    - Run `src/runtime/tests/RootLifecycle.test.ts` and `NextEvent.test.ts` to ensure no regression in execution flow.
+
+### Step 2.4: Timer Behavior Refactoring
+- **Objective:** Clean up `TimerBehavior.ts`.
+- **Action:**
+    - Extract `TimerState` management into `TimerStateManager` class.
+    - Use `TimeCalculator` from Phase 1.
+- **Verification:**
+    - Run `src/runtime/behaviors/TimerBehavior.test.ts`.
+
+---
+
+## Phase 3: Editor Unification
+*Focus: Consolidate Monaco editor logic.*
+
+### Step 3.1: Shared Monaco Hooks
+- **Objective:** Extract common Monaco setup from `WodWiki.tsx` and `MarkdownEditor.tsx`.
+- **Action:**
+    - Create `src/hooks/editor/useMonacoLifecycle.ts` (mount/unmount).
+    - Create `src/hooks/editor/useMonacoTheme.ts` (theme definitions).
+    - Create `src/hooks/editor/useEditorResize.ts` (layout handling).
+- **Verification:**
+    - Update `WodWiki.tsx` to use hooks.
+    - Update `MarkdownEditor.tsx` to use hooks.
+    - Manual verification via Storybook (since editor tests are sparse).
+
+### Step 3.2: Card Parsing & Management
+- **Objective:** Refactor `RowBasedCardManager` and `CardParser`.
+- **Action:**
+    - Split `CardParser.ts`: Create `src/editor/parsers/` and move specific parsers (`HeadingParser`, `MediaParser`, etc.).
+    - Update `CardParser` to use a strategy pattern to iterate these parsers.
+    - Extract event handling from `RowBasedCardManager` into `useEditorEvents` hook or helper class.
+- **Verification:**
+    - Create unit tests for individual parsers (e.g., `HeadingParser.test.ts`).
+
+---
+
+## Phase 4: UI Component Decomposition
+*Focus: Break down large UI components.*
+
+### Step 4.1: Unified Workbench Decomposition
+- **Objective:** Shrink `UnifiedWorkbench.tsx`.
+- **Action:**
+    - Extract sub-panels into separate files:
+        - `src/components/workbench/TrackPanel.tsx`
+        - `src/components/workbench/AnalyzePanel.tsx`
+        - `src/components/workbench/PlanPanel.tsx`
+    - Extract `useWorkbenchRuntime` hook to encapsulate the `useRuntime` + `useWorkoutEvents` + `useEffect` glue code.
+- **Verification:**
+    - Manual verification of the workbench in the app.
+
+### Step 4.2: Runtime Layout Cleanup
+- **Objective:** Shrink `RuntimeLayout.tsx`.
+- **Action:**
+    - Ensure `MockDataService` (if still needed) is separate.
+    - Move `TimerDisplay` to its own component `src/components/runtime/TimerDisplay.tsx` (if not already done/collided with `Step 4.1` work).
+
+### Step 4.3: Test Bench Refactor
+- **Objective:** Clean up `TestBench.tsx`.
+- **Action:**
+    - Create `TestBenchContext` to hold state.
+    - Extract `TestBenchLayout`.
+
+---
+
+## Phase 5: Test Cleanup & Validation
+*Focus: Ensure the test suite is healthy and reflects the new structure.*
+
+### Step 5.1: Test Location Audit
+- Move any tests that are currently co-located in `src/runtime` but belong in `__tests__` or similar standard locations if strictly enforced (optional, but good for organization).
+
+### Step 5.2: New Test Coverage
+- Ensure the new Services (`AnalyticsTransformer`, `ExecutionLogger`) have high coverage.
+- Ensure the new Strategies (`TimerStrategy`, etc.) have basic unit tests verifying their `match` logic.
+
+### Step 5.3: End-to-End Verification
+- Run the full test suite (`npm test`).
+- Verify crucial flows (Workout Start -> Tick -> Complete) using the Test Bench or `useRuntimeExecution.test.ts`.


### PR DESCRIPTION
Added `docs/plan/refactoring-execution-plan.md` which details a step-by-step approach to cleaning up large files and creating common abstractions. The plan is divided into 5 phases: Foundation & Utilities, Runtime Core, Editor Unification, UI Decomposition, and Test Cleanup. It also incorporates findings from `docs/plan/cleanup-refactor.md`.