### PR TITLE
fix: IdleBehavior button registration for root lifecycle tests

### DIFF
--- a/src/runtime/__tests__/RootLifecycle.test.ts
+++ b/src/runtime/__tests__/RootLifecycle.test.ts
@@ -129,7 +129,7 @@ describe('RootLifecycle Integration', () => {
         
         if (!runtime) throw new Error('Failed to create runtime');
 
-        // Helper to get controls
+        // Helper to get controls (finds controls with buttons, prioritizing idle block controls)
         const getControls = () => {
             const refs = runtime.memory.search({
                 type: 'runtime-controls',
@@ -138,6 +138,14 @@ describe('RootLifecycle Integration', () => {
                 visibility: null
             });
             if (refs.length === 0) return null;
+            // Find controls with buttons (idle block's controls) or fall back to first
+            for (const ref of refs) {
+                const controls = runtime.memory.get(ref as TypedMemoryReference<RuntimeControls>);
+                if (controls && controls.buttons.length > 0) {
+                    return controls;
+                }
+            }
+            // Fall back to first controls if none have buttons
             return runtime.memory.get(refs[0] as TypedMemoryReference<RuntimeControls>);
         };
 

--- a/src/runtime/behaviors/IdleBehavior.ts
+++ b/src/runtime/behaviors/IdleBehavior.ts
@@ -39,13 +39,34 @@ export class IdleBehavior implements IRuntimeBehavior {
         // This allows the UI to show appropriate buttons (e.g. "Start" or "Next")
         const buttons: RuntimeButton[] = [];
         
-        if (this.config.popOnNext) {
+        // Add button if popOnNext is true OR if there are popOnEvents configured
+        const hasPopTrigger = this.config.popOnNext || (this.config.popOnEvents && this.config.popOnEvents.length > 0);
+        
+        if (hasPopTrigger) {
+            const labelLower = this.config.buttonLabel?.toLowerCase() || '';
+            const actionLower = this.config.buttonAction?.toLowerCase() || '';
+            
+            // Derive button ID from action or label
+            let buttonId = 'btn-next';
+            let icon = 'next';
+            let variant: 'default' | 'secondary' = 'secondary';
+            
+            if (labelLower.includes('start') || actionLower.includes('start')) {
+                buttonId = 'btn-start';
+                icon = 'play';
+                variant = 'default';
+            } else if (labelLower.includes('analytics') || actionLower.includes('analytics')) {
+                buttonId = 'btn-analytics';
+                icon = 'analytics';
+                variant = 'default';
+            }
+            
             buttons.push({
-                id: 'btn-next',
+                id: buttonId,
                 label: this.config.buttonLabel || 'Next',
-                icon: this.config.buttonLabel?.toLowerCase().includes('start') ? 'play' : 'next',
+                icon: icon,
                 action: this.config.buttonAction || 'timer:next',
-                variant: this.config.buttonLabel?.toLowerCase().includes('start') ? 'default' : 'secondary',
+                variant: variant,
                 size: 'lg'
             });
         }
@@ -55,7 +76,7 @@ export class IdleBehavior implements IRuntimeBehavior {
             block.key.toString(),
             { 
                 buttons,
-                displayMode: 'timer' 
+                displayMode: 'clock' 
             },
             'public'
         );


### PR DESCRIPTION
- Register button when popOnEvents is configured (not just popOnNext)
- Change displayMode from 'timer' to 'clock' for consistency
- Derive button ID based on label/action content (start, analytics, next)
- Update RootLifecycle test helper to find controls with buttons