### PR TITLE
feat: implement WOD results widget and enhance workout result handlin…

### DIFF
--- a/src/components/Editor/UnifiedEditor.tsx
+++ b/src/components/Editor/UnifiedEditor.tsx
@@ -60,6 +60,13 @@ import { sectionGeometry } from "./extensions/section-geometry";
 import { linkOpen } from "./extensions/link-open";
 import { gutterRuntimeHighlights } from "./extensions/gutter-runtime";
 import { foldWidgets } from "./extensions/fold-widgets";
+import {
+  wodResultsWidget,
+  wodResultsField,
+  updateSectionResults,
+  WOD_RESULT_CLICK_EVENT,
+  type WodResultClickDetail,
+} from "./extensions/wod-results-widget";
 import { OverlayTrack } from "./overlays/OverlayTrack";
 import { useOverlayWidthState } from "./overlays/useOverlayWidthState";
 import type { OverlaySlotProps } from "./overlays/OverlayTrack";
@@ -71,6 +78,9 @@ import type { WodCommand } from "./overlays/WodCommand";
 import { FullscreenTimer } from "./overlays/FullscreenTimer";
 import { FullscreenReview } from "./overlays/FullscreenReview";
 import type { Segment } from "@/core/models/AnalyticsModels";
+import { indexedDBService } from "@/services/db/IndexedDBService";
+import { getAnalyticsFromLogs } from "@/services/AnalyticsTransformer";
+import { v4 as uuidv4 } from "uuid";
 
 // Existing state fields
 import { activeWorkoutIdField, wodBlockRuntimeField } from "./state-fields";
@@ -193,6 +203,41 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
     setFullscreenTimerBlock(null);
   }, []);
 
