### PR TITLE
Fix: Implicit AMRAP child rotation for Timers

### DIFF
--- a/src/runtime/compiler/strategies/components/GenericTimerStrategy.ts
+++ b/src/runtime/compiler/strategies/components/GenericTimerStrategy.ts
@@ -42,8 +42,11 @@ export class GenericTimerStrategy implements IRuntimeBlockStrategy {
                .setLabel(label)
                .setSourceIds(statement.id ? [statement.id] : []);
 
+        // Filter out runtime-generated fragments to avoid pollution
+        const cleanFragments = (statement.fragments || []).filter(f => f.collectionState !== FragmentCollectionState.RuntimeGenerated);
+
         const distributor = new PassthroughFragmentDistributor();
-        const fragmentGroups = distributor.distribute(statement.fragments || [], "Timer");
+        const fragmentGroups = distributor.distribute(cleanFragments, "Timer");
         builder.setFragments(fragmentGroups);
         builder.addBehaviorIfMissing(new ActionLayerBehavior(blockKey.toString(), fragmentGroups, statement.id ? [statement.id] : []));
 

--- a/src/runtime/compiler/strategies/fallback/EffortFallbackStrategy.ts
+++ b/src/runtime/compiler/strategies/fallback/EffortFallbackStrategy.ts
@@ -67,8 +67,11 @@ export class EffortFallbackStrategy implements IRuntimeBlockStrategy {
             .setLabel(label) // Use text content as label
             .setSourceIds(statement.id ? [statement.id] : []);
 
+        // Filter out runtime-generated fragments to avoid pollution
+        const cleanFragments = (statement.fragments || []).filter(f => f.collectionState !== FragmentCollectionState.RuntimeGenerated);
+
         const distributor = new PassthroughFragmentDistributor();
-        const fragmentGroups = distributor.distribute(statement.fragments || [], "Effort");
+        const fragmentGroups = distributor.distribute(cleanFragments, "Effort");
         builder.setFragments(fragmentGroups);
 
         builder.addBehaviorIfMissing(new ActionLayerBehavior(blockKey.toString(), fragmentGroups, statement.id ? [statement.id] : []));


### PR DESCRIPTION
If a Timer block has children but no explicit loop logic (e.g. "Rounds"), it now defaults to an infinite loop (AMRAP style) instead of a single pass. This ensures blocks like "20:00 \n 5 pullups" act as AMRAPs.

Also fixes a JIT compilation issue where runtime-generated fragments (artifacts) caused re-compilation to misidentify blocks as Timers.

Tests:
- Added reproduction test `tests/blocks/amrap_child_rotation_test.ts`
- Added regression test `tests/blocks/for_time_child_single_pass_test.ts`