### PR TITLE
Add YouTube Playlist Player to Chromecast Receiver

### DIFF
--- a/.agent/skills/wod-extraction/SKILL.md
+++ b/.agent/skills/wod-extraction/SKILL.md
@@ -449,6 +449,52 @@ For each element of the workout, ask: **"Is this given to the athlete, or does t
 
 ## Common Mistakes to Avoid
 
+### DON'T: Use colons for labels or sections
+```diff
+# BAD: Colons are reserved for timers
+- Warmup:
+-   400m Run
+
+# GOOD: Use simple text for labels
++ Warmup
++   400m Run
+```
+
+### DON'T: Use apostrophes or punctuation in exercise names
+```diff
+# BAD: Identifiers cannot contain apostrophes
+- 1:00 Child's Pose
+
+# GOOD: Remove the apostrophe
++ 1:00 Childs Pose
+```
+
+### DON'T: Include markdown headers inside WOD blocks
+```diff
+# BAD: Markdown headers (#) cause syntax errors
+- ```wod
+- # Morning Flow
+-   1:00 Childs Pose
+- ```
+
+# GOOD: Keep headers outside the code fence
++ # Morning Flow
++ ```wod
++ 1:00 Childs Pose
++ ```
+```
+
+### DON'T: Use brackets for rest or setup periods
+```diff
+# BAD: Brackets are for actions, not effort labels
+- [Rest] 2:00
+- [Setup] 1:00
+
+# GOOD: Use the timer followed by the label
++ 2:00 Rest
++ 1:00 Setup
+```
+
 ### DON'T: Add collectible markers when the system tracks automatically
 ```diff
 # BAD: :? is redundant — "for time" workouts track time by default

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "wod-wiki",
@@ -35,6 +34,7 @@
         "react-joyride": "^2.9.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
+        "react-youtube": "^10.1.0",
         "recharts": "^3.4.1",
         "tailwind-merge": "^3.3.1",
         "uuid": "^13.0.0",
@@ -47,7 +47,6 @@
         "@storybook/addon-docs": "^10.2.17",
         "@storybook/addon-vitest": "^10.2.17",
         "@storybook/react-vite": "^10.2.17",
-        "@storybook/test": "^8.6.15",
         "@testing-library/react": "^16.3.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.5",
@@ -471,15 +470,11 @@
 
     "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
 
-    "@storybook/instrumenter": ["@storybook/instrumenter@8.6.15", "", { "dependencies": { "@storybook/global": "^5.0.0", "@vitest/utils": "^2.1.1" }, "peerDependencies": { "storybook": "^8.6.15" } }, "sha512-TvHR/+yyIAOp/1bLulFai2kkhIBtAlBw7J6Jd9DKyInoGhTWNE1G1Y61jD5GWXX29AlwaHfzGUaX5NL1K+FJpg=="],
-
     "@storybook/react": ["@storybook/react@10.2.17", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.2.17", "react-docgen": "^8.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.17", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-875AVMYil2X9Civil6GFZ8koIzlKxcXbl2eJ7+/GPbhIonTNmwx0qbWPHttjZXUvFuQ4RRtb9KkBwy4TCb/LeA=="],
 
     "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.2.17", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.17" } }, "sha512-x9Kb7eUSZ1zGsEw/TtWrvs1LwWIdNp8qoOQCgPEjdB07reSJcE8R3+ASWHJThmd4eZf66ZALPJyerejake4Osw=="],
 
     "@storybook/react-vite": ["@storybook/react-vite@10.2.17", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.6.4", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.2.17", "@storybook/react": "10.2.17", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.2.17", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-E/1hNmxVsjy9l3TuaNufSqkdz8saTJUGEs8GRCjKlF7be2wljIwewUxjAT3efk+bxOCw76ZmqGHk6MnRa3y7Gw=="],
-
-    "@storybook/test": ["@storybook/test@8.6.15", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/instrumenter": "8.6.15", "@testing-library/dom": "10.4.0", "@testing-library/jest-dom": "6.5.0", "@testing-library/user-event": "14.5.2", "@vitest/expect": "2.0.5", "@vitest/spy": "2.0.5" }, "peerDependencies": { "storybook": "^8.6.15" } }, "sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
@@ -489,11 +484,11 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.0", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "chalk": "^4.1.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "pretty-format": "^27.0.2" } }, "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ=="],
 
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.5.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "chalk": "^3.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "lodash": "^4.17.21", "redent": "^3.0.0" } }, "sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.0", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw=="],
 
-    "@testing-library/user-event": ["@testing-library/user-event@14.5.2", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ=="],
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.28.1", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g=="],
 
@@ -611,7 +606,7 @@
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
-    "@vitest/expect": ["@vitest/expect@2.0.5", "", { "dependencies": { "@vitest/spy": "2.0.5", "@vitest/utils": "2.0.5", "chai": "^5.1.1", "tinyrainbow": "^1.2.0" } }, "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA=="],
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
     "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
 
@@ -621,7 +616,7 @@
 
     "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
 
-    "@vitest/spy": ["@vitest/spy@2.0.5", "", { "dependencies": { "tinyspy": "^3.0.0" } }, "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA=="],
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
@@ -1095,7 +1090,7 @@
 
     "jju": ["jju@1.4.0", "", {}, "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="],
 
-    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -1126,6 +1121,8 @@
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-script": ["load-script@1.0.0", "", {}, "sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA=="],
 
     "local-pkg": ["local-pkg@1.1.2", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A=="],
 
@@ -1395,6 +1392,8 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
+    "react-youtube": ["react-youtube@10.1.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "prop-types": "15.8.1", "youtube-player": "5.5.2" }, "peerDependencies": { "react": ">=0.14.1" } }, "sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg=="],
+
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
@@ -1481,6 +1480,8 @@
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
+    "sister": ["sister@3.0.2", "", {}, "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="],
+
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
@@ -1559,7 +1560,7 @@
 
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
-    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "tldts": ["tldts@7.0.19", "", { "dependencies": { "tldts-core": "^7.0.19" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA=="],
 
@@ -1699,11 +1700,11 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "youtube-player": ["youtube-player@5.5.2", "", { "dependencies": { "debug": "^2.6.6", "load-script": "^1.0.0", "sister": "^3.0.0" } }, "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ=="],
+
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1745,10 +1746,6 @@
 
     "@rushstack/ts-command-line/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "@storybook/instrumenter/@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
-
-    "@testing-library/jest-dom/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
-
     "@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "@ts-morph/common/minimatch": ["minimatch@10.2.3", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg=="],
@@ -1758,14 +1755,6 @@
     "@typescript-eslint/utils/@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
     "@vitest/browser/@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
-
-    "@vitest/browser/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
-
-    "@vitest/expect/@vitest/utils": ["@vitest/utils@2.0.5", "", { "dependencies": { "@vitest/pretty-format": "2.0.5", "estree-walker": "^3.0.3", "loupe": "^3.1.1", "tinyrainbow": "^1.2.0" } }, "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ=="],
-
-    "@vitest/expect/tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
-
-    "@vitest/mocker/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
     "@vitest/mocker/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -1780,6 +1769,8 @@
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "ast-v8-to-istanbul/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "ast-v8-to-istanbul/js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1796,8 +1787,6 @@
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
-
-    "loose-envify/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -1821,14 +1810,6 @@
 
     "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "storybook/@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
-
-    "storybook/@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
-
-    "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
-
-    "storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
-
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
@@ -1837,9 +1818,7 @@
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "vitest/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
-
-    "vitest/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+    "youtube-player/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1855,23 +1834,11 @@
 
     "@rushstack/node-core-library/semver/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
-    "@storybook/instrumenter/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
-
-    "@storybook/instrumenter/@vitest/utils/tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
-
-    "@testing-library/jest-dom/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@typescript-eslint/utils/@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@2.0.5", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ=="],
-
-    "@vitest/expect/@vitest/utils/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
-
-    "@vitest/mocker/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "@vue/language-core/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -1885,10 +1852,6 @@
 
     "react-floater/tree-changes/@gilbarbara/deep-equal": ["@gilbarbara/deep-equal@0.1.2", "", {}, "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA=="],
 
-    "storybook/@testing-library/jest-dom/dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
-
-    "storybook/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
-
     "test-exclude/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "test-exclude/glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
@@ -1897,7 +1860,7 @@
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
-    "vitest/@vitest/spy/tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+    "youtube-player/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "@microsoft/api-extractor/semver/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-joyride": "^2.9.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
+    "react-youtube": "^10.1.0",
     "recharts": "^3.4.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^13.0.0",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -50,7 +50,6 @@ import {
   CommandLineIcon,
   DocumentTextIcon,
   FolderIcon,
-  TvIcon,
   EllipsisVerticalIcon,
   ArrowDownTrayIcon,
   BugAntIcon,
@@ -65,6 +64,7 @@ import { CommandProvider } from '@/components/command-palette/CommandContext'
 import { useCommandPalette } from '@/components/command-palette/CommandContext'
 import { HashRouter, Routes, Route, useNavigate, useParams, useLocation } from 'react-router-dom'
 import { HomePageContent } from './HomePage'
+import { CastButtonRpc } from '@/components/cast/CastButtonRpc'
 
 // Load all markdown files from the wod directory
 const workoutFiles = import.meta.glob('../../wod/**/*.md', { eager: true, query: '?raw', import: 'default' })
@@ -246,8 +246,8 @@ function AppContent() {
                 K
               </kbd>
             </NavbarItem>
-            <NavbarItem className="lg:hidden" title="Cast to Device">
-              <TvIcon data-slot="icon" />
+            <NavbarItem className="lg:hidden">
+              <CastButtonRpc />
             </NavbarItem>
             <NavbarItem href="/inbox" className="max-lg:hidden" aria-label="Inbox">
               <InboxIcon data-slot="icon" />
@@ -391,12 +391,7 @@ function AppContent() {
             <div className="flex items-center justify-between px-6 lg:px-10">
               <h1 className="text-2xl/8 font-semibold text-zinc-950 sm:text-xl/8 dark:text-white">{currentWorkout.name}</h1>
               <div className="flex items-center gap-4">
-                <button
-                  className="text-zinc-500 hover:text-zinc-950 dark:text-zinc-400 dark:hover:text-white transition-colors"
-                  title="Cast to Device"
-                >
-                  <TvIcon data-slot="icon" className="size-5" />
-                </button>
+                <CastButtonRpc />
                 <ActionsMenu />
               </div>
             </div>

--- a/src/components/Editor/UnifiedEditor.tsx
+++ b/src/components/Editor/UnifiedEditor.tsx
@@ -77,6 +77,7 @@ import type { WidgetRegistry } from "./overlays/WidgetCompanion";
 import type { WodCommand } from "./overlays/WodCommand";
 import { FullscreenTimer } from "./overlays/FullscreenTimer";
 import { FullscreenReview } from "./overlays/FullscreenReview";
+import { EditorCastBridge } from "./overlays/EditorCastBridge";
 import type { Segment } from "@/core/models/AnalyticsModels";
 import { indexedDBService } from "@/services/db/IndexedDBService";
 import { getAnalyticsFromLogs } from "@/services/AnalyticsTransformer";
@@ -548,6 +549,11 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
           commands={effectiveCommands}
           visibleCount={visibleCommands}
           onOpenReview={handleOpenReview}
+          hoverLine={props.hoverLine}
+          stickyTopOffset={props.stickyTopOffset}
+          isPanelHovered={props.isPanelHovered}
+          lineDocY={props.lineDocY}
+          rect={props.rect}
         />
       );
     }
@@ -610,6 +616,13 @@ export const UnifiedEditor: React.FC<UnifiedEditorProps> = ({
           onClose={handleReviewClose}
         />
       )}
+
+      <EditorCastBridge
+        sections={sections}
+        isRuntimeActive={fullscreenTimerBlock !== null}
+        editorState={viewRef.current?.state ?? null}
+        onSelectBlock={enableInlineRuntime ? handleRun : undefined}
+      />
     </div>
   );
 };

--- a/src/components/Editor/extensions/markdown-tables.ts
+++ b/src/components/Editor/extensions/markdown-tables.ts
@@ -45,6 +45,26 @@ function parseTableCells(line: string): string[] {
     .map((c) => c.trim());
 }
 
+/**
+ * Returns the character offset *within* a raw table line where cell `ci`
+ * content begins (i.e. just after the (ci+1)-th pipe, past any leading space).
+ */
+function findCellPosInLine(lineText: string, ci: number): number {
+  let pipeCount = 0;
+  for (let i = 0; i < lineText.length; i++) {
+    if (lineText[i] === "|") {
+      pipeCount++;
+      if (pipeCount === ci + 1) {
+        // Skip a single leading space if present (standard table format)
+        let j = i + 1;
+        while (j < lineText.length && lineText[j] === " ") j++;
+        return j;
+      }
+    }
+  }
+  return 0;
+}
+
 function parseTableAlignment(
   line: string
 ): ("left" | "center" | "right")[] {
@@ -74,15 +94,15 @@ class MarkdownTableWidget extends WidgetType {
     );
   }
 
-  toDOM(_view: EditorView): HTMLElement {
+  toDOM(view: EditorView): HTMLElement {
     const wrapper = document.createElement("div");
     wrapper.className = "cm-md-table-preview";
 
-    wrapper.appendChild(this._buildTable());
+    wrapper.appendChild(this._buildTable(view));
     return wrapper;
   }
 
-  private _buildTable(): HTMLElement {
+  private _buildTable(view: EditorView): HTMLElement {
     const lines = this.tableLines;
     const hasSep = lines.length >= 2 && isTableSeparator(lines[1]);
     const alignments = hasSep ? parseTableAlignment(lines[1]) : [];
@@ -101,11 +121,32 @@ class MarkdownTableWidget extends WidgetType {
       const tr = document.createElement("tr");
       tr.className = isHeader ? "cm-md-table-header" : "cm-md-table-row";
 
+      // Map rendered row index back to source line index:
+      //   ri=0 → source line 0 (header)
+      //   ri=1+ → source line ri+1 (skipping separator at index 1)
+      const srcLineIdx = hasSep && ri > 0 ? ri + 1 : ri;
+
       cells.forEach((cell, ci) => {
         const td = document.createElement(isHeader ? "th" : "td");
         const align = alignments[ci] ?? "left";
         td.className = `cm-md-table-cell cm-md-align-${align}`;
         td.textContent = cell || "\u00A0";
+
+        // Click → move cursor into the source cell, collapsing the preview
+        td.addEventListener("mousedown", (e) => {
+          e.preventDefault();
+          const firstLine = view.state.doc.lineAt(this.tableFrom);
+          const targetLineNum = firstLine.number + srcLineIdx;
+          if (targetLineNum > view.state.doc.lines) return;
+          const targetLine = view.state.doc.line(targetLineNum);
+          const colOffset = findCellPosInLine(targetLine.text, ci);
+          view.dispatch({
+            selection: { anchor: targetLine.from + colOffset },
+            scrollIntoView: true,
+          });
+          view.focus();
+        });
+
         tr.appendChild(td);
       });
 
@@ -116,6 +157,8 @@ class MarkdownTableWidget extends WidgetType {
   }
 
   ignoreEvent(): boolean {
+    // Keep true so CM6 doesn’t also try to reposition the cursor via posAtCoords;
+    // our mousedown handler above dispatches the correct selection directly.
     return true;
   }
 }
@@ -219,6 +262,7 @@ const tablePreviewTheme = EditorView.baseTheme({
     borderBottom: "2px solid rgba(128,128,128,0.3)",
     color: "inherit",
     whiteSpace: "nowrap",
+    cursor: "pointer",
   },
 
   // Data rows
@@ -227,6 +271,12 @@ const tablePreviewTheme = EditorView.baseTheme({
     borderBottom: "1px solid rgba(128,128,128,0.12)",
     color: "inherit",
     verticalAlign: "top",
+    cursor: "pointer",
+  },
+
+  // Hover highlight for clickable cells
+  ".cm-md-table-cell:hover": {
+    backgroundColor: "rgba(128,128,128,0.08)",
   },
 
   // Column separators between cells

--- a/src/components/Editor/extensions/theme.ts
+++ b/src/components/Editor/extensions/theme.ts
@@ -28,13 +28,27 @@ export function editorTheme(isDark: boolean): Extension {
       border: "none",
       padding: "0 8px"
     },
+    // Semi-transparent so the drawSelection layer (rendered behind .cm-content)
+    // can bleed through and remain visible when text is selected on the active line.
     ".cm-activeLine": {
-      backgroundColor: isDark ? "#2c2c2c" : "#e8f2ff"
+      backgroundColor: isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(59, 130, 246, 0.09)"
     },
     ".cm-activeLineGutter": {
-      backgroundColor: isDark ? "#2c2c2c" : "#e8f2ff"
+      backgroundColor: isDark ? "rgba(255, 255, 255, 0.07)" : "rgba(59, 130, 246, 0.09)"
+    },
+    // Selection layer — must be strong enough to show through the transparent line bg.
+    "&.cm-focused .cm-selectionBackground": {
+      backgroundColor: isDark ? "rgba(100, 160, 255, 0.35)" : "rgba(30, 100, 230, 0.50)"
+    },
+    ".cm-selectionBackground": {
+      backgroundColor: isDark ? "rgba(100, 160, 255, 0.20)" : "rgba(30, 100, 230, 0.25)"
+    },
+    "::selection": {
+      backgroundColor: isDark ? "rgba(100, 160, 255, 0.35) !important" : "rgba(30, 100, 230, 0.50) !important"
     }
   }, { dark: isDark });
 
-  return isDark ? [baseTheme, oneDark] : [baseTheme];
+  // In dark mode put baseTheme AFTER oneDark so our semi-transparent activeLine
+  // and selection rules take precedence over oneDark's opaque equivalents.
+  return isDark ? [oneDark, baseTheme] : [baseTheme];
 }

--- a/src/components/Editor/md-components/section-renderers/embeds/YouTubeEmbed.tsx
+++ b/src/components/Editor/md-components/section-renderers/embeds/YouTubeEmbed.tsx
@@ -7,33 +7,17 @@
 
 import React, { useMemo } from 'react';
 import { SECTION_LINE_HEIGHT } from '../../SectionContainer';
+import { extractYouTubeVideoId } from '@/lib/youtubeUtils';
 
 export interface YouTubeEmbedProps {
   properties: Record<string, string>;
   lineCount: number;
 }
 
-/** Extract YouTube video ID from various URL formats */
-function extractVideoId(url: string): string | null {
-  // Standard: https://www.youtube.com/watch?v=VIDEO_ID
-  const standardMatch = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
-  if (standardMatch) return standardMatch[1];
-
-  // Short: https://youtu.be/VIDEO_ID
-  const shortMatch = url.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/);
-  if (shortMatch) return shortMatch[1];
-
-  // Embed: https://www.youtube.com/embed/VIDEO_ID
-  const embedMatch = url.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/);
-  if (embedMatch) return embedMatch[1];
-
-  return null;
-}
-
 export const YouTubeEmbed: React.FC<YouTubeEmbedProps> = ({ properties, lineCount }) => {
   const url = properties['url'] || properties['link'] || '';
   const title = properties['title'] || 'YouTube Video';
-  const videoId = useMemo(() => extractVideoId(url), [url]);
+  const videoId = useMemo(() => extractYouTubeVideoId(url), [url]);
 
   const minHeight = lineCount * SECTION_LINE_HEIGHT;
 

--- a/src/components/Editor/overlays/EditorCastBridge.tsx
+++ b/src/components/Editor/overlays/EditorCastBridge.tsx
@@ -1,0 +1,153 @@
+/**
+ * EditorCastBridge — renderless component that sends preview data to the
+ * Chromecast receiver when a cast session is active but no runtime is running.
+ *
+ * Placement: inside UnifiedEditor, alongside the OverlayTrack.
+ *
+ * Responsibilities:
+ * - When castTransport is connected and no inline runtime is active:
+ *   sends 'rpc-workbench-update' with mode='preview' and rich block data.
+ * - When sections change (e.g., user navigates to a different workout page):
+ *   re-sends the preview with updated block info.
+ * - Does NOT send anything when a runtime is active — RuntimeTimerPanel
+ *   handles 'active' mode independently.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useWorkbenchSyncStore } from '@/components/layout/workbenchSyncStore';
+import type { EditorSection } from '../extensions/section-state';
+import type { RpcWorkbenchUpdate } from '@/services/cast/rpc/RpcMessages';
+import type { RpcMessage } from '@/services/cast/rpc/RpcMessages';
+import type { EditorState } from '@codemirror/state';
+import type { WodBlock } from '../types';
+
+interface EditorCastBridgeProps {
+  /** All parsed editor sections */
+  sections: EditorSection[];
+  /** Whether an inline runtime is currently active */
+  isRuntimeActive: boolean;
+  /** CodeMirror EditorState — used to extract section content */
+  editorState: EditorState | null;
+  /** Called when the Chromecast receiver selects a block to start */
+  onSelectBlock?: (block: WodBlock) => void;
+}
+
+export const EditorCastBridge: React.FC<EditorCastBridgeProps> = ({
+  sections,
+  isRuntimeActive,
+  editorState,
+  onSelectBlock,
+}) => {
+  const castTransport = useWorkbenchSyncStore(s => s.castTransport);
+  const lastFingerprintRef = useRef('');
+
+  useEffect(() => {
+    if (!castTransport?.connected || isRuntimeActive || !editorState) return;
+
+    const wodSections = sections.filter(s => s.type === 'wod');
+
+    const blocks = wodSections.map(section => {
+      const content =
+        section.contentFrom !== undefined && section.contentTo !== undefined
+          ? editorState.doc.sliceString(section.contentFrom, section.contentTo)
+          : '';
+
+      const lines = content.split('\n').filter(l => l.trim().length > 0);
+      const contentPreview = lines.slice(0, 3).join('\n');
+
+      // Extract a timer hint from the first line that looks like a duration (e.g. "10:00")
+      const timerMatch = content.match(/^(\d{1,2}:\d{2}(?::\d{2})?)/m);
+      const timerHint = timerMatch?.[1];
+
+      // Derive a title from the first non-empty line or fall back to dialect
+      const title = lines[0]?.substring(0, 60) || section.dialect || 'Workout';
+
+      return {
+        id: section.id,
+        title,
+        statementCount: lines.length,
+        contentPreview,
+        timerHint,
+        dialect: section.dialect || 'wod',
+      };
+    });
+
+    const message: RpcWorkbenchUpdate = {
+      type: 'rpc-workbench-update',
+      mode: blocks.length > 0 ? 'preview' : 'idle',
+      previewData: blocks.length > 0 ? {
+        title: blocks[0].title,
+        blocks,
+      } : undefined,
+    };
+
+    // Deduplicate sends
+    const fingerprint = JSON.stringify(message);
+    if (fingerprint === lastFingerprintRef.current) return;
+    lastFingerprintRef.current = fingerprint;
+
+    try {
+      castTransport.send(message);
+    } catch {
+      // Transport may have disconnected between check and send
+    }
+  }, [castTransport, sections, isRuntimeActive, editorState]);
+
+  // Reset fingerprint when transport disconnects so we re-send on reconnect
+  useEffect(() => {
+    if (!castTransport?.connected) {
+      lastFingerprintRef.current = '';
+    }
+  }, [castTransport]);
+
+  // Reset fingerprint when the runtime becomes inactive so the preview
+  // is re-sent even if the sections haven't changed. Without this, closing
+  // the track screen would leave the Chromecast stuck on idle/review.
+  useEffect(() => {
+    if (!isRuntimeActive) {
+      lastFingerprintRef.current = '';
+    }
+  }, [isRuntimeActive]);
+
+  // Listen for 'select-block' events from the receiver and resolve them
+  // against the current editor sections to start the inline runtime.
+  useEffect(() => {
+    if (!castTransport?.connected || !onSelectBlock || !editorState) return;
+
+    const unsub = castTransport.onMessage((message: RpcMessage) => {
+      if (message.type !== 'rpc-event' || (message as any).name !== 'select-block') return;
+
+      const { index, blockId } = ((message as any).data ?? {}) as { index?: number; blockId?: string };
+      const wodSections = sections.filter(s => s.type === 'wod');
+
+      const targetSection = blockId
+        ? wodSections.find(s => s.id === blockId)
+        : wodSections[index ?? 0];
+
+      if (!targetSection || !editorState) return;
+
+      const content =
+        targetSection.contentFrom !== undefined && targetSection.contentTo !== undefined
+          ? editorState.doc.sliceString(targetSection.contentFrom, targetSection.contentTo)
+          : '';
+
+      const block: WodBlock = {
+        id: targetSection.id,
+        dialect: targetSection.dialect || 'wod',
+        startLine: targetSection.startLine - 1,
+        endLine: targetSection.endLine - 1,
+        content,
+        state: 'idle',
+        version: 1,
+        createdAt: Date.now(),
+        widgetIds: {},
+      };
+
+      onSelectBlock(block);
+    });
+
+    return unsub;
+  }, [castTransport, sections, editorState, onSelectBlock, isRuntimeActive]);
+
+  return null;
+};

--- a/src/components/Editor/overlays/FocusedDialog.tsx
+++ b/src/components/Editor/overlays/FocusedDialog.tsx
@@ -1,0 +1,73 @@
+/**
+ * FocusedDialog
+ *
+ * Full-screen takeover dialog used for immersive views (track, review).
+ * Covers the entire viewport with an opaque background, prevents body scroll,
+ * and renders children in a full-height flex column with an optional header.
+ */
+
+import React, { useEffect } from "react";
+import * as ReactDOM from "react-dom";
+import { X } from "lucide-react";
+
+export interface FocusedDialogProps {
+  /** Title shown in the header bar. If omitted, no header is rendered. */
+  title?: string;
+  /** Called when the user clicks the close button. */
+  onClose: () => void;
+  /** Dialog contents — fills the remaining vertical space. */
+  children: React.ReactNode;
+  /** Extra class name for the close button (e.g. to set z-index when header is hidden). */
+  closeButtonClassName?: string;
+  /** When true, render a floating close button instead of a header bar. */
+  floatingClose?: boolean;
+}
+
+export const FocusedDialog: React.FC<FocusedDialogProps> = ({
+  title,
+  onClose,
+  children,
+  closeButtonClassName,
+  floatingClose = false,
+}) => {
+  // Prevent scrolling on the body while the dialog is open
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  const closeBtn = (
+    <button
+      onClick={onClose}
+      className={
+        closeButtonClassName ??
+        "p-2 rounded-full bg-muted/50 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shadow-sm"
+      }
+      title="Close"
+    >
+      <X className="h-5 w-5" />
+    </button>
+  );
+
+  // Portal to document.body so we escape any CSS containing blocks
+  // (CodeMirror sets `contain: size style` on .cm-editor which traps fixed positioning).
+  return (ReactDOM as any).createPortal(
+    <div className="fixed inset-0 z-[100] flex flex-col bg-background animate-in fade-in duration-200">
+      {floatingClose ? (
+        <div className="absolute top-4 right-4 z-[110]">{closeBtn}</div>
+      ) : title ? (
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-muted/30 shrink-0">
+          <h2 className="text-lg font-semibold">{title}</h2>
+          {closeBtn}
+        </div>
+      ) : null}
+
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};

--- a/src/components/Editor/overlays/FrontmatterCompanion.tsx
+++ b/src/components/Editor/overlays/FrontmatterCompanion.tsx
@@ -52,15 +52,7 @@ function detectSubtype(props: Record<string, string>): FrontmatterSubtype {
   return "default";
 }
 
-function extractYouTubeVideoId(url: string): string | null {
-  const standard = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
-  if (standard) return standard[1];
-  const short = url.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/);
-  if (short) return short[1];
-  const embed = url.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/);
-  if (embed) return embed[1];
-  return null;
-}
+import { extractYouTubeVideoId } from "@/lib/youtubeUtils";
 
 // ── Component ────────────────────────────────────────────────────────
 

--- a/src/components/Editor/overlays/FullscreenReview.tsx
+++ b/src/components/Editor/overlays/FullscreenReview.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { ReviewGrid } from "@/components/review-grid/ReviewGrid";
-import { X } from "lucide-react";
 import type { Segment } from "@/core/models/AnalyticsModels";
+import { FocusedDialog } from "./FocusedDialog";
 
 export interface FullscreenReviewProps {
   segments: Segment[];
@@ -48,40 +48,15 @@ export const FullscreenReview: React.FC<FullscreenReviewProps> = ({
     });
   };
 
-  // Prevent scrolling on the body while the review is open
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, []);
-
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/95 backdrop-blur-md animate-in fade-in duration-200">
-      <div className="relative w-full h-full flex flex-col max-w-7xl mx-auto shadow-2xl border-x border-border bg-card overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-muted/30">
-          <h2 className="text-lg font-semibold">{title}</h2>
-          <button
-            onClick={onClose}
-            className="p-2 rounded-full bg-muted/50 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shadow-sm"
-            title="Close Review"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* Content */}
-        <div className="flex-1 min-h-0 overflow-hidden">
-          <ReviewGrid
-            runtime={null}
-            segments={segments}
-            selectedSegmentIds={selectedSegmentIds}
-            onSelectSegment={handleSelectSegment}
-            groups={[]}
-          />
-        </div>
-      </div>
-    </div>
+    <FocusedDialog title={title} onClose={onClose}>
+      <ReviewGrid
+        runtime={null}
+        segments={segments}
+        selectedSegmentIds={selectedSegmentIds}
+        onSelectSegment={handleSelectSegment}
+        groups={[]}
+      />
+    </FocusedDialog>
   );
 };

--- a/src/components/Editor/overlays/FullscreenTimer.tsx
+++ b/src/components/Editor/overlays/FullscreenTimer.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import type { EditorView } from "@codemirror/view";
 import { RuntimeTimerPanel } from "./RuntimeTimerPanel";
 import type { WodBlock, WorkoutResults } from "../types";
-import { X } from "lucide-react";
+import { ReviewGrid } from "@/components/review-grid/ReviewGrid";
+import { getAnalyticsFromLogs } from "@/services/AnalyticsTransformer";
+import type { Segment } from "@/core/models/AnalyticsModels";
+import { FocusedDialog } from "./FocusedDialog";
 
 export interface FullscreenTimerProps {
   block: WodBlock;
@@ -18,6 +21,10 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
   onCompleteWorkout,
 }) => {
   const [isClosing, setIsClosing] = useState(false);
+  // When a workout completes naturally (last block popped), we show the results
+  // view in place of the timer view within this same popup.
+  const [completedSegments, setCompletedSegments] = useState<Segment[] | null>(null);
+  const [selectedSegmentIds, setSelectedSegmentIds] = useState<Set<number>>(new Set());
 
   const handleClose = () => {
     setIsClosing(true);
@@ -25,36 +32,73 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
     setTimeout(onClose, 100);
   };
 
-  // Prevent scrolling on the body while the timer is open
-  useEffect(() => {
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = "";
-    };
-  }, []);
+  // Called by RuntimeTimerPanel when the workout finishes (either naturally or
+  // via the Stop button).  When completed === true (natural finish), we
+  // transition to the results view instead of closing.
+  const handleComplete = (blockId: string, results: WorkoutResults) => {
+    onCompleteWorkout?.(blockId, results);
 
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-background/95 backdrop-blur-md animate-in fade-in duration-200">
-      <div className="relative w-full h-full flex flex-col max-w-7xl mx-auto shadow-2xl border-x border-border bg-card overflow-hidden">
-        {/* Close Button Overlay (Top Right) */}
-        <button
-          onClick={handleClose}
-          className="absolute top-4 right-4 z-[110] p-2 rounded-full bg-muted/50 hover:bg-muted text-muted-foreground hover:text-foreground transition-colors shadow-sm"
-          title="Close Timer"
-        >
-          <X className="h-5 w-5" />
-        </button>
+    if (results.completed && results.logs && results.logs.length > 0) {
+      const { segments } = getAnalyticsFromLogs(results.logs as any, results.startTime);
+      setCompletedSegments(segments);
+    } else if (results.completed) {
+      // Completed but no logs — still switch to results view (will show empty state)
+      setCompletedSegments([]);
+    }
+    // If not completed (manual stop), fall through — RuntimeTimerPanel will call
+    // onClose() which closes the popup normally.
+  };
 
-        <div className="flex-1 min-h-0">
-          <RuntimeTimerPanel
-            block={block}
-            view={view}
-            onClose={handleClose}
-            onComplete={onCompleteWorkout}
-            isExpanded={true}
-          />
-        </div>
-      </div>
-    </div>
+  const handleSelectSegment = (id: number, modifiers?: { ctrlKey: boolean; shiftKey: boolean }, visibleIds?: number[]) => {
+    setSelectedSegmentIds((prev) => {
+      const next = new Set(prev);
+      if (modifiers?.ctrlKey) {
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+      } else if (modifiers?.shiftKey && visibleIds) {
+        const lastId = Array.from(prev).pop();
+        if (lastId !== undefined) {
+          const startIdx = visibleIds.indexOf(lastId);
+          const endIdx = visibleIds.indexOf(id);
+          if (startIdx !== -1 && endIdx !== -1) {
+            const min = Math.min(startIdx, endIdx);
+            const max = Math.max(startIdx, endIdx);
+            for (let i = min; i <= max; i++) next.add(visibleIds[i]);
+          } else {
+            next.add(id);
+          }
+        } else {
+          next.add(id);
+        }
+      } else {
+        next.clear();
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  return completedSegments !== null ? (
+    /* ── Results view: shown after natural workout completion ── */
+    <FocusedDialog title="Workout Complete" onClose={handleClose}>
+      <ReviewGrid
+        runtime={null}
+        segments={completedSegments}
+        selectedSegmentIds={selectedSegmentIds}
+        onSelectSegment={handleSelectSegment}
+        groups={[]}
+      />
+    </FocusedDialog>
+  ) : (
+    /* ── Track view: active timer ── */
+    <FocusedDialog onClose={handleClose} floatingClose>
+      <RuntimeTimerPanel
+        block={block}
+        view={view}
+        onClose={handleClose}
+        onComplete={handleComplete}
+        isExpanded={true}
+      />
+    </FocusedDialog>
   );
 };

--- a/src/components/Editor/overlays/OverlayTrack.tsx
+++ b/src/components/Editor/overlays/OverlayTrack.tsx
@@ -1,20 +1,18 @@
 /**
  * OverlayTrack
  *
- * React component that renders section-aligned overlay slots on top of the
- * CodeMirror editor. Each slot is positioned at the section's measured geometry
- * and sized to the computed overlay width (0-100% from the right edge).
+ * Renders section-aligned overlay slots on top of the CodeMirror editor.
  *
  * Layout model:
- *  - The track is `position: absolute` inset to the editor's writable content
- *    area: starts after the gutter (line-numbers) and ends before the native
- *    browser scrollbar.  Overlays therefore never cover line numbers or the
- *    scrollbar regardless of width setting.
- *  - Insets are measured via ResizeObserver so they stay correct when gutters
- *    are toggled or the window is resized.
- *  - The track is scroll-synced with `.cm-scroller` via `translateY(-scrollTop)`.
- *  - Each visible slot has `pointer-events: auto` so its contents are interactive.
- *  - Text underneath remains full-width — the overlay floats on top.
+ *  - Track is `position: absolute`, inset to the content area (after gutter,
+ *    before scrollbar).
+ *  - Track inner div is scroll-synced via `translateY(-scrollTop)`.
+ *  - Each WOD slot spans the FULL section height but is transparent — only its
+ *    absolutely-positioned children (strip, card) are visible.
+ *  - The sticky run-button STRIP is always visible, following the viewport
+ *    top as the section scrolls past it (sticky within section bounds).
+ *  - The metric CARD appears on hover or cursor focus, positioned near the
+ *    target line, without hiding the strip.
  */
 
 import React, { useEffect, useRef, useState } from "react";
@@ -24,20 +22,15 @@ import { sectionGeometry } from "../extensions/section-geometry";
 import type { SectionOverlayState } from "./useOverlayWidthState";
 import type { EditorSectionType } from "../extensions/section-state";
 
-// ── Minimum slot heights (px) ────────────────────────────────────────
-// Active slots expand to at least this height to avoid clipping their content.
-const MIN_SLOT_HEIGHT: Partial<Record<EditorSectionType, number>> = {
-  frontmatter: 280,
-  wod:         160,
-  code:        140,
+// ── Non-wod slot heights (px) ────────────────────────────────────────
+const SLOT_HEIGHT_INACTIVE: Partial<Record<EditorSectionType, number>> = {
+  frontmatter: 120,
+  code:        60,
   widget:      220,
 };
-
-// Inactive (compact) slots — no artificial inflation; just match the section.
-const MIN_SLOT_HEIGHT_INACTIVE: Partial<Record<EditorSectionType, number>> = {
-  frontmatter: 120,
-  wod:         0,
-  code:        60,
+const SLOT_HEIGHT_ACTIVE: Partial<Record<EditorSectionType, number>> = {
+  frontmatter: 280,
+  code:        140,
   widget:      220,
 };
 
@@ -54,6 +47,16 @@ export interface OverlaySlotProps {
   docVersion: number;
   /** Widget name (only when sectionType === "widget"). */
   widgetName?: string;
+  /** 1-based line number the mouse is hovering over (undefined = not in this section). */
+  hoverLine?: number;
+  /**
+   * For WOD slots: how many px the section top has scrolled above the viewport.
+   * Used to position the sticky strip inside the full-height transparent slot.
+   */
+  stickyTopOffset: number;
+  isPanelHovered: boolean;
+  /** Document-space Y midpoint of the cursor/hover line; WodCompanion uses this to center the card. */
+  lineDocY?: number;
 }
 
 export interface OverlayTrackProps {
@@ -65,7 +68,7 @@ export interface OverlayTrackProps {
   activeSectionId: string | null;
   /** Render function for slot contents — called for each visible slot */
   renderSlot?: (props: OverlaySlotProps) => React.ReactNode;
-  /** Current cursor line (1-based) — used to center the slot on the active line */
+  /** Current cursor line (1-based) — used to center the card on the active line */
   cursorLine?: number;
 }
 
@@ -81,71 +84,85 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
   const trackRef = useRef<HTMLDivElement>(null);
   const [rects, setRects] = useState<SectionRect[]>([]);
   const [scrollTop, setScrollTop] = useState(0);
-  // left = gutter width; right = scrollbar width
   const [contentInsets, setContentInsets] = useState<{ left: number; right: number }>({ left: 0, right: 0 });
-  // Increments whenever the editor document changes so companions re-derive their data.
   const [docVersion, setDocVersion] = useState(0);
+  // 1-based doc line under the mouse pointer (undefined when outside)
+  const [hoverLine, setHoverLine] = useState<number | undefined>(undefined);
+  // sectionId whose panel the mouse is physically over (keeps panel pinned)
+  const [hoverSectionId, setHoverSectionId] = useState<string | undefined>(undefined);
 
-  // Measure content-area insets: gutter (left) and scrollbar (right).
-  // Re-measures whenever the editor DOM resizes (gutters toggled, window resize, etc.).
+  // Measure gutter + scrollbar insets
   useEffect(() => {
     if (!view) return;
-
     const measure = () => {
-      // Gutter width = offsetLeft of .cm-content within .cm-scroller
       const gutterWidth = view.contentDOM.offsetLeft;
-      // Scrollbar width = total scrollDOM width minus the visible (non-scrollbar) width
       const scrollbarWidth = view.scrollDOM.offsetWidth - view.scrollDOM.clientWidth;
       setContentInsets({ left: gutterWidth, right: scrollbarWidth });
     };
-
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(view.dom);
     return () => observer.disconnect();
   }, [view]);
 
-  // Watch for document mutations: CM6 synchronously updates contentDOM on every
-  // dispatch, so a MutationObserver gives us a reliable change signal without
-  // needing to add a CM6 extension.
+  // MutationObserver → docVersion bump on every CM6 dispatch
   useEffect(() => {
     if (!view) return;
     const observer = new MutationObserver(() => setDocVersion((v) => v + 1));
-    observer.observe(view.contentDOM, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
+    observer.observe(view.contentDOM, { childList: true, subtree: true, characterData: true });
     return () => observer.disconnect();
   }, [view]);
 
-  // Subscribe to section geometry changes
+  // Section geometry subscription
   useEffect(() => {
     if (!view) return;
-
     const plugin = view.plugin(sectionGeometry);
     if (!plugin) return;
-
-    const unsub = plugin.addListener(setRects);
-    return unsub;
+    return plugin.addListener(setRects);
   }, [view]);
 
-  // Scroll sync: listen to .cm-scroller scroll events
+  // Scroll sync
   useEffect(() => {
     if (!view) return;
-
     const scroller = view.scrollDOM;
-    const handleScroll = () => {
-      setScrollTop(scroller.scrollTop);
-    };
-
-    // Initial sync
+    const handleScroll = () => setScrollTop(scroller.scrollTop);
     setScrollTop(scroller.scrollTop);
     scroller.addEventListener("scroll", handleScroll, { passive: true });
     return () => scroller.removeEventListener("scroll", handleScroll);
   }, [view]);
 
-  // Filter to slots that have width > 0
+  // Hover-line tracking at DOCUMENT level so events fire even when the
+  // mouse is over the overlay panel (which is a sibling of the CM scroller,
+  // not a child, so scroller-level listeners miss those events).
+  useEffect(() => {
+    if (!view) return;
+    const scroller = view.scrollDOM;
+    const handleMouseMove = (e: MouseEvent) => {
+      const bounds = scroller.getBoundingClientRect();
+      if (
+        e.clientY < bounds.top || e.clientY > bounds.bottom ||
+        e.clientX < bounds.left || e.clientX > bounds.right
+      ) {
+        setHoverLine(undefined);
+        return;
+      }
+      try {
+        const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
+        if (pos == null) { setHoverLine(undefined); return; }
+        setHoverLine(view.state.doc.lineAt(pos).number);
+      } catch {
+        setHoverLine(undefined);
+      }
+    };
+    const handleMouseLeave = () => setHoverLine(undefined);
+    document.addEventListener("mousemove", handleMouseMove, { passive: true });
+    scroller.addEventListener("mouseleave", handleMouseLeave);
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      scroller.removeEventListener("mouseleave", handleMouseLeave);
+    };
+  }, [view]);
+
   const visibleSlots = rects.filter((rect) => {
     const state = widths.get(rect.sectionId);
     return state && state.effectiveWidth > 0;
@@ -164,7 +181,7 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
         right: contentInsets.right,
         bottom: 0,
         pointerEvents: "none",
-        overflow: "hidden",
+        overflow: "visible",
         zIndex: 10,
       }}
     >
@@ -178,63 +195,65 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
         {visibleSlots.map((rect) => {
           const state = widths.get(rect.sectionId)!;
           const isActive = rect.sectionId === activeSectionId;
+          const isPanelHovered = hoverSectionId === rect.sectionId;
 
-          // ── Slot height ────────────────────────────────────────────
-          // Active slots use a larger minimum to avoid clipping panel content.
-          // Inactive (compact) slots use a smaller minimum so they don't
-          // create empty space below the action buttons.
-          const heightMap = isActive ? MIN_SLOT_HEIGHT : MIN_SLOT_HEIGHT_INACTIVE;
-          const minH = heightMap[rect.type] ?? 0;
-          // Widget slots use a fixed height — their section height is inflated
-          // by the JSON body lines which aren't displayed in the slot.
-          const effectiveHeight = rect.type === "widget"
-            ? minH
-            : Math.max(rect.height, minH);
+          // ── For WOD blocks: slot always spans full section height ────
+          // The WodCompanion renders its children (strip + card) using
+          // absolute positioning within this transparent full-height container.
+          let slotTop: number;
+          let slotHeight: number;
 
-          // ── Slot width ──────────────────────────────────────────────
-          // Normal: use the computed overlay width.
-          const slotWidthPct = state.effectiveWidth;
+          if (rect.type === "wod") {
+            slotTop = rect.top;
+            slotHeight = rect.height;
+          } else {
+            // Non-WOD: sized and centered as before
+            const isComp = isActive;
+            const heightMap = isComp ? SLOT_HEIGHT_ACTIVE : SLOT_HEIGHT_INACTIVE;
+            const minH = heightMap[rect.type] ?? 0;
+            slotHeight = rect.type === "widget" ? minH : Math.max(rect.height, minH);
 
-          // ── Slot vertical position ──────────────────────────────────
-          // Centering logic for normal slots:
-          //   - Slot LARGER than section  → center on the section midline.
-          //   - Slot SMALLER than section → center on the cursor line (if cursor
-          //     is inside this section), otherwise center on section midline.
-          //   Result is clamped so the slot never rises above the track's top.
-          const sectionMidY = rect.top + rect.height / 2;
-          let targetCenterY = sectionMidY;
-
-          if (effectiveHeight < rect.height && cursorLine !== undefined && view) {
-            // Convert cursor line to document-space Y (top of that line block).
-            try {
-              const lineCount = view.state.doc.lines;
-              const safeLine = Math.max(1, Math.min(cursorLine, lineCount));
-              const lineFrom = view.state.doc.line(safeLine).from;
-              const lineBlock = view.lineBlockAt(lineFrom);
-              const cursorDocY = lineBlock.top + lineBlock.height / 2;
-              // Only use cursor centering if the cursor is within the section.
-              if (cursorDocY >= rect.top && cursorDocY <= rect.top + rect.height) {
-                targetCenterY = cursorDocY;
+            if (isActive) {
+              // Center on cursor line for active non-wod slots
+              const sectionMidY = rect.top + rect.height / 2;
+              let targetCenterY = sectionMidY;
+              if (cursorLine !== undefined) {
+                try {
+                  const lineCount = view.state.doc.lines;
+                  const safeLine = Math.max(1, Math.min(cursorLine, lineCount));
+                  const lineFrom = view.state.doc.line(safeLine).from;
+                  const lb = view.lineBlockAt(lineFrom);
+                  const y = lb.top + lb.height / 2;
+                  if (y >= rect.top && y <= rect.top + rect.height) targetCenterY = y;
+                } catch { /* ignore */ }
               }
-            } catch {
-              // lineBlockAt can throw on unmounted views — fall back to midline
+              const unclamped = targetCenterY - slotHeight / 2;
+              slotTop = Math.max(rect.top, Math.min(unclamped, rect.top + rect.height - slotHeight));
+            } else {
+              slotTop = rect.top;
             }
           }
 
-          const unclamped = targetCenterY - effectiveHeight / 2;
-          // Clamp so the slot never floats above its own section top.
-          // Using rect.top (not 0) prevents taller-than-section slots from
-          // drifting up into the previous section's space when the bottom-pin
-          // term (rect.top + rect.height - effectiveHeight) goes negative.
-          // When the slot fits inside the section, this keeps it within bounds.
-          const slotTop = Math.max(
-            rect.top,
-            Math.min(unclamped, rect.top + rect.height - effectiveHeight),
-          );
+          // stickyTopOffset: clamped to [0, rect.height - 28] so strip stays within section.
+          const STRIP_H = 28;
+          const rawSticky = Math.max(0, scrollTop - rect.top);
+          const stickyTopOffset = Math.min(rawSticky, Math.max(0, rect.height - STRIP_H));
 
-          // When clicking on the overlay background (not on a button/input/a),
-          // resolve the document position from click coordinates and move the
-          // editor cursor there so the user isn't stuck.
+          // lineDocY: document-space Y midpoint of the active cursor or hover line,
+          // only for WOD blocks. WodCompanion uses it to center the metric card.
+          let lineDocY: number | undefined;
+          if (rect.type === "wod") {
+            const refLine = isActive ? cursorLine : hoverLine;
+            if (refLine !== undefined) {
+              try {
+                const sf = Math.max(1, Math.min(refLine, view.state.doc.lines));
+                const lb = view.lineBlockAt(view.state.doc.line(sf).from);
+                const y = lb.top + lb.height / 2;
+                if (y >= rect.top && y <= rect.top + rect.height) lineDocY = y;
+              } catch { /* ignore */ }
+            }
+          }
+
           const handleSlotClick = (e: React.MouseEvent<HTMLDivElement>) => {
             const target = e.target as HTMLElement;
             if (target.closest("button,a,input,select,textarea,[role=button]")) return;
@@ -252,13 +271,15 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
                 position: "absolute",
                 top: slotTop,
                 right: 0,
-                width: `${slotWidthPct}%`,
-                height: effectiveHeight,
-                pointerEvents: "auto",
-                transition: "width 150ms ease, opacity 150ms ease",
-                overflow: "hidden",
+                width: `${state.effectiveWidth}%`,
+                height: slotHeight,
+                pointerEvents: rect.type === "wod" ? "none" : "auto",
+                transition: "width 150ms ease",
+                overflow: "visible",
               }}
-              onClick={handleSlotClick}
+              onClick={rect.type !== "wod" ? handleSlotClick : undefined}
+              onMouseEnter={() => setHoverSectionId(rect.sectionId)}
+              onMouseLeave={() => setHoverSectionId(undefined)}
             >
               {renderSlot?.({
                 sectionId: rect.sectionId,
@@ -269,6 +290,10 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
                 view,
                 docVersion,
                 widgetName: rect.widgetName,
+                hoverLine,
+                stickyTopOffset,
+                isPanelHovered,
+                lineDocY,
               })}
             </div>
           );
@@ -277,4 +302,3 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
     </div>
   );
 };
-

--- a/src/components/Editor/overlays/OverlayWidthPolicy.ts
+++ b/src/components/Editor/overlays/OverlayWidthPolicy.ts
@@ -29,7 +29,7 @@ export interface OverlayWidthDefaults {
 // ── Default policy values ────────────────────────────────────────────
 
 export const DEFAULT_OVERLAY_WIDTHS: OverlayWidthDefaults = {
-  wod:         { active: 35, inactive: 15 },
+  wod:         { active: 35, inactive: 20 },
   frontmatter: { active: 35, inactive: 100 },
   markdown:    { active: 0,  inactive: 0 },
   code:        { active: 30, inactive: 0 },

--- a/src/components/Editor/overlays/RuntimeTimerPanel.tsx
+++ b/src/components/Editor/overlays/RuntimeTimerPanel.tsx
@@ -19,7 +19,6 @@
  */
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Tv } from "lucide-react";
 import type { EditorView } from "@codemirror/view";
 import { ScriptRuntimeProvider } from "@/runtime/context/RuntimeContext";
 import { TimerDisplay } from "@/panels/timer-panel";
@@ -28,7 +27,11 @@ import { PanelSizeProvider, usePanelSize } from "@/panels/panel-system/PanelSize
 import { RuntimeFactory } from "@/runtime/compiler/RuntimeFactory";
 import { globalCompiler, globalParser } from "@/runtime-test-bench/services/testbench-services";
 import { useRuntimeExecution, type UseRuntimeExecutionReturn } from "@/runtime-test-bench/hooks/useRuntimeExecution";
-import { useChromecast } from "@/hooks/useChromecast";
+import { useWorkbenchSyncStore } from "@/components/layout/workbenchSyncStore";
+import { SubscriptionManager } from "@/runtime/subscriptions/SubscriptionManager";
+import { ChromecastRuntimeSubscription } from "@/services/cast/rpc/ChromecastRuntimeSubscription";
+import { ChromecastEventProvider } from "@/services/cast/rpc/ChromecastEventProvider";
+import { ClockSyncService } from "@/services/cast/rpc/ClockSync";
 import type { WodBlock, WorkoutResults } from "../types";
 import type { IScriptRuntime } from "@/runtime/contracts/IScriptRuntime";
 import type { ScriptRuntime } from "@/runtime/ScriptRuntime";
@@ -36,6 +39,9 @@ import type { StackSnapshot } from "@/runtime/contracts/IRuntimeStack";
 import type { IOutputStatement } from "@/core/models/OutputStatement";
 import { dispatchGutterHighlights } from "../extensions/gutter-runtime";
 import { NextEvent } from "@/runtime/events/NextEvent";
+import { formatTimeMMSS } from "@/lib/formatTime";
+import type { RpcWorkbenchUpdate } from "@/services/cast/rpc/RpcMessages";
+import { extractYouTubePlaylistId } from "@/lib/youtubeUtils";
 
 // Singleton factory — avoids re-constructing the compiler on every render
 const factory = new RuntimeFactory(globalCompiler);
@@ -67,47 +73,63 @@ interface RuntimeTimerBodyProps {
   execution: UseRuntimeExecutionReturn;
   outputCount: number;
   completedAt: Date | null;
-  casting: ReturnType<typeof useChromecast>;
-  handleCast: () => void;
   handleStart: () => void;
   handleStop: () => void;
   handleNext: () => void;
+  playlistId?: string | null;
+  castTransportConnected?: boolean;
 }
+
+import { Music, Play, Pause } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useWorkbenchRuntime } from '@/components/workbench/useWorkbenchRuntime';
+import { useWorkbenchSyncStore } from '@/components/layout/workbenchSyncStore';
 
 const RuntimeTimerBody: React.FC<RuntimeTimerBodyProps> = ({
   execution,
   outputCount,
   completedAt,
-  casting,
-  handleCast,
   handleStart,
   handleStop,
   handleNext,
+  playlistId,
+  castTransportConnected,
 }) => {
   const { isCompact } = usePanelSize();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTrack, setCurrentTrack] = useState<string | null>(null);
+  const castTransport = useWorkbenchSyncStore(s => s.castTransport);
+
+  // In the sender (browser), we only control the playlist IF we are casting.
+  // The receiver does the actual playback. We show the UI and send RPC events to the receiver.
+  const handlePlaylistPlayPause = () => {
+    if (castTransport?.connected) {
+        if (isPlaying) {
+            castTransport.send({ type: 'rpc-event', name: 'playlist-pause', timestamp: Date.now() });
+        } else {
+            castTransport.send({ type: 'rpc-event', name: 'playlist-play', timestamp: Date.now() });
+        }
+    }
+    setIsPlaying(!isPlaying);
+  };
+
+  useEffect(() => {
+    if (!castTransport?.connected) return;
+
+    // We can listen for state updates from the receiver if we wanted to sync 'isPlaying' or 'currentTrack' perfectly
+    const handleMessage = (msg: any) => {
+        if (msg.type === 'rpc-event') {
+            if (msg.name === 'playlist-playing') setIsPlaying(true);
+            if (msg.name === 'playlist-paused') setIsPlaying(false);
+        }
+    };
+    const unsub = castTransport.onMessage(handleMessage);
+    return unsub;
+  }, [castTransport]);
+
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-background">
-      {/* ── Header: Cast button ── */}
-      <div className="flex items-center justify-between px-3 py-2 border-b border-border/50 bg-muted/20">
-        <span className="text-xs font-semibold text-foreground">Running</span>
-        <button
-          onClick={handleCast}
-          disabled={casting.sdkState === "unavailable" || casting.sdkState === "not-loaded" || casting.isConnecting}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-sm text-xs font-medium transition-colors hover:bg-muted"
-          style={{
-            backgroundColor: casting.isCasting ? "#3b82f6" : "transparent",
-            color: casting.isCasting ? "white" : "inherit",
-            opacity: casting.sdkState === "unavailable" || casting.sdkState === "not-loaded" ? 0.5 : 1,
-            cursor: casting.sdkState === "unavailable" || casting.sdkState === "not-loaded" || casting.isConnecting ? "not-allowed" : "pointer",
-          }}
-          title={casting.isCasting ? "Casting to device" : "Cast to device"}
-        >
-          <Tv size={14} />
-          <span>{casting.isConnecting ? "Connecting..." : casting.isCasting ? "Casting" : "Cast"}</span>
-        </button>
-      </div>
-
       {/* ── Body: stacked on mobile, side-by-side on desktop ── */}
       <div className={`min-h-0 flex-1 overflow-hidden flex ${isCompact ? "flex-col" : "flex-row"}`}>
         {/* Visual State — top on mobile, left on desktop */}
@@ -123,6 +145,26 @@ const RuntimeTimerBody: React.FC<RuntimeTimerBodyProps> = ({
         <div className={`flex flex-col justify-center overflow-hidden bg-background ${
           isCompact ? "shrink-0" : "w-[48%]"
         }`}>
+          {playlistId && castTransportConnected && (
+             <div className="flex justify-center mb-4">
+               <div className="bg-secondary/40 backdrop-blur-md rounded-full px-4 py-2 flex items-center gap-3 border border-border/50 shadow-sm max-w-[80%]">
+                 <div className="bg-primary/20 p-1.5 rounded-full">
+                     <Music className="w-4 h-4 text-primary" />
+                 </div>
+                 <div className="text-sm font-medium truncate flex-1 min-w-0 pr-2">
+                     {currentTrack || "Playing on Chromecast..."}
+                 </div>
+                 <Button
+                     size="icon"
+                     variant="ghost"
+                     className="h-8 w-8 rounded-full hover:bg-primary/20 hover:text-primary transition-colors focus:ring-2 focus:ring-primary focus:outline-none"
+                     onClick={handlePlaylistPlayPause}
+                 >
+                     {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+                 </Button>
+               </div>
+             </div>
+          )}
           <TimerDisplay
             elapsedMs={execution.elapsedTime}
             hasActiveBlock={true}
@@ -169,8 +211,10 @@ export const RuntimeTimerPanel: React.FC<RuntimeTimerPanelProps> = ({
   const [outputCount, setOutputCount] = useState(0);
   const [completedAt, setCompletedAt] = useState<Date | null>(null);
 
-  // Chromecast integration
-  const casting = useChromecast();
+  const playlistId = useWorkbenchSyncStore(s => {
+    const fmSection = s.documentItems.find(item => item.type === 'frontmatter');
+    return fmSection?.properties?.playlist ? extractYouTubePlaylistId(fmSection.properties.playlist) : null;
+  });
 
   // Gutter base: 0-indexed block.startLine → 1-based fence line
   // statement sourceId = 1-based line within content
@@ -260,20 +304,38 @@ export const RuntimeTimerPanel: React.FC<RuntimeTimerPanelProps> = ({
     onComplete?.(block.id, results);
   }, [block.id, execution.elapsedTime, execution.startTime, onComplete]);
 
-  // Track completion time and handle auto-close
+  // Track completion: notify parent immediately so it can switch to results view.
+  // The parent (FullscreenTimer) will unmount this panel when it transitions.
+  // Also send review mode to Chromecast BEFORE the panel unmounts (which would
+  // otherwise lose the cast subscription).
   useEffect(() => {
     if (execution.status === "completed" && !completedAt) {
       setCompletedAt(new Date());
       handleComplete(true);
 
-      // Auto-close after 2 seconds so the user can see the "Completed" state
-      const timer = setTimeout(() => {
-        onClose();
-      }, 2000);
-
-      return () => clearTimeout(timer);
+      // Send review data to Chromecast so the receiver transitions to the
+      // review screen. This must happen before the panel unmounts and the
+      // cast subscription is disposed.
+      const transport = useWorkbenchSyncStore.getState().castTransport;
+      if (transport?.connected) {
+        const allOutputs = runtimeRef.current?.getOutputStatements() || [];
+        const segmentCount = allOutputs.filter(o => o.outputType === 'segment').length;
+        const reviewMessage: RpcWorkbenchUpdate = {
+          type: 'rpc-workbench-update',
+          mode: 'review',
+          reviewData: {
+            totalDurationMs: execution.elapsedTime,
+            completedSegments: segmentCount,
+            rows: [
+              { label: 'Total Time', value: formatTimeMMSS(execution.elapsedTime) },
+              { label: 'Segments', value: String(segmentCount) },
+            ],
+          },
+        };
+        try { transport.send(reviewMessage); } catch { /* ignore */ }
+      }
     }
-  }, [execution.status, completedAt, onClose, handleComplete]);
+  }, [execution.status, completedAt, handleComplete]);
 
   const handleStop = () => {
     execution.stop();
@@ -292,33 +354,51 @@ export const RuntimeTimerPanel: React.FC<RuntimeTimerPanelProps> = ({
     runtimeRef.current?.handle(new NextEvent());
   };
 
-  // Handle cast button click
-  const handleCast = async () => {
-    if (casting.isCasting) {
-      return; // Already casting
-    }
-    await casting.requestSession();
-  };
+  // ── Chromecast RPC syncing ──────────────────────────────────────────
+  // When a cast transport is active (connected from the app-level CastButtonRpc),
+  // wire the local runtime into the Chromecast RPC pipeline so the receiver
+  // gets proper stack snapshots, output statements, and timer data.
+  const castTransport = useWorkbenchSyncStore(s => s.castTransport);
 
-  // Sync runtime state to receiver when casting
   useEffect(() => {
-    if (!casting.isCasting || !runtimeRef.current) return;
+    const rt = runtimeRef.current;
+    if (!castTransport?.connected || !rt) return;
 
-    const syncState = () => {
-      if (!runtimeRef.current) return;
-      // Send runtime state snapshot to receiver
-      const state = {
-        elapsedTime: execution.elapsedTime,
-        status: execution.status,
-        timestamp: Date.now(),
-      };
-      casting.sendMessage("state-update", state);
+    // Signal active mode to receiver
+    try { castTransport.send({ type: 'rpc-workbench-update', mode: 'active' }); } catch { /* ignore */ }
+
+    // Create a local SubscriptionManager that fans out runtime events
+    const subMgr = new SubscriptionManager(rt);
+    const chromecastSub = new ChromecastRuntimeSubscription(castTransport, { id: 'inline-chromecast' });
+    subMgr.add(chromecastSub);
+
+    // Remote control: D-Pad events from receiver → local runtime
+    const eventProvider = new ChromecastEventProvider(castTransport);
+    const unsubEvents = eventProvider.onEvent((event) => {
+      switch (event.name) {
+        case 'next': runtimeRef.current?.handle(new NextEvent()); break;
+        case 'start': execution.start(); break;
+        case 'pause': execution.pause(); break;
+        case 'stop': handleStop(); break;
+      }
+    });
+
+    // Clock sync (best-effort, non-blocking)
+    const clockSync = new ClockSyncService(castTransport);
+    clockSync.sync().catch(() => {});
+
+    return () => {
+      unsubEvents();
+      eventProvider.dispose();
+      clockSync.dispose();
+      subMgr.dispose();
+      // Do NOT send mode='idle' here — let EditorCastBridge or WorkbenchCastBridge
+      // handle the mode transition. Sending 'idle' would flash the waiting screen
+      // before the correct mode (preview or review) is re-sent by the bridge.
     };
-
-    // Sync on every execution update
-    const interval = setInterval(syncState, 100); // 10Hz updates
-    return () => clearInterval(interval);
-  }, [casting.isCasting, execution.elapsedTime, execution.status, casting]);
+    // Only re-run when transport connection changes or runtime is created
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [castTransport?.connected, ready]);
 
   if (!ready || !runtimeRef.current) {
     return (
@@ -335,11 +415,11 @@ export const RuntimeTimerPanel: React.FC<RuntimeTimerPanelProps> = ({
           execution={execution}
           outputCount={outputCount}
           completedAt={completedAt}
-          casting={casting}
-          handleCast={handleCast}
           handleStart={handleStart}
           handleStop={handleStop}
           handleNext={handleNext}
+          playlistId={playlistId}
+          castTransportConnected={castTransport?.connected ?? false}
         />
       </ScriptRuntimeProvider>
     </PanelSizeProvider>

--- a/src/components/Editor/overlays/WodCompanion.tsx
+++ b/src/components/Editor/overlays/WodCompanion.tsx
@@ -291,11 +291,11 @@ const ResultLine: React.FC<{
     return (
       <div 
         onClick={handleClick}
-        className="mt-auto flex flex-col items-end p-1.5 cursor-pointer hover:bg-primary/20 transition-colors group bg-primary/5 border-t border-primary/10"
+        className="flex items-center gap-1.5 px-2 py-0.5 cursor-pointer hover:bg-primary/20 transition-colors group bg-primary/10 border border-primary/20 rounded-md shadow-sm"
         title={`Latest: ${formatDuration(result.data.duration)} (${new Date(result.completedAt).toLocaleDateString()})`}
       >
         <History className="h-3 w-3 text-primary" />
-        <span className="text-[8px] font-mono font-bold text-primary mt-0.5">{formatDuration(result.data.duration)}</span>
+        <span className="text-[10px] font-mono font-bold text-primary">{formatDuration(result.data.duration)}</span>
       </div>
     );
   }
@@ -330,14 +330,21 @@ export interface WodCompanionProps {
   widthPercent: number;
   /** Absolute 1-based document line number of the cursor (for metric lookup). */
   cursorLine: number;
+  /** Absolute 1-based document line number the mouse is hovering over (may be undefined when mouse is over the panel itself). */
+  hoverLine?: number;
+  /** How many px the section top has scrolled above the viewport. */
+  stickyTopOffset: number;
+  /** True while the mouse is physically over the slot (keeps card pinned). */
+  isPanelHovered: boolean;
+  /** Document-space Y midpoint of cursor/hover line (for card centering). */
+  lineDocY?: number;
+  /** Section rect — used for card position clamping. */
+  rect: import('../extensions/section-geometry').SectionRect;
   /** Increments on every document change — forces re-parse on content edits. */
   docVersion: number;
   /** Commands to display as action buttons. */
   commands: WodCommand[];
-  /**
-   * How many commands show as direct buttons.  Additional commands are hidden
-   * behind a "…" overflow menu.  Default: 1.
-   */
+  /** How many commands show as direct buttons. Default: 1. */
   visibleCount?: number;
   /** Callback to open the full-screen review grid for a set of segments. */
   onOpenReview?: (segments: Segment[]) => void;
@@ -349,18 +356,21 @@ export const WodCompanion: React.FC<WodCompanionProps> = ({
   view,
   isActive,
   cursorLine,
+  hoverLine,
+  stickyTopOffset,
+  isPanelHovered,
+  lineDocY,
+  rect,
   docVersion,
   commands,
   visibleCount = 1,
   onOpenReview,
 }) => {
-  // In a real app, this would come from a NoteContext
   const noteId = propNoteId || (view.state as any).noteId || "current";
   const { results } = useWodBlockResults(noteId, sectionId);
 
   const section = useMemo(
     () => getSection(view, sectionId),
-    // docVersion forces re-lookup when doc content changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [view, sectionId, docVersion],
   );
@@ -371,9 +381,28 @@ export const WodCompanion: React.FC<WodCompanionProps> = ({
     [view, section?.id, docVersion],
   );
 
+  // Track last valid hoverLine inside this section so the card doesn't blank
+  // when the mouse moves from editor text into the panel itself.
+  const lastHoverLineRef = React.useRef<number | null>(null);
+  const hoverInsideSection = section && hoverLine !== undefined
+    && hoverLine >= section.startLine
+    && hoverLine <= section.endLine;
+  if (hoverInsideSection && hoverLine !== undefined) {
+    lastHoverLineRef.current = hoverLine;
+  }
+
+  // Use remembered line when panel is hovered but hoverLine dropped off
+  const effectiveHoverLine = hoverInsideSection
+    ? hoverLine!
+    : (isPanelHovered ? (lastHoverLineRef.current ?? null) : null);
+
+  const showCard = isActive || effectiveHoverLine !== null;
+  const effectiveLine = isActive ? cursorLine : (effectiveHoverLine ?? cursorLine);
+
   const activeStatement = useMemo(
-    () => (section && isActive ? findActiveStatement(statements, section, cursorLine) : null),
-    [section, isActive, statements, cursorLine],
+    () => (section && showCard ? findActiveStatement(statements, section, effectiveLine) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [section, effectiveLine, showCard, statements],
   );
 
   const chips = useMemo(
@@ -383,105 +412,104 @@ export const WodCompanion: React.FC<WodCompanionProps> = ({
 
   if (!section) return null;
 
-  // ── INACTIVE: compact action strip ──────────────────────────────
-  if (!isActive) {
-    return (
-      <div className="h-full w-full flex flex-col bg-popover/60 backdrop-blur-sm border-l border-border/50 overflow-visible">
-        <CommandButtons commands={commands} visibleCount={visibleCount} section={section} view={view} compact />
-        {/* Minimized results indicator if they exist */}
+  const lineText = (activeStatement?.meta as any)?.raw ?? "";
+  const lineInContent = effectiveLine - section.startLine;
+
+  // The slot is full-height and transparent. We render two absolute children:
+  //  1. STRIP — always visible, sticky to top of viewport within section bounds
+  //  2. CARD  — compact metric panel, shown on hover/active, positioned below strip
+
+  const STRIP_H = 28;
+  const CARD_H  = 200;
+
+  // Card top: centered on the active line, but clamped to stay within the slot
+  // and below the sticky strip. lineDocY is document-space, rect.top is slot top.
+  let cardTop: number;
+  if (lineDocY !== undefined) {
+    const lineRelY = lineDocY - rect.top;              // line Y relative to slot top
+    const centered = lineRelY - CARD_H / 2;           // center card on line
+    const minTop = stickyTopOffset + STRIP_H + 4;     // must be below strip
+    const maxTop = rect.height - CARD_H;              // must not overflow slot bottom
+    cardTop = Math.max(minTop, Math.min(centered, Math.max(minTop, maxTop)));
+  } else {
+    cardTop = stickyTopOffset + STRIP_H + 4;          // fallback: just below strip
+  }
+
+  return (
+    <div className="relative w-full h-full" style={{ pointerEvents: "none" }}>
+
+      {/* ── STRIP: always visible, sticky-top ────────────────────── */}
+      <div
+        className="absolute inset-x-0 flex items-center justify-end gap-1 px-2 pointer-events-auto
+                   bg-background/70 backdrop-blur-sm border-l border-b border-border/40 rounded-bl-md"
+        style={{ top: stickyTopOffset, height: STRIP_H }}
+      >
         {results.length > 0 && (
           <ResultLine result={results[0]} onOpenReview={onOpenReview} compact />
         )}
-      </div>
-    );
-  }
-
-  // ── ACTIVE: metric details + results + action buttons ─────────────
-  const lineText = (activeStatement?.meta as any)?.raw ?? "";
-  const lineInContent = cursorLine - section.startLine;
-
-  return (
-    <div className="h-full w-full flex flex-col bg-popover/90 backdrop-blur-sm border-l border-border overflow-hidden">
-      {/* Header: dialect + current line indicator */}
-      <div className="flex items-center gap-2 px-2.5 py-1.5 border-b border-border/50 bg-muted/30">
-        <span className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-500 uppercase tracking-wide">
-          {section.dialect ?? "wod"}
-        </span>
-        <span className="text-[10px] text-muted-foreground">line {lineInContent}</span>
+        <CommandButtons
+          commands={commands}
+          visibleCount={visibleCount}
+          section={section}
+          view={view}
+          compact
+        />
       </div>
 
-      {/* Latest Result Line (New minimized results view) */}
-      {results.length > 0 && (
-        <ResultLine result={results[0]} onOpenReview={onOpenReview} />
-      )}
-
-      {/* Current line raw text */}
-      <div className="px-2.5 py-2 border-b border-border/30">
+      {/* ── CARD: compact metric panel on hover / cursor ─────────── */}
+      {showCard && (
         <div
-          className="text-xs font-mono text-foreground truncate"
-          title={lineText}
+          className="absolute inset-x-0 flex flex-col bg-popover/95 backdrop-blur-md
+                     border border-border/80 shadow-xl rounded-lg overflow-hidden pointer-events-auto"
+          style={{ top: cardTop, maxHeight: CARD_H }}
         >
-          {lineText || <span className="italic text-muted-foreground">—</span>}
-        </div>
-      </div>
-
-      {/* Metric chips */}
-      <div className="px-2.5 py-2 border-b border-border/30">
-        {chips.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5">
-            {chips.map((chip, i) => (
-              <div
-                key={i}
-                className={`flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${chip.color}`}
-                title={chip.label}
-              >
-                <span>{chip.icon}</span>
-                <span className="font-mono">{chip.value}</span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <span className="text-[10px] italic text-muted-foreground">No parsed metrics</span>
-        )}
-      </div>
-
-      {/* Results history section (more details) */}
-      <div className="flex-1 overflow-auto">
-        {results.length > 1 && (
-          <div className="flex flex-col">
-            <div className="px-2.5 py-1.5 text-[10px] font-semibold text-muted-foreground/70 uppercase tracking-tight flex items-center gap-1.5 bg-muted/20 border-b border-border/10">
-              History
+          {/* Header */}
+          <div className="flex items-center gap-2 px-3 py-2 bg-muted/40 border-b border-border/50 shrink-0">
+            <span className="text-[11px] font-mono px-2 py-0.5 rounded bg-blue-500/10 text-blue-400 uppercase tracking-wider font-semibold">
+              {section.dialect ?? "wod"}
+            </span>
+            <div className="flex items-center min-w-0 gap-2">
+              <span className="text-xs text-muted-foreground/60">L{lineInContent}</span>
+              <span className="text-muted-foreground/40">·</span>
+              <span className="text-xs font-mono text-foreground/90 truncate font-medium" title={lineText}>
+                {lineText || <span className="italic text-muted-foreground">—</span>}
+              </span>
             </div>
-            <div className="divide-y divide-border/30">
-              {results.slice(1, 5).map((res) => (
-                <div
-                  key={res.id}
-                  onClick={() => {
-                    if (res.data?.logs && onOpenReview) {
-                      const { segments } = getAnalyticsFromLogs(res.data.logs as any, res.data.startTime);
-                      onOpenReview(segments);
-                    }
-                  }}
-                  className="group flex items-center justify-between px-2.5 py-1.5 hover:bg-muted/50 cursor-pointer transition-colors"
-                >
-                  <div className="flex flex-col gap-0.5">
-                    <span className="text-[10px] text-foreground font-medium">
-                      {new Date(res.completedAt).toLocaleDateString()}
-                    </span>
-                    <span className="text-[9px] text-muted-foreground font-mono">
-                      {formatDuration(res.data.duration)}
-                    </span>
+          </div>
+
+          {/* Metric chips */}
+          <div className="px-3 py-2.5 min-h-0 overflow-auto">
+            {chips.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {chips.map((chip, i) => (
+                  <div
+                    key={i}
+                    className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-sm font-semibold ${chip.color}`}
+                    title={chip.label}
+                  >
+                    <span className="text-base leading-none">{chip.icon}</span>
+                    <span className="font-mono tracking-tight">{chip.value}</span>
                   </div>
