### PR TITLE
chore(core): remove stale TODO from BlockKey and add unit tests

### DIFF
--- a/src/core/models/BlockKey.ts
+++ b/src/core/models/BlockKey.ts
@@ -5,8 +5,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
 export class BlockKey {
-    // TODO: make value optional, and if no value is passed, it should
-    // generates a new unique ID (e.g., UUID or incrementing number)
     constructor(public readonly value: string = uuidv4()) {}
 
     toString(): string {

--- a/src/core/models/__tests__/BlockKey.test.ts
+++ b/src/core/models/__tests__/BlockKey.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { BlockKey } from '../BlockKey';
+import { validate as uuidValidate } from 'uuid';
+
+describe('BlockKey', () => {
+    it('generates a new unique ID (UUID) when no value is passed', () => {
+        const key1 = new BlockKey();
+        const key2 = new BlockKey();
+
+        expect(key1.value).toBeDefined();
+        expect(key2.value).toBeDefined();
+        expect(key1.value).not.toBe(key2.value);
+        expect(uuidValidate(key1.value)).toBe(true);
+        expect(uuidValidate(key2.value)).toBe(true);
+    });
+
+    it('uses the provided value when one is passed', () => {
+        const customValue = 'my-custom-key';
+        const key = new BlockKey(customValue);
+
+        expect(key.value).toBe(customValue);
+    });
+
+    it('returns the value when toString is called', () => {
+        const key = new BlockKey('test-key');
+        expect(key.toString()).toBe('test-key');
+    });
+
+    it('returns the value when valueOf is called', () => {
+        const key = new BlockKey('test-key');
+        expect(key.valueOf()).toBe('test-key');
+    });
+
+    it('checks equality correctly', () => {
+        const key1 = new BlockKey('same-key');
+        const key2 = new BlockKey('same-key');
+        const key3 = new BlockKey('different-key');
+
+        expect(key1.equals(key2)).toBe(true);
+        expect(key1.equals(key3)).toBe(false);
+    });
+});


### PR DESCRIPTION
- Removed stale TODO in BlockKey.ts as the logic was already implemented.
- Added comprehensive unit tests in src/core/models/__tests__/BlockKey.test.ts to verify default UUID generation and value assignment.