+  // Intercept workout completion: immediately push the new result into the CM6
+  // wodResultsField so the inline results bar updates without waiting for a DB
+  // round-trip, then forward to the parent's onCompleteWorkout callback.
+  const handleCompleteWorkout = useCallback(
+    (blockId: string, results: WodBlock["results"]) => {
+      if (results && viewRef.current) {
+        const view = viewRef.current;
+        const now = results.endTime || Date.now();
+        const newResult = {
+          id: uuidv4(),
+          noteId: noteId ?? "",
+          sectionId: blockId,
+          segmentId: blockId,
+          data: results,
+          completedAt: now,
+        };
+
+        // Read existing results for this section and prepend the new one
+        // (most-recent first) before dispatching.
+        const existingMap = view.state.field(wodResultsField);
+        const prev = existingMap.get(blockId) ?? [];
+        view.dispatch({
+          effects: [
+            updateSectionResults.of({
+              sectionId: blockId,
+              results: [newResult, ...prev],
+            }),
+          ],
+        });
+      }
+      onCompleteWorkout?.(blockId, results);
+    },
+    [noteId, onCompleteWorkout],
+  );
+
   // Open the full-screen review.
   const handleOpenReview = useCallback((segments: Segment[]) => {
     setFullscreenReviewSegments(segments);
@@ -202,6 +247,53 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
   const handleReviewClose = useCallback(() => {
     setFullscreenReviewSegments(null);
   }, []);
+
+  // Fetch workout results for all WOD sections and push them into the editor
+  // via the wodResultsField StateEffect so the inline results bar is visible.
+  useEffect(() => {
+    if (!viewRef.current) return;
+    const wodSections = sections.filter((s) => s.type === "wod");
+    if (wodSections.length === 0) return;
+
+    for (const section of wodSections) {
+      indexedDBService
+        .getResultsForSection(noteId ?? "", section.id)
+        .then((results) => {
+          const view = viewRef.current;
+          if (!view || !view.dom.isConnected) return;
+          const sorted = results.sort((a, b) => b.completedAt - a.completedAt);
+          view.dispatch({
+            effects: [
+              updateSectionResults.of({ sectionId: section.id, results: sorted }),
+            ],
+          });
+        })
+        .catch(() => {
+          // IndexedDB unavailable (e.g. Storybook) – silently ignore
+        });
+    }
+  }, [noteId, sections]);
+
+  // Listen for result pill clicks fired by the CM6 widget and open the
+  // full-screen review overlay if the result has detailed logs.
+  useEffect(() => {
+    const el = editorRef.current;
+    if (!el) return;
+
+    const handleResultClick = (e: Event) => {
+      const { result } = (e as CustomEvent<WodResultClickDetail>).detail;
+      if (result?.data?.logs && result.data.logs.length > 0) {
+        const { segments } = getAnalyticsFromLogs(
+          result.data.logs as any,
+          result.data.startTime,
+        );
+        handleOpenReview(segments);
+      }
+    };
+
+    el.addEventListener(WOD_RESULT_CLICK_EVENT, handleResultClick);
+    return () => el.removeEventListener(WOD_RESULT_CLICK_EVENT, handleResultClick);
+  }, [handleOpenReview]);
 
   // Build effective command list: use explicit commands if provided, otherwise
   // synthesize from legacy onStartWorkout / onAddToPlan for backward compat.
@@ -319,6 +411,9 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
 
       // Auto-fold widget fence bodies (keeps JSON off-screen)
       foldWidgets,
+
+      // Results bar widgets — shown after each WOD block's closing fence
+      ...wodResultsWidget,
 
       // Update listener
       EditorView.updateListener.of((update) => {
@@ -505,7 +600,7 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
           block={fullscreenTimerBlock}
           view={viewRef.current}
           onClose={handleTimerClose}
-          onCompleteWorkout={onCompleteWorkout}
+          onCompleteWorkout={handleCompleteWorkout}
         />
       )}
 

--- a/src/components/Editor/extensions/wod-results-widget.ts
+++ b/src/components/Editor/extensions/wod-results-widget.ts
@@ -1,0 +1,241 @@
+/**
+ * wod-results-widget
+ *
+ * CM6 extension that inserts a compact results bar after the closing fence of
+ * every WOD block that has recorded workout results.
+ *
+ * Each result appears as a clickable pill showing duration + date.  Clicking a
+ * pill emits a `WOD_RESULT_CLICK_EVENT` CustomEvent on the editor DOM so that
+ * React components above the editor can open the full-screen review overlay.
+ *
+ * Architecture:
+ *   1. `updateSectionResults` StateEffect — dispatched from React when results
+ *      are fetched for a section.
+ *   2. `wodResultsField` StateField — holds a Map<sectionId, WorkoutResult[]>.
+ *   3. `wodResultsDecorations` StateField — builds block widget decorations
+ *      anchored to the end of each wod section's closing fence line.
+ *   4. `WodResultsBarWidget` WidgetType — renders the DOM bar.
+ */
+
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  WidgetType,
+} from "@codemirror/view";
+import { StateEffect, StateField, EditorState, Range } from "@codemirror/state";
+import { sectionField } from "./section-state";
+import type { WorkoutResult } from "@/types/storage";
+
+// ── Custom DOM event ─────────────────────────────────────────────────
+
+/** Fired on the editor DOM when the user clicks a result pill. */
+export const WOD_RESULT_CLICK_EVENT = "wod-result-click";
+
+export interface WodResultClickDetail {
+  sectionId: string;
+  result: WorkoutResult;
+}
+
+// ── StateEffect ──────────────────────────────────────────────────────
+
+/** Dispatch this effect to update (replace) results for a single section. */
+export const updateSectionResults = StateEffect.define<{
+  sectionId: string;
+  results: WorkoutResult[];
+}>();
+
+// ── StateField: results map ──────────────────────────────────────────
+
+export const wodResultsField = StateField.define<Map<string, WorkoutResult[]>>({
+  create: () => new Map(),
+  update(map, tr) {
+    let newMap: Map<string, WorkoutResult[]> | null = null;
+    for (const e of tr.effects) {
+      if (e.is(updateSectionResults)) {
+        if (!newMap) newMap = new Map(map);
+        newMap.set(e.value.sectionId, e.value.results);
+      }
+    }
+    return newMap ?? map;
+  },
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "--:--";
+  const secs = Math.floor(ms / 1000);
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = secs % 60;
+  if (h > 0)
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+// ── Widget ────────────────────────────────────────────────────────────
+
+class WodResultsBarWidget extends WidgetType {
+  constructor(
+    readonly sectionId: string,
+    readonly results: WorkoutResult[],
+  ) {
+    super();
+  }
+
+  eq(other: WodResultsBarWidget): boolean {
+    if (other.sectionId !== this.sectionId) return false;
+    if (other.results.length !== this.results.length) return false;
+    // Quick equality check: compare completion timestamps of first two entries
+    for (let i = 0; i < Math.min(2, this.results.length); i++) {
+      if (this.results[i].completedAt !== other.results[i].completedAt) return false;
+    }
+    return true;
+  }
+
+  toDOM(view: EditorView): HTMLElement {
+    const bar = document.createElement("div");
+    bar.className = "cm-wod-results-bar";
+
+    // Clock icon label
+    const icon = document.createElement("span");
+    icon.className = "cm-wod-results-icon";
+    icon.textContent = "🕐";
+    icon.title = `${this.results.length} result${this.results.length !== 1 ? "s" : ""}`;
+    bar.appendChild(icon);
+
+    // Result pills — ordered most-recent first (already sorted by caller)
+    for (const result of this.results) {
+      const duration = formatDuration(result.data?.duration ?? 0);
+      const date = formatDate(result.completedAt);
+
+      const pill = document.createElement("button");
+      pill.className = "cm-wod-result-pill";
+      pill.textContent = `${duration}  ${date}`;
+      pill.title = `Recorded: ${new Date(result.completedAt).toLocaleString()}`;
+
+      pill.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const detail: WodResultClickDetail = { sectionId: this.sectionId, result };
+        view.dom.dispatchEvent(
+          new CustomEvent(WOD_RESULT_CLICK_EVENT, { detail, bubbles: true }),
+        );
+      });
+
+      bar.appendChild(pill);
+    }
+
+    return bar;
+  }
+
+  /** Let CM6 know this widget takes up vertical space. */
+  get estimatedHeight(): number {
+    return 24;
+  }
+
+  /** Clicks on pills should reach our listener, not be ignored. */
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+// ── Build decorations ─────────────────────────────────────────────────
+
+function _buildResultsDecorations(state: EditorState): DecorationSet {
+  const { sections } = state.field(sectionField);
+  const resultsMap: Map<string, WorkoutResult[]> = state.field(wodResultsField);
+  const decos: Range<Decoration>[] = [];
+
+  for (const section of sections) {
+    if (section.type !== "wod") continue;
+    const results = resultsMap.get(section.id);
+    if (!results || results.length === 0) continue;
+
+    const doc = state.doc;
+    if (section.endLine > doc.lines) continue;
+
+    const closeLine = doc.line(section.endLine);
+
+    decos.push(
+      Decoration.widget({
+        widget: new WodResultsBarWidget(section.id, results),
+        block: true,
+        side: 1,
+      }).range(closeLine.to),
+    );
+  }
+
+  decos.sort((a, b) => a.from - b.from);
+  return Decoration.set(decos);
+}
+
+// ── StateField: decorations ──────────────────────────────────────────
+
+export const wodResultsDecorations = StateField.define<DecorationSet>({
+  create(state) {
+    return _buildResultsDecorations(state);
+  },
+  update(prev, tr) {
+    if (tr.docChanged || tr.effects.some((e) => e.is(updateSectionResults))) {
+      return _buildResultsDecorations(tr.state);
+    }
+    return prev.map(tr.changes);
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// ── Theme ─────────────────────────────────────────────────────────────
+
+export const wodResultsTheme = EditorView.baseTheme({
+  ".cm-wod-results-bar": {
+    display: "flex",
+    alignItems: "center",
+    gap: "4px",
+    padding: "2px 10px 2px 8px",
+    overflowX: "auto",
+    whiteSpace: "nowrap",
+    boxSizing: "border-box",
+    borderTop: "1px solid rgba(128, 128, 128, 0.2)",
+    background: "rgba(128, 128, 128, 0.05)",
+    fontSize: "11px",
+  },
+  ".cm-wod-results-icon": {
+    opacity: "0.5",
+    fontSize: "10px",
+    marginRight: "4px",
+    userSelect: "none",
+  },
+  ".cm-wod-result-pill": {
+    cursor: "pointer",
+    border: "1px solid rgba(100, 100, 240, 0.3)",
+    borderRadius: "4px",
+    padding: "1px 7px",
+    fontSize: "10px",
+    fontFamily: "monospace",
+    background: "rgba(100, 100, 240, 0.08)",
+    color: "inherit",
+    transition: "background 0.12s",
+    "&:hover": {
+      background: "rgba(100, 100, 240, 0.18)",
+    },
+  },
+});
+
+// ── Bundle ────────────────────────────────────────────────────────────
+
+export const wodResultsWidget = [
+  wodResultsField,
+  wodResultsDecorations,
+  wodResultsTheme,
+];

--- a/src/components/Editor/overlays/OverlayTrack.tsx
+++ b/src/components/Editor/overlays/OverlayTrack.tsx
@@ -25,11 +25,19 @@ import type { SectionOverlayState } from "./useOverlayWidthState";
 import type { EditorSectionType } from "../extensions/section-state";
 
 // ── Minimum slot heights (px) ────────────────────────────────────────
-// Slots expand to at least this height and re-center against their section.
+// Active slots expand to at least this height to avoid clipping their content.
 const MIN_SLOT_HEIGHT: Partial<Record<EditorSectionType, number>> = {
   frontmatter: 280,
-  wod:         200,
+  wod:         160,
   code:        140,
+  widget:      220,
+};
+
+// Inactive (compact) slots — no artificial inflation; just match the section.
+const MIN_SLOT_HEIGHT_INACTIVE: Partial<Record<EditorSectionType, number>> = {
+  frontmatter: 120,
+  wod:         0,
+  code:        60,
   widget:      220,
 };
 
@@ -172,8 +180,11 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
           const isActive = rect.sectionId === activeSectionId;
 
           // ── Slot height ────────────────────────────────────────────
-          // Normal: expand to a minimum per-type height.
-          const minH = MIN_SLOT_HEIGHT[rect.type] ?? 0;
+          // Active slots use a larger minimum to avoid clipping panel content.
+          // Inactive (compact) slots use a smaller minimum so they don't
+          // create empty space below the action buttons.
+          const heightMap = isActive ? MIN_SLOT_HEIGHT : MIN_SLOT_HEIGHT_INACTIVE;
+          const minH = heightMap[rect.type] ?? 0;
           // Widget slots use a fixed height — their section height is inflated
           // by the JSON body lines which aren't displayed in the slot.
           const effectiveHeight = rect.type === "widget"
@@ -211,9 +222,13 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
           }
 
           const unclamped = targetCenterY - effectiveHeight / 2;
-          // Never go above track top (0), never push bottom below section end.
+          // Clamp so the slot never floats above its own section top.
+          // Using rect.top (not 0) prevents taller-than-section slots from
+          // drifting up into the previous section's space when the bottom-pin
+          // term (rect.top + rect.height - effectiveHeight) goes negative.
+          // When the slot fits inside the section, this keeps it within bounds.
           const slotTop = Math.max(
-            0,
+            rect.top,
             Math.min(unclamped, rect.top + rect.height - effectiveHeight),
           );
 

--- a/src/components/review-grid/ReviewGrid.tsx
+++ b/src/components/review-grid/ReviewGrid.tsx
@@ -272,11 +272,11 @@ export const ReviewGrid: React.FC<ReviewGridProps> = ({
   );
 
   const handleOverrideSave = useCallback(
-    (value: string, image?: string) => {
-      setOverride(overrideDialog.blockKey, overrideDialog.type, value, image);
+    (blockKey: string, metricType: MetricType, value: unknown, image?: string) => {
+      setOverride(blockKey, metricType, value, image);
       setOverrideDialog((prev) => ({ ...prev, isOpen: false }));
     },
-    [overrideDialog.blockKey, overrideDialog.type, setOverride],
+    [setOverride],
   );
 
   const handleOverrideRemove = useCallback(() => {

--- a/src/components/review-grid/useGridData.ts
+++ b/src/components/review-grid/useGridData.ts
@@ -241,6 +241,17 @@ function segmentsToRows(
     const overrides = blockKey ? userOverrides.get(blockKey) : undefined;
     if (overrides) {
       for (const frag of overrides) {
+        // Remove hinted placeholders (origin === 'hinted') of the same type so
+        // the user value replaces the '?' instead of appearing alongside it.
+        const existing = cells.get(frag.type as MetricType);
+        if (existing) {
+          const withoutHinted = existing.metrics.filter((m) => m.origin !== 'hinted');
+          if (withoutHinted.length === 0) {
+            cells.delete(frag.type as MetricType);
+          } else {
+            cells.set(frag.type as MetricType, { metrics: withoutHinted, hasUserOverride: false });
+          }
+        }
         groupFragmentIntoCell(cells, frag);
       }
     }
@@ -251,6 +262,10 @@ function segmentsToRows(
         (f) => f.origin === 'user',
       );
     }
+
+    // Derive Volume (reps × weight) when both Rep and Resistance are known.
+    // This re-runs whenever user overrides supply a missing rep or weight value.
+    deriveVolumeCell(cells);
 
     const outputType = ((seg as SegmentWithContext).context?.outputType as string) ?? seg.type;
 
@@ -281,6 +296,50 @@ function extractBlockKey(seg: Segment): string | undefined {
   const ctx = (seg as SegmentWithContext).context;
   if (ctx?.sourceBlockKey) return ctx.sourceBlockKey as string;
   return seg.name;
+}
+
+/**
+ * Derive a Volume cell (reps × weight kg) when both Rep and Resistance cells
+ * are present with numeric values.  Skips if a Volume cell already exists or
+ * either source cell is missing.
+ */
+function deriveVolumeCell(cells: Map<MetricType, GridCell>): void {
+  // Already have a computed volume — don't overwrite
+  if (cells.has(MetricType.Volume)) return;
+
+  const repCell = cells.get(MetricType.Rep);
+  const resistanceCell = cells.get(MetricType.Resistance);
+  if (!repCell || !resistanceCell) return;
+
+  let reps = 0;
+  for (const m of repCell.metrics) {
+    if (typeof m.value === 'number') reps += m.value;
+  }
+
+  let weightKg = 0;
+  let unit = 'kg';
+  for (const m of resistanceCell.metrics) {
+    const val = m.value as any;
+    if (typeof val?.amount === 'number') {
+      weightKg += val.amount;
+      if (val.unit) unit = val.unit;
+    } else if (typeof m.value === 'number') {
+      weightKg += m.value;
+    }
+  }
+
+  if (reps <= 0 || weightKg <= 0) return;
+
+  const volume = reps * weightKg;
+  cells.set(MetricType.Volume, {
+    metrics: [{
+      type: MetricType.Volume,
+      value: volume,
+      image: `${volume} ${unit}`,
+      origin: 'analyzed',
+    }],
+    hasUserOverride: false,
+  });
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a new inline results bar for WOD (Workout of the Day) blocks in the unified editor, improves the review grid's handling of user overrides and derived metrics, and refines overlay slot sizing and positioning. The main focus is on surfacing workout results immediately in the editor and enabling quick access to detailed reviews. Below are the most important changes:

**WOD Results Bar Integration:**

- Added a new CodeMirror 6 extension (`wod-results-widget.ts`) that displays a compact, clickable results bar after each WOD block with recorded results. Clicking a result pill emits a custom event to open the full-screen review overlay. The extension includes state management, widget rendering, and theming.
- In `UnifiedEditor.tsx`, integrated the results widget extension, ensured that results are fetched from IndexedDB and injected into the editor's state, and handled immediate updates when a workout is completed. Also, results pill clicks now open the review overlay if detailed logs are available. [[1]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0R63-R69) [[2]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0R81-R83) [[3]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0R206-R240) [[4]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0R251-R297) [[5]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0R415-R417) [[6]](diffhunk://#diff-cda3b240eda216c6221e8d31d60ca7b3bae2041103b0de75b4ecd7f8240357d0L508-R603)

**Overlay Slot Sizing and Positioning:**

- Refined overlay slot minimum heights: active slots have larger minimums to avoid clipping content, while inactive slots are more compact to reduce empty space. Slot positioning is now clamped to never float above their section, improving visual alignment and preventing overlap. [[1]](diffhunk://#diff-e02f81a851a8d738e0c5982f2abf3fc952c434c46ece17719be3143a2e84759eL28-R43) [[2]](diffhunk://#diff-e02f81a851a8d738e0c5982f2abf3fc952c434c46ece17719be3143a2e84759eL175-R187) [[3]](diffhunk://#diff-e02f81a851a8d738e0c5982f2abf3fc952c434c46ece17719be3143a2e84759eL214-R231)

**Review Grid and Metrics Handling:**

- Improved override handling in the review grid: user overrides now replace hinted placeholders instead of appearing alongside them, preventing duplicate/confusing metrics in the UI.
- Added logic to automatically derive "Volume" (reps × weight) metrics in the review grid when both reps and resistance are present, including after user overrides supply missing values. [[1]](diffhunk://#diff-6e2a7e560cdc85e81e09bd595e1f3548d8e0a8f27931fe00ff0fe6a2bd101123R266-R269) [[2]](diffhunk://#diff-6e2a7e560cdc85e81e09bd595e1f3548d8e0a8f27931fe00ff0fe6a2bd101123R301-R344)
- Simplified the override save handler to match the new signature and avoid stale closure issues.

These changes collectively enhance the workout review and results experience, making results more visible and actionable directly within the editor.…g in UnifiedEditor