### PR TITLE
feat(ux): enhance accessibility for icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility of Icon-Only Buttons
+**Learning:** Icon-only buttons (like the '+' command palette trigger or close 'X' buttons) are frequently missed in accessibility passes because they look "clean" visually but offer no context to screen readers.
+**Action:** When using `size="icon"` on Buttons, always verify `aria-label` or `sr-only` text is present. Use a linter rule or manual check for `size="icon"` usages.

--- a/src/components/layout/PlanPanel.tsx
+++ b/src/components/layout/PlanPanel.tsx
@@ -236,6 +236,8 @@ const OverlayPanel: React.FC<{
             size="icon"
             className="h-8 w-8"
             onClick={onClose}
+            aria-label="Close index"
+            title="Close index"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/src/components/layout/UnifiedWorkbench.tsx
+++ b/src/components/layout/UnifiedWorkbench.tsx
@@ -397,6 +397,8 @@ const UnifiedWorkbenchContent: React.FC<UnifiedWorkbenchProps> = ({
                   setIsOpen(true);
                 }}
                 className="text-muted-foreground hover:text-foreground"
+                aria-label="Open command palette"
+                title="Open command palette"
               >
                 <Plus className="h-4 w-4" />
               </Button>
@@ -410,6 +412,8 @@ const UnifiedWorkbenchContent: React.FC<UnifiedWorkbenchProps> = ({
               size={isMobile ? 'icon' : 'sm'}
               onClick={() => setViewMode('plan')}
               className={cn('gap-2', viewMode !== 'plan' && 'text-muted-foreground hover:text-foreground')}
+              aria-label={isMobile ? "Switch to Plan view" : undefined}
+              title={isMobile ? "Switch to Plan view" : undefined}
             >
               <Edit className="h-4 w-4" />
               {!isMobile && 'Plan'}
@@ -419,6 +423,8 @@ const UnifiedWorkbenchContent: React.FC<UnifiedWorkbenchProps> = ({
               size={isMobile ? 'icon' : 'sm'}
               onClick={() => setViewMode('track')}
               className={cn('gap-2', viewMode !== 'track' && 'text-muted-foreground hover:text-foreground')}
+              aria-label={isMobile ? "Switch to Track view" : undefined}
+              title={isMobile ? "Switch to Track view" : undefined}
             >
               <Timer className="h-4 w-4" />
               {!isMobile && 'Track'}
@@ -428,6 +434,8 @@ const UnifiedWorkbenchContent: React.FC<UnifiedWorkbenchProps> = ({
               size={isMobile ? 'icon' : 'sm'}
               onClick={() => setViewMode('analyze')}
               className={cn('gap-2', viewMode !== 'analyze' && 'text-muted-foreground hover:text-foreground')}
+              aria-label={isMobile ? "Switch to Analyze view" : undefined}
+              title={isMobile ? "Switch to Analyze view" : undefined}
             >
               <BarChart2 className="h-4 w-4" />
               {!isMobile && 'Analyze'}
@@ -444,6 +452,7 @@ const UnifiedWorkbenchContent: React.FC<UnifiedWorkbenchProps> = ({
                 rel="noopener noreferrer"
                 className="text-muted-foreground hover:text-foreground transition-colors ml-2"
                 title="Check us out on GitHub"
+                aria-label="Visit WOD Wiki on GitHub"
               >
                 <Github className="h-5 w-5" />
               </a>

--- a/src/components/workout/RuntimeDebugPanel.tsx
+++ b/src/components/workout/RuntimeDebugPanel.tsx
@@ -362,7 +362,7 @@ export const RuntimeDebugPanel: React.FC<RuntimeDebugPanelProps> = ({
             <div className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
             <h3 className="font-semibold text-sm">Runtime Debugger</h3>
           </div>
-          <Button variant="ghost" size="icon" onClick={onClose}>
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close debugger" title="Close debugger">
             <X className="h-4 w-4" />
           </Button>
         </div>


### PR DESCRIPTION
- Add `aria-label` and `title` to Command Palette button in UnifiedWorkbench
- Add `aria-label` and `title` to GitHub link in UnifiedWorkbench
- Add `aria-label` and `title` to View Mode buttons in UnifiedWorkbench (mobile view)
- Add `aria-label` and `title` to Close button in PlanPanel
- Add `aria-label` and `title` to Close button in RuntimeDebugPanel
- Create .Jules/palette.md journal