-                  <ExternalLink className="h-3 w-3 text-muted-foreground/30 group-hover:text-muted-foreground transition-colors" />
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            ) : (
+              <span className="text-xs italic text-muted-foreground">No metrics on this line</span>
+            )}
           </div>
-        )}
-      </div>
 
-      {/* Action buttons */}
-      <CommandButtons commands={commands} visibleCount={visibleCount} section={section} view={view} />
+          {/* Latest result */}
+          {results.length > 0 && (
+            <div className="border-t border-border/40 shrink-0">
+              <ResultLine result={results[0]} onOpenReview={onOpenReview} compact />
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="border-t border-border/40 shrink-0">
+            <CommandButtons commands={commands} visibleCount={visibleCount} section={section} view={view} />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Editor/overlays/__tests__/OverlayWidthPolicy.test.ts
+++ b/src/components/Editor/overlays/__tests__/OverlayWidthPolicy.test.ts
@@ -7,7 +7,6 @@ import {
   computeOverlayWidth,
   DEFAULT_OVERLAY_WIDTHS,
 } from "../OverlayWidthPolicy";
-import type { OverlayWidthInput } from "../OverlayWidthPolicy";
 
 describe("computeOverlayWidth", () => {
   // ── Default policy tests ──
@@ -16,8 +15,8 @@ describe("computeOverlayWidth", () => {
     expect(computeOverlayWidth({ sectionType: "wod", isActive: true })).toBe(35);
   });
 
-  it("wod inactive → 15%", () => {
-    expect(computeOverlayWidth({ sectionType: "wod", isActive: false })).toBe(15);
+  it("wod inactive → 20%", () => {
+    expect(computeOverlayWidth({ sectionType: "wod", isActive: false })).toBe(20);
   });
 
   it("frontmatter active → 35%", () => {

--- a/src/components/cast/CastButtonRpc.tsx
+++ b/src/components/cast/CastButtonRpc.tsx
@@ -258,12 +258,25 @@ export const CastButtonRpc: React.FC = () => {
 
         const unsub = eventProvider.onEvent((event) => {
             const state = useWorkbenchSyncStore.getState();
-            const { handleNext, handleStart, handlePause, handleStop } = state;
+            const { handleNext, handleStart, handlePause, handleStop, handleStartWorkoutAction } = state;
             switch (event.name) {
                 case 'next': handleNext(); break;
                 case 'start': handleStart(); break;
                 case 'pause': handlePause(); break;
                 case 'stop': handleStop(); break;
+                case 'select-block': {
+                    // Receiver user selected a preview block — find the matching
+                    // WodBlock from documentItems and start the workout.
+                    const { index, blockId } = (event.data ?? {}) as { index?: number; blockId?: string };
+                    const wodItems = state.documentItems.filter(i => i.type === 'wod');
+                    const target = blockId
+                        ? wodItems.find(i => i.id === blockId)
+                        : wodItems[index ?? 0];
+                    if (target?.wodBlock) {
+                        handleStartWorkoutAction(target.wodBlock);
+                    }
+                    break;
+                }
             }
         });
         return unsub;

--- a/src/components/cast/WorkbenchCastBridge.tsx
+++ b/src/components/cast/WorkbenchCastBridge.tsx
@@ -76,6 +76,12 @@ export const WorkbenchCastBridge: React.FC = () => {
             message = buildPreviewMessage(selectedBlock, documentItems);
         }
 
+        // Add frontmatter to all messages
+        const fmSection = documentItems.find(item => item.type === 'frontmatter');
+        if (fmSection && fmSection.properties) {
+            message.frontmatter = fmSection.properties;
+        }
+
         // Skip send if nothing has changed
         const fingerprint = JSON.stringify(message);
         if (fingerprint === lastFingerprintRef.current) return;

--- a/src/components/cast/YouTubePlaylistPlayer.tsx
+++ b/src/components/cast/YouTubePlaylistPlayer.tsx
@@ -1,0 +1,118 @@
+/**
+ * YouTubePlaylistPlayer
+ *
+ * A visually compact/hidden YouTube player component that plays a playlist.
+ * Designed to run on the Chromecast Receiver. Exposes state changes to the UI
+ * and accepts playback controls.
+ */
+
+import React, { useState, useImperativeHandle, forwardRef, useRef } from 'react';
+import YouTube, { YouTubeProps } from 'react-youtube';
+
+export interface YouTubePlaylistPlayerProps {
+    /** The playlist ID extracted from the frontmatter URL */
+    playlistId: string;
+    /** Callback when the player's internal state changes (e.g. playing, paused) */
+    onStateChange?: (state: number) => void;
+    /** Callback when the track changes or title is retrieved */
+    onTrackChange?: (title: string) => void;
+}
+
+export interface YouTubePlaylistPlayerRef {
+    play: () => void;
+    pause: () => void;
+    next: () => void;
+    previous: () => void;
+    getPlayerState: () => number;
+}
+
+export const YouTubePlaylistPlayer = forwardRef<YouTubePlaylistPlayerRef, YouTubePlaylistPlayerProps>(({
+    playlistId,
+    onStateChange,
+    onTrackChange
+}, ref) => {
+    const [playerReady, setPlayerReady] = useState(false);
+    const playerRef = useRef<any>(null); // Type 'any' used because YouTubePlayer is not exported by react-youtube's types directly in a simple way
+
+    useImperativeHandle(ref, () => ({
+        play: () => {
+            if (playerReady && playerRef.current) {
+                playerRef.current.playVideo();
+            }
+        },
+        pause: () => {
+            if (playerReady && playerRef.current) {
+                playerRef.current.pauseVideo();
+            }
+        },
+        next: () => {
+            if (playerReady && playerRef.current) {
+                playerRef.current.nextVideo();
+            }
+        },
+        previous: () => {
+            if (playerReady && playerRef.current) {
+                playerRef.current.previousVideo();
+            }
+        },
+        getPlayerState: () => {
+            if (playerReady && playerRef.current) {
+                return playerRef.current.getPlayerState();
+            }
+            return -1; // unstarted
+        }
+    }));
+
+    const handleReady: YouTubeProps['onReady'] = (event) => {
+        playerRef.current = event.target;
+        setPlayerReady(true);
+        // Once ready, if we have a track title, report it immediately
+        const data = event.target.getVideoData();
+        if (data && data.title) {
+            onTrackChange?.(data.title);
+        }
+    };
+
+    const handleStateChange: YouTubeProps['onStateChange'] = (event) => {
+        onStateChange?.(event.data);
+
+        // YouTube Player States:
+        // -1 (unstarted), 0 (ended), 1 (playing), 2 (paused), 3 (buffering), 5 (video cued)
+        if (event.data === 1 || event.data === 5 || event.data === -1) {
+            const data = event.target.getVideoData();
+            if (data && data.title) {
+                onTrackChange?.(data.title);
+            }
+        }
+    };
+
+    const opts: YouTubeProps['opts'] = {
+        height: '0',
+        width: '0',
+        playerVars: {
+            // https://developers.google.com/youtube/player_parameters
+            autoplay: 0,
+            controls: 0,
+            disablekb: 1,
+            fs: 0,
+            modestbranding: 1,
+            listType: 'playlist',
+            list: playlistId
+        },
+    };
+
+    // Render an invisible player (height/width 0 in opts, plus absolute hidden container)
+    return (
+        <div style={{ position: 'absolute', top: -9999, left: -9999, width: 0, height: 0, overflow: 'hidden' }}>
+            {playlistId && (
+                <YouTube
+                    opts={opts}
+                    onReady={handleReady}
+                    onStateChange={handleStateChange}
+                />
+            )}
+        </div>
+    );
+});
+
+YouTubePlaylistPlayer.displayName = 'YouTubePlaylistPlayer';

--- a/src/components/layout/RuntimeLifecycleContext.ts
+++ b/src/components/layout/RuntimeLifecycleContext.ts
@@ -26,7 +26,7 @@ export interface RuntimeLifecycleState {
   error: Error | null;
   
   /** Initialize a new runtime for the given block */
-  initializeRuntime: (block: WodBlock) => void;
+  initializeRuntime: (block: WodBlock, frontmatter?: Record<string, string>) => void;
   
   /** Dispose the current runtime */
   disposeRuntime: () => void;

--- a/src/components/layout/RuntimeLifecycleProvider.tsx
+++ b/src/components/layout/RuntimeLifecycleProvider.tsx
@@ -79,7 +79,7 @@ export const RuntimeLifecycleProvider: React.FC<RuntimeLifecycleProviderProps> =
    * Initialize a new runtime for the given block
    * Automatically disposes existing runtime first
    */
-  const initializeRuntime = useCallback((block: WodBlock) => {
+  const initializeRuntime = useCallback((block: WodBlock, frontmatter?: Record<string, string>) => {
     // Guard against duplicate initialization
     if (isInitializing) {
       return;
@@ -114,7 +114,7 @@ export const RuntimeLifecycleProvider: React.FC<RuntimeLifecycleProviderProps> =
 
       // Now create the new runtime and update state.
       // Pass the tracker in the options
-      const newRuntime = factoryRef.current.createRuntime(block, { tracker }) as ScriptRuntime | null;
+      const newRuntime = factoryRef.current.createRuntime(block, { tracker, frontmatter }) as ScriptRuntime | null;
       currentRuntimeRef.current = newRuntime;
       setRuntime(newRuntime);
 

--- a/src/components/layout/WorkbenchSyncBridge.tsx
+++ b/src/components/layout/WorkbenchSyncBridge.tsx
@@ -202,7 +202,6 @@ export const WorkbenchSyncBridge: React.FC<WorkbenchSyncBridgeProps> = ({ childr
   ]);
 
   // --- Runtime initialization on view mode changes ---
-  // --- Runtime initialization on view mode changes ---
   const lastInitializedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -213,8 +212,12 @@ export const WorkbenchSyncBridge: React.FC<WorkbenchSyncBridgeProps> = ({ childr
         
         // Clear analytics before starting the new runtime
         store.getState().setAnalytics([], []);
+
+        // Find frontmatter in the document to pass down to runtime
+        const fmSection = documentItems.find(item => item.type === 'frontmatter');
+        const frontmatter = fmSection?.properties;
         
-        initializeRuntime(selectedBlock);
+        initializeRuntime(selectedBlock, frontmatter);
         lastInitializedKeyRef.current = currentKey;
       }
     } else if (viewMode !== 'track') {
@@ -223,7 +226,7 @@ export const WorkbenchSyncBridge: React.FC<WorkbenchSyncBridgeProps> = ({ childr
         lastInitializedKeyRef.current = null;
       }
     }
-  }, [viewMode, selectedBlock, initializeRuntime, disposeRuntime]);
+  }, [viewMode, selectedBlock, documentItems, initializeRuntime, disposeRuntime]);
 
   // --- Wake lock (keep screen awake during workouts) ---
   useWakeLock({

--- a/src/components/layout/workbenchSyncStore.ts
+++ b/src/components/layout/workbenchSyncStore.ts
@@ -55,7 +55,7 @@ interface WorkbenchSyncState {
   // --- Runtime & Execution (hydrated from React hooks via bridge) ---
   runtime: IScriptRuntime | null;
   execution: UseRuntimeExecutionReturn;
-  initializeRuntime: (block: WodBlock) => void;
+  initializeRuntime: (block: WodBlock, frontmatter?: Record<string, string>) => void;
   disposeRuntime: () => void;
 
   // --- Execution Controls (hydrated from React hooks via bridge) ---
@@ -135,7 +135,7 @@ interface WorkbenchSyncActions {
   _hydrateRuntime: (payload: {
     runtime: IScriptRuntime | null;
     execution: UseRuntimeExecutionReturn;
-    initializeRuntime: (block: WodBlock) => void;
+    initializeRuntime: (block: WodBlock, frontmatter?: Record<string, string>) => void;
     disposeRuntime: () => void;
     handleStart: () => void;
     handlePause: () => void;

--- a/src/lib/youtubeUtils.ts
+++ b/src/lib/youtubeUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * YouTube utility functions for parsing URLs.
+ */
+
+export function extractYouTubeVideoId(url: string): string | null {
+  const standard = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
+  if (standard) return standard[1];
+  const short = url.match(/youtu\.be\/([a-zA-Z0-9_-]{11})/);
+  if (short) return short[1];
+  const embed = url.match(/youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/);
+  if (embed) return embed[1];
+  return null;
+}
+
+export function extractYouTubePlaylistId(url: string): string | null {
+  const playlistMatch = url.match(/[?&]list=([a-zA-Z0-9_-]+)/);
+  if (playlistMatch) return playlistMatch[1];
+  return null;
+}

--- a/src/panels/preview-panel-chromecast.tsx
+++ b/src/panels/preview-panel-chromecast.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import type { WorkbenchDisplayState } from '@/services/cast/rpc/ChromecastProxyRuntime';
 import type { FocusProps } from '@/hooks/useSpatialNavigation';
 import {
+    Clock,
     Dumbbell,
     Play,
 } from 'lucide-react';
@@ -36,23 +37,43 @@ export const ReceiverPreviewPanel: React.FC<{
 
             {/* Workout list */}
             {previewData.blocks.length > 0 && (
-                <div className="w-full max-w-lg flex flex-col gap-2">
+                <div className="w-full max-w-2xl flex flex-col gap-3">
                     {previewData.blocks.map((block, index) => (
                         <div
                             key={block.id}
                             {...(getFocusProps ? getFocusProps(`preview-block-${index}`) : {})}
-                            className="tv-focusable flex items-center justify-between rounded-lg border border-border/60 bg-card/50 px-4 py-3 text-sm transition-all cursor-pointer"
+                            className="tv-focusable flex flex-col rounded-lg border border-border/60 bg-card/50 px-5 py-4 transition-all cursor-pointer hover:border-primary/40 hover:bg-card/80"
                         >
-                            <div className="flex items-center gap-2">
-                                <Play className="h-4 w-4 text-muted-foreground" />
-                                <span className="font-medium text-foreground truncate max-w-xs">
-                                    {block.title}
-                                </span>
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2.5 min-w-0">
+                                    <Play className="h-4 w-4 text-muted-foreground shrink-0" />
+                                    <span className="font-medium text-foreground truncate">
+                                        {block.title}
+                                    </span>
+                                </div>
+                                <div className="flex items-center gap-2 shrink-0 ml-3">
+                                    {block.timerHint && (
+                                        <span className="flex items-center gap-1 text-xs font-mono text-primary/80 bg-primary/10 px-2 py-0.5 rounded">
+                                            <Clock className="h-3 w-3" />
+                                            {block.timerHint}
+                                        </span>
+                                    )}
+                                    {block.dialect && block.dialect !== 'wod' && (
+                                        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60 bg-muted/30 px-1.5 py-0.5 rounded">
+                                            {block.dialect}
+                                        </span>
+                                    )}
+                                    {block.statementCount > 0 && (
+                                        <span className="text-xs text-muted-foreground">
+                                            {block.statementCount} steps
+                                        </span>
+                                    )}
+                                </div>
                             </div>
-                            {block.statementCount > 0 && (
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                    {block.statementCount} steps
-                                </span>
+                            {block.contentPreview && (
+                                <pre className="mt-2 text-xs text-muted-foreground/70 font-mono leading-relaxed whitespace-pre-wrap line-clamp-3 pl-6">
+                                    {block.contentPreview}
+                                </pre>
                             )}
                         </div>
                     ))}

--- a/src/panels/timer-panel-chromecast.tsx
+++ b/src/panels/timer-panel-chromecast.tsx
@@ -13,11 +13,17 @@ import { usePrimaryTimer, useSecondaryTimers, useStackTimers } from '@/runtime/h
 import { calculateDuration } from '@/lib/timeUtils';
 import type { FocusProps } from '@/hooks/useSpatialNavigation';
 
+import { Music, Play, Pause } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useState } from 'react';
+
 export const ReceiverTimerPanel: React.FC<{
     localNow: number;
     onEvent: (name: string) => void;
     getFocusProps?: (id: string) => FocusProps;
-}> = ({ localNow, onEvent, getFocusProps }) => {
+    currentTrack?: string | null;
+}> = ({ localNow, onEvent, getFocusProps, currentTrack }) => {
+    const [isPlaying, setIsPlaying] = useState(false);
     const primaryTimerEntry = usePrimaryTimer();
     const secondaryTimers = useSecondaryTimers();
     const allTimers = useStackTimers();
@@ -74,6 +80,31 @@ export const ReceiverTimerPanel: React.FC<{
 
     return (
         <div className="flex-1 flex flex-col justify-center">
+            {currentTrack !== undefined && (
+                <div className="flex items-center justify-center gap-3 mb-6 animate-in fade-in slide-in-from-top-4">
+                    <div className="bg-secondary/40 backdrop-blur-md rounded-full px-4 py-2 flex items-center gap-3 border border-border/50 shadow-sm max-w-[80%]">
+                        <div className="bg-primary/20 p-1.5 rounded-full">
+                            <Music className="w-4 h-4 text-primary" />
+                        </div>
+                        <div className="text-sm font-medium truncate flex-1 min-w-0 pr-2">
+                            {currentTrack || "Loading playlist..."}
+                        </div>
+                        <Button
+                            id="btn-playlist-playpause"
+                            size="icon"
+                            variant="ghost"
+                            className="h-8 w-8 rounded-full hover:bg-primary/20 hover:text-primary transition-colors focus:ring-2 focus:ring-primary focus:outline-none"
+                            onClick={() => {
+                                setIsPlaying(!isPlaying);
+                                // The actual event emission is handled by ReceiverApp's onSelect mapping for the ID
+                            }}
+                            {...(getFocusProps ? getFocusProps('btn-playlist-playpause') : {})}
+                        >
+                            {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
+                        </Button>
+                    </div>
+                </div>
+            )}
             <TimerStackView
                 elapsedMs={primaryElapsed}
                 hasActiveBlock={!!primaryTimerEntry}

--- a/src/receiver-rpc.tsx
+++ b/src/receiver-rpc.tsx
@@ -30,6 +30,8 @@ import { ReceiverPreviewPanel } from '@/panels/preview-panel-chromecast';
 import { ReceiverReviewPanel } from '@/panels/review-panel-chromecast';
 import { calculateDuration } from '@/lib/timeUtils';
 import { useSpatialNavigation } from '@/hooks/useSpatialNavigation';
+import { YouTubePlaylistPlayer, YouTubePlaylistPlayerRef } from '@/components/cast/YouTubePlaylistPlayer';
+import { extractYouTubePlaylistId } from '@/lib/youtubeUtils';
 import '@/index.css';
 
 // ============================================================================
@@ -44,17 +46,19 @@ const ReceiverApp: React.FC = () => {
     const [dpadFlash, setDpadFlash] = useState(false);
     const runtimeRef = useRef<ChromecastProxyRuntime | null>(null);
     const transportRef = useRef<WebRtcRpcTransport | null>(null);
+    const youtubePlayerRef = useRef<YouTubePlaylistPlayerRef>(null);
 
     // Persistent signaling instance (lives for the life of the Receiver app)
     const signalingRef = useRef<ReceiverCastSignaling | null>(null);
 
     // Send event back to browser via the proxy runtime
-    const sendEvent = useCallback((eventName: string) => {
+    const sendEvent = useCallback((eventName: string, data?: unknown) => {
         const runtime = runtimeRef.current;
         if (!runtime) return;
         runtime.handle({
             name: eventName,
             timestamp: new Date(),
+            data,
         });
     }, []);
 
@@ -64,17 +68,24 @@ const ReceiverApp: React.FC = () => {
         setTimeout(() => setDpadFlash(false), 200);
     }, []);
 
+    // Keep workbenchState in a ref so the onSelect callback always reads
+    // the latest value without needing it in its dependency array.
+    const workbenchStateRef = useRef(workbenchState);
+    workbenchStateRef.current = workbenchState;
+
     // ── Spatial Navigation ──────────────────────────────────────────────────
     // The hook handles ArrowUp/Down/Left/Right (focus movement) and
     // Enter/Select (activation). We map element IDs to runtime events.
-    const { getFocusProps } = useSpatialNavigation({
+    const { getFocusProps, setFocusedId } = useSpatialNavigation({
         enabled: !!proxyRuntime,
         initialFocusId: workbenchState.mode === 'preview' ? 'preview-block-0' : 'btn-next',
         onSelect: useCallback((elementId: string, element: HTMLElement) => {
             flash();
-            // Preview screen items → start the workout
+            // Preview screen items → select the block to start the workout
             if (elementId.startsWith('preview-block-')) {
-                sendEvent('next');
+                const index = parseInt(elementId.replace('preview-block-', ''), 10);
+                const blockId = workbenchStateRef.current.previewData?.blocks[index]?.id;
+                sendEvent('select-block', { index, blockId });
                 return;
             }
             // Track panel controls
@@ -89,6 +100,18 @@ const ReceiverApp: React.FC = () => {
                 case 'btn-next':
                     sendEvent('next');
                     break;
+                case 'btn-playlist-playpause':
+                    // We handle playlist play/pause locally, but also emit event if needed
+                    if (youtubePlayerRef.current) {
+                        if (youtubePlayerRef.current.getPlayerState() === 1) {
+                            youtubePlayerRef.current.pause();
+                            sendEvent('playlist-paused');
+                        } else {
+                            youtubePlayerRef.current.play();
+                            sendEvent('playlist-playing');
+                        }
+                    }
+                    break;
                 default:
                     // Fallback: click the element
                     element.click();
@@ -96,6 +119,16 @@ const ReceiverApp: React.FC = () => {
             }
         }, [sendEvent, flash]),
     });
+
+    // Move focus to the appropriate element when the display mode changes.
+    // Preview → focus first block; Active → focus the Next button.
+    useEffect(() => {
+        if (workbenchState.mode === 'preview') {
+            setFocusedId('preview-block-0');
+        } else if (workbenchState.mode === 'active') {
+            setFocusedId('btn-next');
+        }
+    }, [workbenchState.mode, setFocusedId]);
 
     // Local clock for smooth timer interpolation
     // Uses the proxy runtime's clock sync offset to match sender's elapsed time
@@ -321,6 +354,39 @@ const ReceiverApp: React.FC = () => {
         );
     }
 
+    const playlistId = workbenchState.frontmatter?.playlist ? extractYouTubePlaylistId(workbenchState.frontmatter.playlist) : null;
+    const [currentTrack, setCurrentTrack] = useState<string | null>(null);
+
+    // Watch for RPC events from sender to control playlist and coordinate playback with WOD lifecycle
+    useEffect(() => {
+        if (!proxyRuntime) return;
+        const unsubEvents = proxyRuntime.eventBus.on('*', (event) => {
+            if (event.name === 'playlist-play') {
+                youtubePlayerRef.current?.play();
+            } else if (event.name === 'playlist-pause') {
+                youtubePlayerRef.current?.pause();
+            }
+        }, 'receiver-rpc');
+
+        const unsubStack = proxyRuntime.subscribeToStack((snapshot) => {
+            if (youtubePlayerRef.current) {
+                // If the stack goes from depth 1 (Session root) to depth 2+ (actual blocks started),
+                // and the player is unstarted, we auto-start it.
+                if (snapshot.depth >= 2 && youtubePlayerRef.current.getPlayerState() === -1) {
+                    youtubePlayerRef.current.play();
+                } else if (snapshot.depth === 0) {
+                    // WOD complete or stopped -> stop the music
+                    youtubePlayerRef.current.pause();
+                }
+            }
+        });
+
+        return () => {
+            unsubEvents();
+            unsubStack();
+        };
+    }, [proxyRuntime]);
+
     // Active / Idle mode: normal stack + timer layout
     return (
         <ScriptRuntimeProvider runtime={proxyRuntime}>
@@ -338,10 +404,22 @@ const ReceiverApp: React.FC = () => {
 
                     {/* Right Column: Timer & Controls */}
                     <div className="w-1/2 flex flex-col bg-background transition-all duration-300">
+                        {playlistId && (
+                            <YouTubePlaylistPlayer
+                                ref={youtubePlayerRef}
+                                playlistId={playlistId}
+                                onTrackChange={(title) => setCurrentTrack(title)}
+                            />
+                        )}
                         <div className="p-4 pt-6">
                             <MetricTrackerCard />
                         </div>
-                        <ReceiverTimerPanel localNow={now} onEvent={sendEvent} getFocusProps={getFocusProps} />
+                        <ReceiverTimerPanel
+                            localNow={now}
+                            onEvent={sendEvent}
+                            getFocusProps={getFocusProps}
+                            currentTrack={currentTrack}
+                        />
                         <div className="absolute bottom-2 right-2 opacity-10 text-[8px] font-mono tracking-tighter uppercase">
                             {connectionStatus}
                         </div>

--- a/src/runtime/compiler/RuntimeBuilder.ts
+++ b/src/runtime/compiler/RuntimeBuilder.ts
@@ -93,6 +93,14 @@ export class RuntimeBuilder {
     }
 
     /**
+     * Set the frontmatter properties parsed from the document.
+     */
+    withFrontmatter(frontmatter: Record<string, string>): this {
+        this.options.frontmatter = frontmatter;
+        return this;
+    }
+
+    /**
      * Get the current options (for inspection/debugging)
      */
     getOptions(): Readonly<IRuntimeOptions> {

--- a/src/runtime/contracts/IRuntimeOptions.ts
+++ b/src/runtime/contracts/IRuntimeOptions.ts
@@ -49,6 +49,12 @@ export interface IRuntimeOptions {
      * Defaults to 20 if not specified.
      */
     maxActionDepth?: number;
+
+    /**
+     * Optional frontmatter properties parsed from the document.
+     * Used for things like attaching a youtube playlist to a workout session.
+     */
+    frontmatter?: Record<string, string>;
 }
 
 /**

--- a/src/services/cast/rpc/ChromecastProxyRuntime.ts
+++ b/src/services/cast/rpc/ChromecastProxyRuntime.ts
@@ -527,6 +527,7 @@ export class ChromecastProxyRuntime implements IScriptRuntime {
     private handleWorkbenchUpdate(message: RpcWorkbenchUpdate): void {
         this._workbenchState = {
             mode: message.mode,
+            frontmatter: message.frontmatter,
             previewData: message.previewData,
             reviewData: message.reviewData,
         };

--- a/src/services/cast/rpc/RpcMessages.ts
+++ b/src/services/cast/rpc/RpcMessages.ts
@@ -147,12 +147,24 @@ export interface RpcWorkbenchUpdate {
     type: 'rpc-workbench-update';
     /** Current workbench display mode */
     mode: 'idle' | 'preview' | 'active' | 'review';
+    /** Frontmatter parsed from the markdown document, containing properties like 'playlist' */
+    frontmatter?: Record<string, string>;
     /** Populated in 'preview' mode — info about the loaded document */
     previewData?: {
         /** Title of the selected WOD block (or document title) */
         title: string;
         /** Workout blocks available in the document */
-        blocks: Array<{ id: string; title: string; statementCount: number }>;
+        blocks: Array<{
+            id: string;
+            title: string;
+            statementCount: number;
+            /** First few lines of block content */
+            contentPreview?: string;
+            /** Timer duration hint (e.g. "10:00") if detected */
+            timerHint?: string;
+            /** WOD dialect (wod, log, plan) */
+            dialect?: string;
+        }>;
     };
     /** Populated in 'review' mode — summary of completed workout */
     reviewData?: {


### PR DESCRIPTION
This PR introduces support for embedding and remote-controlling a YouTube playlist directly on the Chromecast receiver during a WOD. 

It accomplishes this by extracting the `playlist` frontmatter property defined in a markdown block, propagating it via the RPC channel to the `ChromecastProxyRuntime`, and rendering a `react-youtube` iframe component that operates silently in the background on the TV.

A new "Now Playing" UI element has been added above the primary timers on both the Receiver (`ReceiverTimerPanel`) and the Sender (`RuntimeTimerPanel`). Playback is coordinated automatically with the workout lifecycle (starts when the WOD begins, pauses when stopped/completed), and cross-device remote control is implemented via RPC events.

---
*PR created automatically by Jules for task [12078832360518298568](https://jules.google.com/task/12078832360518298568) started by @SergeiGolos*