### PR TITLE
Fix mobile navigation padding and expand sticky panel height

### DIFF
--- a/playground/src/components/ParallaxSection.tsx
+++ b/playground/src/components/ParallaxSection.tsx
@@ -365,8 +365,8 @@ export function ParallaxSection({
 
   const mobilePanelNode = (
     <div
-      className="lg:hidden sticky z-20 shrink-0 px-4 pt-4 pb-3"
-      style={{ top: `${MOBILE_STICKY_TOP}px`, height: `calc(40vh - ${MOBILE_STICKY_TOP / 2}px)` }}
+      className="lg:hidden sticky z-20 shrink-0 px-4 pt-[2px] pb-3"
+      style={{ top: `${MOBILE_STICKY_TOP}px`, height: `calc(50vh - ${MOBILE_STICKY_TOP / 2}px)` }}
     >
       <MacOSChrome title={chromeTitle} onReset={onReset} headerActions={headerActions}>
         {stickyPanel}


### PR DESCRIPTION
This pull request makes a small adjustment to the mobile panel in the `ParallaxSection` component to improve its appearance and layout.

- UI adjustment for mobile: Increased the panel height from `40vh` to `50vh` and changed the top padding from `4px` to `2px` in the mobile view of `ParallaxSection.tsx`.