### PR TITLE
Implement virtual date scroll with infinite loading and architectural fixes

### DIFF
--- a/docs/design-system/queriable-list/journal-list.md
+++ b/docs/design-system/queriable-list/journal-list.md
@@ -1,53 +1,98 @@
-# Route: `/journal` (Weekly View)
+# Route: `/journal` (Date Scroll View)
 
 | | |
 |--|--|
 | **Route Pattern** | `/journal` |
 | **Template** | [Queriable List](_template.md) |
 | **Query Organism** | None (journal nav panel drives date/tag state via URL) |
-| **Component** | `JournalWeeklyPage` (`playground/src/views/ListViews.tsx`) |
+| **Component** | `JournalWeeklyPage` → `JournalDateScroll` (`playground/src/views/ListViews.tsx`, `playground/src/views/queriable-list/JournalDateScroll.tsx`) |
 | **Shell** | `CanvasPage` (title-bar mode, no subheader) |
 
 ## Description
 
-A focused, tactical view of recent training activity and upcoming sessions, sorted by date descending. The page has no inline query organism — date and tag filtering is driven by the journal nav panel's calendar widget and tag chips. This is distinct from the `/journal/:id` route, which is a per-entry workspace.
+An infinite-scroll, date-centric view of all training activity. Dates are shown in **ascending order** (oldest at top, newest toward bottom). Today is centered in the viewport on initial load. Scrolling **up** travels into past dates; scrolling **down** moves into future dates. Each date has an inline "Add note" prompt for today and future days. This is distinct from the `/journal/:id` route, which is a per-entry editor workspace.
 
-## Configuration (Queriable List Template)
+## Date Layout
 
-| Property | Configuration |
-|----------|---------------|
-| **Data Source** | Merged source (Playground + Journal from IndexedDB). |
-| **Query Organism** | None inline. Date/tag state comes from the journal nav panel via `useJournalQueryState`. |
-| **Filtered List** | `FilteredList` rendered directly by `JournalWeeklyPage` (no `QueriableListView` wrapper). |
+```
+↑  past  ↑
+─────────────
+  2026-04-01
+  2026-04-02
+  ...
+  2026-04-13  ← today (centered on load)
+  2026-04-14
+  ...
+─────────────
+↓  future  ↓
+```
 
-> **Implementation note:** `JournalWeeklyPage` renders `FilteredList` directly without the `QueriableListView` wrapper. The journal nav panel (calendar + tag chips) communicates with the list through the shared `useJournalQueryState` hook and URL params.
+The visible window is initially ±14 days around the target date (today or `?d=`). Sentinels at the top and bottom extend the window by 7 days at a time as the user approaches either edge.
+
+## Infinite Scroll
+
+`JournalDateScroll` uses two `IntersectionObserver` sentinels (window viewport, `root: null`):
+
+| Sentinel | Location | Action | Compensation |
+|----------|----------|--------|--------------|
+| Top | Before first date group | Prepend 7 past days | `window.scrollBy` (instant) using anchor-element delta to keep viewport stable |
+| Bottom | After last date group | Append 7 future days | None needed (DOM grows below viewport) |
+
+Both sentinels use a 600 px `rootMargin` to load eagerly before the user hits the edge.
+
+> **Why `root: null`:** `CanvasPage` renders `div.min-h-screen` so no inner container ever clips — the **window** is the scroller. All IO observers, scroll APIs (`scrollBy`, `scrollTo`, `scrollend`), and position calculations must target `window`/`document`, not a container ref.
+
+## Scroll Suppression
+
+All programmatic scrolls (mount centering, calendar navigation, off-window jumps) set `suppressReportRef = true` to prevent:
+
+1. **Visible-date IO** from reporting mid-animation dates back to the URL (which would trigger another scroll in `ListViews`).
+2. **Sentinel observers** from triggering prepend/append during navigation (prepend compensation would fight the in-flight scroll with an instant `scrollBy`).
+
+Suppression is released by the native `scrollend` event (Chrome 114+, FF 109+, Safari 16.4+). A `scrollY`-stability poll (100 ms intervals, 2 stable polls) acts as a fallback for older browsers and replaces the old fixed 1 s timeout, which was too short for long smooth scrolls.
+
+After suppression releases, both sentinel observers are **force-reconnected** (`unobserve` + `observe`) so that if a sentinel is still within the preload margin, IO re-fires immediately rather than stalling until the user scrolls again.
+
+## Calendar Navigation
+
+When the user clicks a date in the journal nav panel calendar, `scrollToDate(date)` is called on the imperative handle:
+
+- **Date is in current window** → smooth scroll to the date group (top-aligned below sticky header).
+- **Date is outside current window** → window is rebuilt as ±14 days around the target, then an **instant** scroll aligns to the target. Smooth scroll is intentionally avoided here because the DOM has been fully replaced.
+
+The `lastIODateRef` guard in `JournalWeeklyPage` distinguishes IO-driven `selectedDate` changes (user is scrolling → don't re-scroll) from user-intent navigation (calendar click → do scroll). It is seeded with the initial `selectedDate` so that the first render does not trigger a redundant scroll competing with the mount centering.
+
+## "Add Note" Ghost Row
+
+Each date group whose key is ≥ today shows a dashed "Add note" button at the bottom of the group. Past dates show no creation prompt since historical entries have already been created.
 
 ## State Management
 
-State is shared across `JournalWeeklyPage` and the journal nav panel via the `useJournalQueryState` hook.
+State is shared across `JournalWeeklyPage` and the journal nav panel via `useJournalQueryState`.
 
 ### URL State
 
 | Param | Mechanism | `history` | Purpose |
 |-------|-----------|-----------|---------|
-| `?s=` | `nuqs` via `CanvasPage` | `push` | Active TOC section ID. |
-| `?d=` | `nuqs` via `useJournalQueryState` | `replace` | Selected date (`YYYY-MM-DD`). Set by the journal nav calendar; drives scroll-to-date in `FilteredList`. Updated by scroll sync as user scrolls. |
-| `?month=` | `nuqs` via `useJournalQueryState` | `replace` | Visible month in the journal nav calendar widget (`YYYY-MM`). |
-| `?tags=` | `nuqs` via `useJournalQueryState` | `replace` | Active tag filters (comma-separated). Set by journal nav panel tag chips. |
+| `?d=` | `nuqs` via `useJournalQueryState` | `replace` | Active date (`YYYY-MM-DD`). Updated by IO scroll tracking as the user scrolls. Used to set the initial window and to sync the nav calendar. |
+| `?month=` | `nuqs` via `useJournalQueryState` | `replace` | Visible month in the nav calendar widget (`YYYY-MM`). Auto-derived from `?d=` when not set explicitly. |
+| `?tags=` | `nuqs` via `useJournalQueryState` | `replace` | Active tag filters (comma-separated). Set by nav panel tag chips. |
 
 ### Local State (outside URL)
 
-| State | Type | Purpose |
-|-------|------|---------|
+| State / Ref | Type | Purpose |
+|-------------|------|---------|
 | `results` | `any[]` | Recent results loaded from IndexedDB on mount. |
-| `isScrollUpdating` | `ref<boolean>` | Guard preventing scroll-driven date updates from conflicting with nav panel clicks. |
-
-## Scroll Sync
-
-As the user scrolls `FilteredList`, an `IntersectionObserver` fires `onVisibleDateChange`, which updates `?d=` via `setDateParam`. This keeps the journal nav panel calendar in sync with the user's scroll position.
+| `lastIODateRef` | `ref<string>` | Tracks the last date key reported by IO scroll tracking. Guards the `useEffect([selectedDate])` in `JournalWeeklyPage` so that IO-driven URL updates do not cause a re-scroll. Seeded from the initial `selectedDate` on mount. |
+| `dateWindow` | `{ start, end }` state | The current loaded date range inside `JournalDateScroll`. Grows as sentinels fire. |
+| `suppressReportRef` | `ref<boolean>` | True during any programmatic scroll. Suppresses both visible-date IO reports and sentinel loading. |
+| `mountScrollDoneRef` | `ref<boolean>` | False until the initial center scroll completes. Prevents sentinels from firing before the user has had a chance to orient. |
 
 ## Workflow
 
-1. **Focus**: The user sees all activity sorted by date descending, with tag filtering from the nav panel.
-2. **Navigate**: Clicking a date in the journal nav calendar sets `?d=` and the list scrolls to that date group.
-3. **Track**: Tap any list item to open the workout editor or review a completed session.
+1. **Load**: Page opens with today (or `?d=` target) centered in the viewport. ±14 days of dates are rendered.
+2. **Browse past**: Scroll up → history dates appear, top sentinel prepends more with invisible scroll compensation.
+3. **Browse future**: Scroll down → future dates appear, bottom sentinel appends more.
+4. **Navigate**: Click a calendar date → smooth (in-window) or instant (out-of-window) scroll to that date.
+5. **Create**: Tap "Add note for …" on any today-or-future date group to start a new entry.
+6. **Review**: Tap any historical item to open the workout editor or results review.

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1025,6 +1025,18 @@ function AppContent() {
     }
   }, [navigate])
 
+  /**
+   * Navigate to a journal entry for the given date.
+   * If a page already exists for that date, opens it. If not, the JournalPageShell
+   * creates a new entry. No conflict dialog needed from the scroll view.
+   */
+  const handleCreateJournalEntry = useCallback((date: Date) => {
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, '0')
+    const d = String(date.getDate()).padStart(2, '0')
+    navigate(`/journal/${y}-${m}-${d}`)
+  }, [navigate])
+
   // Reset strategy when palette closes
   useEffect(() => {
     if (!isCommandPaletteOpen) {
@@ -1226,6 +1238,7 @@ function AppContent() {
               <JournalWeeklyPage 
                 workoutItems={workoutItems}
                 onSelect={handleSelectWorkout}
+                onCreateEntry={handleCreateJournalEntry}
               />
             </CanvasPage>
           ) : location.pathname === '/search' ? (

--- a/playground/src/hooks/useJournalQueryState.ts
+++ b/playground/src/hooks/useJournalQueryState.ts
@@ -28,7 +28,7 @@ export function useJournalQueryState() {
   // ── Date parameter ────────────────────────────────────────────────────
   const [dateParam, setDateParam] = useQueryState('d', {
     defaultValue: '',
-    shallow: false,
+    shallow: true,
     history: 'replace',
   });
 
@@ -45,7 +45,10 @@ export function useJournalQueryState() {
       if (!date) {
         setDateParam('');
       } else {
-        setDateParam(date.toISOString().split('T')[0]);
+        const y = date.getFullYear();
+        const m = String(date.getMonth() + 1).padStart(2, '0');
+        const d = String(date.getDate()).padStart(2, '0');
+        setDateParam(`${y}-${m}-${d}`);
       }
     },
     [setDateParam],
@@ -54,7 +57,7 @@ export function useJournalQueryState() {
   // ── Month parameter ───────────────────────────────────────────────────
   const [monthParam, setMonthParam] = useQueryState('month', {
     defaultValue: '',
-    shallow: false,
+    shallow: true,
     history: 'replace',
   });
 
@@ -77,7 +80,7 @@ export function useJournalQueryState() {
   // ── Tags parameter ────────────────────────────────────────────────────
   const [tagsParam, setTagsParam] = useQueryState('tags', {
     defaultValue: '',
-    shallow: false,
+    shallow: true,
     history: 'replace',
   });
 

--- a/playground/src/views/ListViews.tsx
+++ b/playground/src/views/ListViews.tsx
@@ -21,9 +21,9 @@ export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: Jou
   const [results, setResults] = useState<any[]>([]);
   const scrollRef = useRef<JournalDateScrollHandle>(null);
 
-  // Track the last date reported by the IO observer so we can distinguish
-  // IO-driven selectedDate changes (no scroll) from user-intent navigation (scroll).
-  const lastIODateRef = useRef<string>('');
+  // Seed with the initial date so the first-render effect doesn't trigger a
+  // redundant scroll — JournalDateScroll already centers the date on mount.
+  const lastIODateRef = useRef<string>(selectedDate ? localDateKey(selectedDate) : '');
 
   useEffect(() => {
     indexedDBService.getRecentResults(100).then(setResults);

--- a/playground/src/views/ListViews.tsx
+++ b/playground/src/views/ListViews.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryState } from 'nuqs';
 import { FilteredList } from './queriable-list/FilteredList';
+import { JournalDateScroll, localDateKey, type JournalDateScrollHandle } from './queriable-list/JournalDateScroll';
 import { indexedDBService } from '@/services/db/IndexedDBService';
 import { useJournalQueryState } from '../hooks/useJournalQueryState';
 import type { FilteredListItem } from './queriable-list/types';
@@ -11,11 +12,18 @@ interface BaseProps {
   onSelect: (item: any) => void;
 }
 
-export function JournalWeeklyPage({ workoutItems, onSelect }: BaseProps) {
+interface JournalWeeklyPageProps extends BaseProps {
+  onCreateEntry: (date: Date) => void;
+}
+
+export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: JournalWeeklyPageProps) {
   const { selectedDate, setDateParam, selectedTags } = useJournalQueryState();
   const [results, setResults] = useState<any[]>([]);
-  // Guard to prevent scroll-driven date updates from fighting user clicks
-  const isScrollUpdating = useRef(false);
+  const scrollRef = useRef<JournalDateScrollHandle>(null);
+
+  // Track the last date reported by the IO observer so we can distinguish
+  // IO-driven selectedDate changes (no scroll) from user-intent navigation (scroll).
+  const lastIODateRef = useRef<string>('');
 
   useEffect(() => {
     indexedDBService.getRecentResults(100).then(setResults);
@@ -30,20 +38,26 @@ export function JournalWeeklyPage({ workoutItems, onSelect }: BaseProps) {
     }
   };
 
-  /** Called by FilteredList IntersectionObserver as the user scrolls */
+  /** Called by JournalDateScroll IO as the user scrolls — updates URL only, never triggers re-scroll. */
   const handleVisibleDateChange = useCallback(
     (dateKey: string) => {
       if (dateKey && dateKey !== 'no-date') {
-        isScrollUpdating.current = true;
+        lastIODateRef.current = dateKey;
         setDateParam(dateKey);
-        // Release the guard after a tick so React can reconcile
-        requestAnimationFrame(() => {
-          isScrollUpdating.current = false;
-        });
       }
     },
     [setDateParam],
   );
+
+  // Scroll to selectedDate only when it changes from user intent (calendar click),
+  // not when it changes because the IO observer updated the URL while the user was scrolling.
+  useEffect(() => {
+    if (!selectedDate) return;
+    const key = localDateKey(selectedDate);
+    // If the IO just reported this date, it's already visible — don't scroll back to it.
+    if (key === lastIODateRef.current) return;
+    scrollRef.current?.scrollToDate(selectedDate);
+  }, [selectedDate]);
 
   const allItems = useMemo(() => {
     const combined: FilteredListItem[] = [];
@@ -85,14 +99,15 @@ export function JournalWeeklyPage({ workoutItems, onSelect }: BaseProps) {
   }, [workoutItems, results, selectedTags]);
 
   return (
-    <div className="flex-1 min-h-0 overflow-y-auto bg-card">
-      <FilteredList
-        items={allItems}
-        onSelect={handleSelect}
-        selectedDate={selectedDate}
-        onVisibleDateChange={handleVisibleDateChange}
-      />
-    </div>
+    <JournalDateScroll
+      ref={scrollRef}
+      items={allItems}
+      onSelect={handleSelect}
+      onCreateEntry={onCreateEntry}
+      initialDate={selectedDate}
+      onVisibleDateChange={handleVisibleDateChange}
+      className="flex-1 min-h-0"
+    />
   );
 }
 

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -189,14 +189,16 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       },
     }), [suppressReportUntilScrollEnd, scrollToElement]);
 
-    // On mount: instantly scroll to today (or initialDate) so it appears at the top.
+    // On mount: instantly center today (or initialDate) in the viewport.
     // Sentinels are suppressed until this completes to avoid mount-time burst loading.
     useEffect(() => {
       const key = localDateKey(initialDate ?? new Date());
       const el = dateGroupRefs.current.get(key);
       if (el) {
-        const top = el.getBoundingClientRect().top + window.scrollY - stickyOffset - 8;
-        window.scrollTo({ top, behavior: 'instant' });
+        const rect = el.getBoundingClientRect();
+        // Center the date group in the viewport
+        const top = rect.top + window.scrollY - window.innerHeight / 2 + rect.height / 2;
+        window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
       }
       requestAnimationFrame(() => {
         mountScrollDoneRef.current = true;

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -1,0 +1,369 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { PlusIcon, CalendarIcon, FileTextIcon, PlayIcon, CheckCircleIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { FilteredListItem } from './types';
+
+// ── Date utilities ─────────────────────────────────────────────────────────
+
+/** Returns 'YYYY-MM-DD' in local time. Avoids UTC timezone shift from toISOString(). */
+export function localDateKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function addDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function formatDateHeader(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface JournalDateScrollHandle {
+  /** Imperatively scroll to a date. Only call this in response to deliberate user navigation. */
+  scrollToDate(date: Date): void;
+}
+
+interface JournalDateScrollProps {
+  items: FilteredListItem[];
+  onSelect: (item: FilteredListItem) => void;
+  onCreateEntry: (date: Date) => void;
+  /**
+   * Passive anchor: used only to set the initial window on first render.
+   * Changing this prop does NOT trigger a scroll.
+   * Use the imperative `scrollToDate` handle for user-intent navigation.
+   */
+  initialDate?: Date;
+  onVisibleDateChange?: (dateKey: string) => void;
+  stickyOffset?: number;
+  className?: string;
+}
+
+// ── Item icon ──────────────────────────────────────────────────────────────
+
+const ItemIcon = ({ type }: { type: FilteredListItem['type'] }) => {
+  switch (type) {
+    case 'note':   return <FileTextIcon className="size-4 text-blue-500" />;
+    case 'block':  return <PlayIcon className="size-4 text-emerald-500" />;
+    case 'result': return <CheckCircleIcon className="size-4 text-purple-500" />;
+  }
+};
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDateScrollProps>(
+  (
+    {
+      items,
+      onSelect,
+      onCreateEntry,
+      initialDate,
+      onVisibleDateChange,
+      stickyOffset = 0,
+      className,
+    },
+    ref,
+  ) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const topSentinelRef = useRef<HTMLDivElement>(null);
+    const bottomSentinelRef = useRef<HTMLDivElement>(null);
+
+    // Map from date key → DOM element; populated via stable callback refs during render.
+    const dateGroupRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+    // Prepend scroll anchoring
+    const isPrependingRef = useRef(false);
+    const scrollHeightBeforeRef = useRef(0);
+
+    // Off-window scroll: key to scroll to once the window is rebuilt around it
+    const pendingScrollKeyRef = useRef<string | null>(null);
+
+    // Suppress IO visible-date reports during programmatic scroll
+    const suppressReportRef = useRef(false);
+    const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const lastReportedRef = useRef<string>('');
+
+    // ── Date window ──────────────────────────────────────────────────────────
+
+    const [dateWindow, setDateWindow] = useState<{ start: Date; end: Date }>(() => {
+      const anchor = initialDate ?? new Date();
+      return {
+        start: addDays(anchor, -7),
+        end: addDays(anchor, 3),
+      };
+    });
+
+    // Descending list of all dates in the window (newest → oldest)
+    const dates = useMemo(() => {
+      const result: Date[] = [];
+      let d = new Date(dateWindow.end);
+      const stop = dateWindow.start;
+      while (d >= stop) {
+        result.push(new Date(d));
+        d = addDays(d, -1);
+      }
+      return result;
+    }, [dateWindow]);
+
+    // Group items by local date key
+    const itemsByDate = useMemo(() => {
+      const map = new Map<string, FilteredListItem[]>();
+      items.forEach(item => {
+        if (!item.date) return;
+        const key = localDateKey(new Date(item.date));
+        const group = map.get(key) ?? [];
+        group.push(item);
+        map.set(key, group);
+      });
+      return map;
+    }, [items]);
+
+    // ── Suppress visible-date reports during programmatic scroll ─────────────
+
+    const suppressReportUntilScrollEnd = useCallback(() => {
+      suppressReportRef.current = true;
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
+      suppressTimerRef.current = setTimeout(() => {
+        suppressReportRef.current = false;
+      }, 1000);
+      containerRef.current?.addEventListener(
+        'scrollend',
+        () => {
+          suppressReportRef.current = false;
+          if (suppressTimerRef.current) {
+            clearTimeout(suppressTimerRef.current);
+            suppressTimerRef.current = null;
+          }
+        },
+        { once: true },
+      );
+    }, []);
+
+    // ── Imperative handle ─────────────────────────────────────────────────────
+
+    useImperativeHandle(ref, () => ({
+      scrollToDate(date: Date) {
+        const key = localDateKey(date);
+        const el = dateGroupRefs.current.get(key);
+        if (el) {
+          suppressReportUntilScrollEnd();
+          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        } else {
+          // Date is outside the current window — rebuild window around this date
+          pendingScrollKeyRef.current = key;
+          setDateWindow({
+            start: addDays(date, -7),
+            end: addDays(date, 3),
+          });
+        }
+      },
+    }), [suppressReportUntilScrollEnd]);
+
+    // After window rebuild: complete a pending off-window scroll once dates are rendered
+    useEffect(() => {
+      const key = pendingScrollKeyRef.current;
+      if (!key) return;
+      const el = dateGroupRefs.current.get(key);
+      if (!el) return;
+      pendingScrollKeyRef.current = null;
+      suppressReportUntilScrollEnd();
+      requestAnimationFrame(() => {
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    }, [dates, suppressReportUntilScrollEnd]);
+
+    // ── Top sentinel: load future dates (prepend) ─────────────────────────────
+
+    useEffect(() => {
+      const container = containerRef.current;
+      const sentinel = topSentinelRef.current;
+      if (!container || !sentinel) return;
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting || isPrependingRef.current) return;
+          isPrependingRef.current = true;
+          scrollHeightBeforeRef.current = container.scrollHeight;
+          setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
+        },
+        { root: container, threshold: 0 },
+      );
+      observer.observe(sentinel);
+      return () => observer.disconnect();
+    }, []);
+
+    // After prepend: restore scroll position to prevent viewport jump
+    useLayoutEffect(() => {
+      const container = containerRef.current;
+      if (!container || scrollHeightBeforeRef.current === 0) return;
+      const delta = container.scrollHeight - scrollHeightBeforeRef.current;
+      if (delta > 0) container.scrollTop += delta;
+      scrollHeightBeforeRef.current = 0;
+      // Release the guard after the browser has painted
+      requestAnimationFrame(() => {
+        isPrependingRef.current = false;
+      });
+    }, [dateWindow.end]);
+
+    // ── Bottom sentinel: load past dates (append) ─────────────────────────────
+
+    useEffect(() => {
+      const container = containerRef.current;
+      const sentinel = bottomSentinelRef.current;
+      if (!container || !sentinel) return;
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          setDateWindow(w => ({ ...w, start: addDays(w.start, -7) }));
+        },
+        { root: container, threshold: 0 },
+      );
+      observer.observe(sentinel);
+      return () => observer.disconnect();
+    }, []);
+
+    // ── Visible date IO — ratioMap pattern to avoid oscillation ──────────────
+
+    useEffect(() => {
+      if (!onVisibleDateChange || !containerRef.current) return;
+      const container = containerRef.current;
+      const ratioMap = new Map<string, number>();
+
+      const observer = new IntersectionObserver(
+        entries => {
+          entries.forEach(entry => {
+            if (entry.target.id) ratioMap.set(entry.target.id, entry.intersectionRatio);
+          });
+
+          if (suppressReportRef.current) return;
+
+          // Winner = date group with the highest visible ratio
+          let bestId = '';
+          let bestRatio = -1;
+          ratioMap.forEach((ratio, id) => {
+            if (ratio > bestRatio) {
+              bestRatio = ratio;
+              bestId = id;
+            }
+          });
+
+          if (bestId && bestId !== lastReportedRef.current) {
+            lastReportedRef.current = bestId;
+            onVisibleDateChange(bestId);
+          }
+        },
+        { root: container, rootMargin: '0px 0px -50% 0px', threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0] },
+      );
+
+      dateGroupRefs.current.forEach(el => el && observer.observe(el));
+      return () => observer.disconnect();
+    }, [dates, onVisibleDateChange]);
+
+    // ── Stable callback ref factory ───────────────────────────────────────────
+
+    const setDateGroupRef = useCallback(
+      (key: string) => (el: HTMLElement | null) => {
+        if (el) dateGroupRefs.current.set(key, el);
+        else dateGroupRefs.current.delete(key);
+      },
+      [],
+    );
+
+    // ── Render ────────────────────────────────────────────────────────────────
+
+    const todayKey = localDateKey(new Date());
+
+    return (
+      <div ref={containerRef} className={cn('overflow-y-auto bg-card', className)}>
+        <div ref={topSentinelRef} className="h-px" />
+
+        {dates.map(date => {
+          const key = localDateKey(date);
+          const dayItems = itemsByDate.get(key) ?? [];
+          const isToday = key === todayKey;
+
+          return (
+            <div key={key} id={key} ref={setDateGroupRef(key) as React.RefCallback<HTMLDivElement>} className="flex flex-col">
+              {/* Sticky date header */}
+              <div
+                className="sticky z-[5] px-6 py-2 bg-muted/80 backdrop-blur-sm border-y border-border flex items-center gap-2"
+                style={{ top: stickyOffset }}
+              >
+                <CalendarIcon className="size-3 text-muted-foreground" />
+                <span className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+                  {formatDateHeader(date)}
+                  {isToday && <span className="ml-2 text-primary font-black">— Today</span>}
+                </span>
+              </div>
+
+              {/* Entries for this day */}
+              {dayItems.length > 0 && (
+                <div className="divide-y divide-border/50">
+                  {dayItems.map(item => (
+                    <button
+                      key={`${item.type}-${item.id}`}
+                      onClick={() => onSelect(item)}
+                      className="w-full flex items-center gap-4 px-6 py-4 hover:bg-muted/50 transition-colors text-left group"
+                    >
+                      <div className="flex-shrink-0 size-10 rounded-xl bg-muted flex items-center justify-center group-hover:bg-background transition-colors">
+                        <ItemIcon type={item.type} />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center justify-between mb-0.5">
+                          <h3 className="text-sm font-bold text-foreground truncate uppercase tracking-tight">
+                            {item.title}
+                          </h3>
+                          {item.date && (
+                            <span className="text-[10px] font-bold text-muted-foreground uppercase">
+                              {new Date(item.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-xs text-muted-foreground truncate font-medium">{item.subtitle}</p>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+
+              {/* Ghost "Add note" row — always visible, invites creating an entry */}
+              <button
+                onClick={() => onCreateEntry(date)}
+                className="flex items-center gap-3 mx-4 my-2 px-4 py-2.5 rounded-lg border border-dashed border-border/50 hover:border-primary/40 hover:bg-primary/5 transition-all text-left group w-[calc(100%-2rem)]"
+              >
+                <div className="flex-shrink-0 size-7 rounded-md bg-muted/50 flex items-center justify-center group-hover:bg-primary/10 transition-colors">
+                  <PlusIcon className="size-3.5 text-muted-foreground/60 group-hover:text-primary transition-colors" />
+                </div>
+                <span className="text-xs text-muted-foreground/60 group-hover:text-primary transition-colors font-medium">
+                  Add note for {date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+
+        <div ref={bottomSentinelRef} className="h-px" />
+      </div>
+    );
+  },
+);
+
+JournalDateScroll.displayName = 'JournalDateScroll';

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -84,6 +84,10 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     const topSentinelRef = useRef<HTMLDivElement>(null);
     const bottomSentinelRef = useRef<HTMLDivElement>(null);
 
+    // Stored observer refs so we can reconnect them after programmatic scrolls
+    const topObserverRef = useRef<IntersectionObserver | null>(null);
+    const bottomObserverRef = useRef<IntersectionObserver | null>(null);
+
     // Map from date key → DOM element; populated via stable callback refs during render.
     const dateGroupRefs = useRef<Map<string, HTMLElement>>(new Map());
 
@@ -142,26 +146,70 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       return map;
     }, [items]);
 
-    // ── Suppress visible-date reports during programmatic scroll ─────────────
+    // ── Suppress visible-date reports + sentinels during programmatic scroll ──
+
+    /**
+     * Re-observe both sentinels to force IO to re-evaluate their current
+     * intersection state. Called after suppression ends so that sentinels
+     * that were blocked during a programmatic scroll fire immediately if
+     * they are still within the preload margin.
+     */
+    const recheckSentinels = useCallback(() => {
+      const reconnect = (
+        observerRef: React.MutableRefObject<IntersectionObserver | null>,
+        sentinelRef: React.RefObject<HTMLDivElement | null>,
+      ) => {
+        if (observerRef.current && sentinelRef.current) {
+          observerRef.current.unobserve(sentinelRef.current);
+          observerRef.current.observe(sentinelRef.current);
+        }
+      };
+      reconnect(topObserverRef, topSentinelRef);
+      reconnect(bottomObserverRef, bottomSentinelRef);
+    }, []);
 
     const suppressReportUntilScrollEnd = useCallback(() => {
       suppressReportRef.current = true;
       if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
-      suppressTimerRef.current = setTimeout(() => {
+
+      const clearSuppression = () => {
         suppressReportRef.current = false;
-      }, 1000);
-      window.addEventListener(
-        'scrollend',
-        () => {
-          suppressReportRef.current = false;
-          if (suppressTimerRef.current) {
-            clearTimeout(suppressTimerRef.current);
-            suppressTimerRef.current = null;
+        if (suppressTimerRef.current) {
+          clearTimeout(suppressTimerRef.current);
+          suppressTimerRef.current = null;
+        }
+        recheckSentinels();
+      };
+
+      // Primary: release on the native scrollend event (Chrome 114+, FF 109+, Safari 16.4+)
+      window.addEventListener('scrollend', clearSuppression, { once: true });
+
+      // Fallback: poll scrollY every 100 ms; release once it has been
+      // stable for two consecutive polls. This handles:
+      //   - browsers without scrollend
+      //   - instant scrolls (scrollend fires synchronously, poll is a no-op)
+      //   - long smooth scrolls that would exceed a fixed 1s timeout
+      let lastY = window.scrollY;
+      let stableCount = 0;
+      const poll = () => {
+        if (!suppressReportRef.current) return; // already cleared by scrollend
+        const y = window.scrollY;
+        if (y === lastY) {
+          stableCount++;
+          if (stableCount >= 2) {
+            window.removeEventListener('scrollend', clearSuppression);
+            clearSuppression();
+            return;
           }
-        },
-        { once: true },
-      );
-    }, []);
+        } else {
+          lastY = y;
+          stableCount = 0;
+        }
+        suppressTimerRef.current = setTimeout(poll, 100);
+      };
+      // Start polling after 150 ms to let the scroll begin before measuring
+      suppressTimerRef.current = setTimeout(poll, 150);
+    }, [recheckSentinels]);
 
     // ── Imperative handle ─────────────────────────────────────────────────────
 
@@ -207,7 +255,9 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // After window rebuild: complete a pending off-window scroll once dates are rendered
+    // After window rebuild: instantly jump to the pending off-window target.
+    // Smooth scroll is wrong here — the DOM was fully rebuilt so there is no
+    // continuous path to animate along. Instant keeps the UX clean.
     useEffect(() => {
       const key = pendingScrollKeyRef.current;
       if (!key) return;
@@ -215,8 +265,11 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       if (!el) return;
       pendingScrollKeyRef.current = null;
       suppressReportUntilScrollEnd();
-      requestAnimationFrame(() => scrollToElement(el));
-    }, [dates, suppressReportUntilScrollEnd, scrollToElement]);
+      requestAnimationFrame(() => {
+        const top = el.getBoundingClientRect().top + window.scrollY - stickyOffset - 8;
+        window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
+      });
+    }, [dates, suppressReportUntilScrollEnd, stickyOffset]);
 
     // ── Top sentinel: load past dates (prepend older at top) ─────────────────
 
@@ -226,7 +279,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
       const observer = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting || isPrependingRef.current || !mountScrollDoneRef.current) return;
+          if (!entry.isIntersecting || isPrependingRef.current || !mountScrollDoneRef.current || suppressReportRef.current) return;
           isPrependingRef.current = true;
           // Anchor on the current visible date group to compensate after DOM grows above
           const anchorKey = lastReportedRef.current;
@@ -239,7 +292,11 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
         { rootMargin: '600px 0px 0px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
-      return () => observer.disconnect();
+      topObserverRef.current = observer;
+      return () => {
+        observer.disconnect();
+        topObserverRef.current = null;
+      };
     }, []);
 
     // After prepend: compensate scroll so the viewport stays on the same date
@@ -263,7 +320,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
       const observer = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting || isAppendingRef.current || !mountScrollDoneRef.current) return;
+          if (!entry.isIntersecting || isAppendingRef.current || !mountScrollDoneRef.current || suppressReportRef.current) return;
           isAppendingRef.current = true;
           setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
         },
@@ -271,7 +328,11 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
         { rootMargin: '0px 0px 600px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
-      return () => observer.disconnect();
+      bottomObserverRef.current = observer;
+      return () => {
+        observer.disconnect();
+        bottomObserverRef.current = null;
+      };
     }, []);
 
     // After append: release the guard once DOM has settled

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -246,7 +246,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
         const rect = el.getBoundingClientRect();
         // Center the date group in the viewport
         const top = rect.top + window.scrollY - window.innerHeight / 2 + rect.height / 2;
-        window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
+        window.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
       }
       requestAnimationFrame(() => {
         mountScrollDoneRef.current = true;
@@ -267,7 +267,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       suppressReportUntilScrollEnd();
       requestAnimationFrame(() => {
         const top = el.getBoundingClientRect().top + window.scrollY - stickyOffset - 8;
-        window.scrollTo({ top: Math.max(0, top), behavior: 'instant' });
+        window.scrollTo({ top: Math.max(0, top), behavior: 'auto' });
       });
     }, [dates, suppressReportUntilScrollEnd, stickyOffset]);
 
@@ -304,7 +304,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       const el = prependAnchorElRef.current;
       if (!el) return;
       const delta = el.getBoundingClientRect().top - prependAnchorTopRef.current;
-      if (delta !== 0) window.scrollBy({ top: delta, behavior: 'instant' });
+      if (delta !== 0) window.scrollBy({ top: delta, behavior: 'auto' });
       prependAnchorElRef.current = null;
       prependAnchorTopRef.current = 0;
       requestAnimationFrame(() => {

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -81,16 +81,19 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     },
     ref,
   ) => {
-    const containerRef = useRef<HTMLDivElement>(null);
     const topSentinelRef = useRef<HTMLDivElement>(null);
     const bottomSentinelRef = useRef<HTMLDivElement>(null);
 
     // Map from date key → DOM element; populated via stable callback refs during render.
     const dateGroupRefs = useRef<Map<string, HTMLElement>>(new Map());
 
-    // Prepend scroll anchoring
+    // Prepend scroll anchoring — anchor-element-based to avoid scrollHeight over-compensation
     const isPrependingRef = useRef(false);
-    const scrollHeightBeforeRef = useRef(0);
+    const prependAnchorElRef = useRef<HTMLElement | null>(null);
+    const prependAnchorTopRef = useRef(0);
+
+    // Append guard — prevents burst-loading when bottom sentinel stays visible
+    const isAppendingRef = useRef(false);
 
     // Off-window scroll: key to scroll to once the window is rebuilt around it
     const pendingScrollKeyRef = useRef<string | null>(null);
@@ -158,23 +161,29 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
     // ── Imperative handle ─────────────────────────────────────────────────────
 
+    /** Scroll to a date group, accounting for the sticky header. */
+    const scrollToElement = useCallback((el: HTMLElement) => {
+      const top = el.getBoundingClientRect().top + window.scrollY - stickyOffset - 8;
+      window.scrollTo({ top, behavior: 'smooth' });
+    }, [stickyOffset]);
+
     useImperativeHandle(ref, () => ({
       scrollToDate(date: Date) {
         const key = localDateKey(date);
         const el = dateGroupRefs.current.get(key);
         if (el) {
           suppressReportUntilScrollEnd();
-          el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          scrollToElement(el);
         } else {
           // Date is outside the current window — rebuild window around this date
           pendingScrollKeyRef.current = key;
           setDateWindow({
-            start: addDays(date, -7),
-            end: addDays(date, 3),
+            start: addDays(date, -14),
+            end: addDays(date, 7),
           });
         }
       },
-    }), [suppressReportUntilScrollEnd]);
+    }), [suppressReportUntilScrollEnd, scrollToElement]);
 
     // After window rebuild: complete a pending off-window scroll once dates are rendered
     useEffect(() => {
@@ -184,10 +193,8 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       if (!el) return;
       pendingScrollKeyRef.current = null;
       suppressReportUntilScrollEnd();
-      requestAnimationFrame(() => {
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      });
-    }, [dates, suppressReportUntilScrollEnd]);
+      requestAnimationFrame(() => scrollToElement(el));
+    }, [dates, suppressReportUntilScrollEnd, scrollToElement]);
 
     // ── Top sentinel: load future dates (prepend) ─────────────────────────────
 
@@ -199,24 +206,28 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
         ([entry]) => {
           if (!entry.isIntersecting || isPrependingRef.current) return;
           isPrependingRef.current = true;
-          // Capture page height before DOM changes so we can compensate scroll position
-          scrollHeightBeforeRef.current = document.documentElement.scrollHeight;
+          // Anchor on the first visible date group so we can compensate after DOM grows
+          const anchorKey = lastReportedRef.current;
+          const anchorEl = anchorKey ? dateGroupRefs.current.get(anchorKey) : [...dateGroupRefs.current.values()][0];
+          prependAnchorElRef.current = anchorEl ?? null;
+          prependAnchorTopRef.current = anchorEl ? anchorEl.getBoundingClientRect().top : 0;
           setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
         },
-        // root:null = window viewport; 600px top margin fires before sentinel scrolls into view
+        // root:null = window viewport; 600px top margin fires ~4 date groups before hitting top
         { rootMargin: '600px 0px 0px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
       return () => observer.disconnect();
     }, []);
 
-    // After prepend: restore scroll position to prevent viewport jump
+    // After prepend: compensate scroll using the anchor element's position delta
     useLayoutEffect(() => {
-      if (scrollHeightBeforeRef.current === 0) return;
-      const delta = document.documentElement.scrollHeight - scrollHeightBeforeRef.current;
-      if (delta > 0) window.scrollBy({ top: delta, behavior: 'instant' });
-      scrollHeightBeforeRef.current = 0;
-      // Release the guard after the browser has painted
+      const el = prependAnchorElRef.current;
+      if (!el) return;
+      const delta = el.getBoundingClientRect().top - prependAnchorTopRef.current;
+      if (delta !== 0) window.scrollBy({ top: delta, behavior: 'instant' });
+      prependAnchorElRef.current = null;
+      prependAnchorTopRef.current = 0;
       requestAnimationFrame(() => {
         isPrependingRef.current = false;
       });
@@ -230,36 +241,52 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
       const observer = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting) return;
+          if (!entry.isIntersecting || isAppendingRef.current) return;
+          isAppendingRef.current = true;
           setDateWindow(w => ({ ...w, start: addDays(w.start, -7) }));
         },
-        // root:null = window viewport; 600px bottom margin fires before sentinel scrolls into view
+        // root:null = window viewport; 600px bottom margin fires ~4 date groups before hitting bottom
         { rootMargin: '0px 0px 600px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
       return () => observer.disconnect();
     }, []);
 
-    // ── Visible date IO — ratioMap pattern to avoid oscillation ──────────────
+    // After append: release the guard once DOM has settled
+    useEffect(() => {
+      requestAnimationFrame(() => {
+        isAppendingRef.current = false;
+      });
+    }, [dateWindow.start]);
+
+    // ── Visible date IO — top-proximity: pick the date group closest to sticky header ──
 
     useEffect(() => {
       if (!onVisibleDateChange) return;
-      const ratioMap = new Map<string, number>();
+      // Map: id → viewport-relative top at last observation (only intersecting elements kept)
+      const topMap = new Map<string, number>();
 
       const observer = new IntersectionObserver(
         entries => {
           entries.forEach(entry => {
-            if (entry.target.id) ratioMap.set(entry.target.id, entry.intersectionRatio);
+            if (!entry.target.id) return;
+            if (entry.isIntersecting) {
+              topMap.set(entry.target.id, entry.boundingClientRect.top);
+            } else {
+              topMap.delete(entry.target.id);
+            }
           });
 
           if (suppressReportRef.current) return;
 
-          // Winner = date group with the highest visible ratio
+          // Winner = intersecting group whose top is closest to the sticky header bottom
+          const threshold = stickyOffset + 8;
           let bestId = '';
-          let bestRatio = -1;
-          ratioMap.forEach((ratio, id) => {
-            if (ratio > bestRatio) {
-              bestRatio = ratio;
+          let bestDist = Infinity;
+          topMap.forEach((top, id) => {
+            const dist = Math.abs(top - threshold);
+            if (dist < bestDist) {
+              bestDist = dist;
               bestId = id;
             }
           });
@@ -269,13 +296,13 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
             onVisibleDateChange(bestId);
           }
         },
-        // root:null = window viewport; focus on top ~40% of viewport to pick the "current" date
-        { rootMargin: '-10% 0px -50% 0px', threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0] },
+        // Pixel inset excludes the sticky chrome; bottom half excluded to focus on "current" date
+        { rootMargin: `-${stickyOffset + 8}px 0px -50% 0px`, threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0] },
       );
 
       dateGroupRefs.current.forEach(el => el && observer.observe(el));
       return () => observer.disconnect();
-    }, [dates, onVisibleDateChange]);
+    }, [dates, onVisibleDateChange, stickyOffset]);
 
     // ── Stable callback ref factory ───────────────────────────────────────────
 
@@ -292,7 +319,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     const todayKey = localDateKey(new Date());
 
     return (
-      <div ref={containerRef} className={cn('overflow-y-auto bg-card', className)}>
+      <div className={cn('bg-card', className)}>
         <div ref={topSentinelRef} className="h-px" />
 
         {dates.map(date => {
@@ -301,7 +328,13 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
           const isToday = key === todayKey;
 
           return (
-            <div key={key} id={key} ref={setDateGroupRef(key) as React.RefCallback<HTMLDivElement>} className="flex flex-col">
+            <div
+              key={key}
+              id={key}
+              ref={setDateGroupRef(key) as React.RefCallback<HTMLDivElement>}
+              className="flex flex-col"
+              style={{ scrollMarginTop: stickyOffset + 8 }}
+            >
               {/* Sticky date header */}
               <div
                 className="sticky z-[5] px-6 py-2 bg-muted/80 backdrop-blur-sm border-y border-border flex items-center gap-2"

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -105,8 +105,8 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     const [dateWindow, setDateWindow] = useState<{ start: Date; end: Date }>(() => {
       const anchor = initialDate ?? new Date();
       return {
-        start: addDays(anchor, -7),
-        end: addDays(anchor, 3),
+        start: addDays(anchor, -14),
+        end: addDays(anchor, 7),
       };
     });
 
@@ -143,7 +143,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       suppressTimerRef.current = setTimeout(() => {
         suppressReportRef.current = false;
       }, 1000);
-      containerRef.current?.addEventListener(
+      window.addEventListener(
         'scrollend',
         () => {
           suppressReportRef.current = false;
@@ -192,18 +192,19 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     // ── Top sentinel: load future dates (prepend) ─────────────────────────────
 
     useEffect(() => {
-      const container = containerRef.current;
       const sentinel = topSentinelRef.current;
-      if (!container || !sentinel) return;
+      if (!sentinel) return;
 
       const observer = new IntersectionObserver(
         ([entry]) => {
           if (!entry.isIntersecting || isPrependingRef.current) return;
           isPrependingRef.current = true;
-          scrollHeightBeforeRef.current = container.scrollHeight;
+          // Capture page height before DOM changes so we can compensate scroll position
+          scrollHeightBeforeRef.current = document.documentElement.scrollHeight;
           setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
         },
-        { root: container, threshold: 0 },
+        // root:null = window viewport; 600px top margin fires before sentinel scrolls into view
+        { rootMargin: '600px 0px 0px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
       return () => observer.disconnect();
@@ -211,10 +212,9 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
     // After prepend: restore scroll position to prevent viewport jump
     useLayoutEffect(() => {
-      const container = containerRef.current;
-      if (!container || scrollHeightBeforeRef.current === 0) return;
-      const delta = container.scrollHeight - scrollHeightBeforeRef.current;
-      if (delta > 0) container.scrollTop += delta;
+      if (scrollHeightBeforeRef.current === 0) return;
+      const delta = document.documentElement.scrollHeight - scrollHeightBeforeRef.current;
+      if (delta > 0) window.scrollBy({ top: delta, behavior: 'instant' });
       scrollHeightBeforeRef.current = 0;
       // Release the guard after the browser has painted
       requestAnimationFrame(() => {
@@ -225,16 +225,16 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     // ── Bottom sentinel: load past dates (append) ─────────────────────────────
 
     useEffect(() => {
-      const container = containerRef.current;
       const sentinel = bottomSentinelRef.current;
-      if (!container || !sentinel) return;
+      if (!sentinel) return;
 
       const observer = new IntersectionObserver(
         ([entry]) => {
           if (!entry.isIntersecting) return;
           setDateWindow(w => ({ ...w, start: addDays(w.start, -7) }));
         },
-        { root: container, threshold: 0 },
+        // root:null = window viewport; 600px bottom margin fires before sentinel scrolls into view
+        { rootMargin: '0px 0px 600px 0px', threshold: 0 },
       );
       observer.observe(sentinel);
       return () => observer.disconnect();
@@ -243,8 +243,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     // ── Visible date IO — ratioMap pattern to avoid oscillation ──────────────
 
     useEffect(() => {
-      if (!onVisibleDateChange || !containerRef.current) return;
-      const container = containerRef.current;
+      if (!onVisibleDateChange) return;
       const ratioMap = new Map<string, number>();
 
       const observer = new IntersectionObserver(
@@ -270,7 +269,8 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
             onVisibleDateChange(bestId);
           }
         },
-        { root: container, rootMargin: '0px 0px -50% 0px', threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0] },
+        // root:null = window viewport; focus on top ~40% of viewport to pick the "current" date
+        { rootMargin: '-10% 0px -50% 0px', threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0] },
       );
 
       dateGroupRefs.current.forEach(el => el && observer.observe(el));

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -95,6 +95,9 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
     // Append guard — prevents burst-loading when bottom sentinel stays visible
     const isAppendingRef = useRef(false);
 
+    // Suppress sentinel firing until the initial mount scroll has completed
+    const mountScrollDoneRef = useRef(false);
+
     // Off-window scroll: key to scroll to once the window is rebuilt around it
     const pendingScrollKeyRef = useRef<string | null>(null);
 
@@ -109,18 +112,19 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       const anchor = initialDate ?? new Date();
       return {
         start: addDays(anchor, -14),
-        end: addDays(anchor, 7),
+        end: addDays(anchor, 14),
       };
     });
 
-    // Descending list of all dates in the window (newest → oldest)
+    // Ascending list of all dates in the window (oldest → newest).
+    // Today sits in the middle; scroll up = past, scroll down = future.
     const dates = useMemo(() => {
       const result: Date[] = [];
-      let d = new Date(dateWindow.end);
-      const stop = dateWindow.start;
-      while (d >= stop) {
+      let d = new Date(dateWindow.start);
+      const stop = dateWindow.end;
+      while (d <= stop) {
         result.push(new Date(d));
-        d = addDays(d, -1);
+        d = addDays(d, 1);
       }
       return result;
     }, [dateWindow]);
@@ -175,15 +179,31 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
           suppressReportUntilScrollEnd();
           scrollToElement(el);
         } else {
-          // Date is outside the current window — rebuild window around this date
+          // Date is outside the current window — rebuild symmetric window around it
           pendingScrollKeyRef.current = key;
           setDateWindow({
             start: addDays(date, -14),
-            end: addDays(date, 7),
+            end: addDays(date, 14),
           });
         }
       },
     }), [suppressReportUntilScrollEnd, scrollToElement]);
+
+    // On mount: instantly scroll to today (or initialDate) so it appears at the top.
+    // Sentinels are suppressed until this completes to avoid mount-time burst loading.
+    useEffect(() => {
+      const key = localDateKey(initialDate ?? new Date());
+      const el = dateGroupRefs.current.get(key);
+      if (el) {
+        const top = el.getBoundingClientRect().top + window.scrollY - stickyOffset - 8;
+        window.scrollTo({ top, behavior: 'instant' });
+      }
+      requestAnimationFrame(() => {
+        mountScrollDoneRef.current = true;
+      });
+      // Intentionally run only on mount; deps are stable
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // After window rebuild: complete a pending off-window scroll once dates are rendered
     useEffect(() => {
@@ -196,7 +216,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       requestAnimationFrame(() => scrollToElement(el));
     }, [dates, suppressReportUntilScrollEnd, scrollToElement]);
 
-    // ── Top sentinel: load future dates (prepend) ─────────────────────────────
+    // ── Top sentinel: load past dates (prepend older at top) ─────────────────
 
     useEffect(() => {
       const sentinel = topSentinelRef.current;
@@ -204,14 +224,14 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
       const observer = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting || isPrependingRef.current) return;
+          if (!entry.isIntersecting || isPrependingRef.current || !mountScrollDoneRef.current) return;
           isPrependingRef.current = true;
-          // Anchor on the first visible date group so we can compensate after DOM grows
+          // Anchor on the current visible date group to compensate after DOM grows above
           const anchorKey = lastReportedRef.current;
           const anchorEl = anchorKey ? dateGroupRefs.current.get(anchorKey) : [...dateGroupRefs.current.values()][0];
           prependAnchorElRef.current = anchorEl ?? null;
           prependAnchorTopRef.current = anchorEl ? anchorEl.getBoundingClientRect().top : 0;
-          setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
+          setDateWindow(w => ({ ...w, start: addDays(w.start, -7) }));
         },
         // root:null = window viewport; 600px top margin fires ~4 date groups before hitting top
         { rootMargin: '600px 0px 0px 0px', threshold: 0 },
@@ -220,7 +240,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       return () => observer.disconnect();
     }, []);
 
-    // After prepend: compensate scroll using the anchor element's position delta
+    // After prepend: compensate scroll so the viewport stays on the same date
     useLayoutEffect(() => {
       const el = prependAnchorElRef.current;
       if (!el) return;
@@ -231,9 +251,9 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       requestAnimationFrame(() => {
         isPrependingRef.current = false;
       });
-    }, [dateWindow.end]);
+    }, [dateWindow.start]);
 
-    // ── Bottom sentinel: load past dates (append) ─────────────────────────────
+    // ── Bottom sentinel: load future dates (append newer at bottom) ───────────
 
     useEffect(() => {
       const sentinel = bottomSentinelRef.current;
@@ -241,9 +261,9 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
 
       const observer = new IntersectionObserver(
         ([entry]) => {
-          if (!entry.isIntersecting || isAppendingRef.current) return;
+          if (!entry.isIntersecting || isAppendingRef.current || !mountScrollDoneRef.current) return;
           isAppendingRef.current = true;
-          setDateWindow(w => ({ ...w, start: addDays(w.start, -7) }));
+          setDateWindow(w => ({ ...w, end: addDays(w.end, 7) }));
         },
         // root:null = window viewport; 600px bottom margin fires ~4 date groups before hitting bottom
         { rootMargin: '0px 0px 600px 0px', threshold: 0 },
@@ -257,7 +277,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       requestAnimationFrame(() => {
         isAppendingRef.current = false;
       });
-    }, [dateWindow.start]);
+    }, [dateWindow.end]);
 
     // ── Visible date IO — top-proximity: pick the date group closest to sticky header ──
 
@@ -377,7 +397,8 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
                 </div>
               )}
 
-              {/* Ghost "Add note" row — always visible, invites creating an entry */}
+              {/* Ghost "Add note" row — only on today and future dates */}
+              {key >= todayKey && (
               <button
                 onClick={() => onCreateEntry(date)}
                 className="flex items-center gap-3 mx-4 my-2 px-4 py-2.5 rounded-lg border border-dashed border-border/50 hover:border-primary/40 hover:bg-primary/5 transition-all text-left group w-[calc(100%-2rem)]"
@@ -389,6 +410,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
                   Add note for {date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
                 </span>
               </button>
+              )}
             </div>
           );
         })}

--- a/playground/src/views/queriable-list/types.ts
+++ b/playground/src/views/queriable-list/types.ts
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { CommandPaletteResult } from '../../components/command-palette/types';
 
 export interface QueryObject {
   text?: string;

--- a/src/components/Editor/extensions/section-geometry.ts
+++ b/src/components/Editor/extensions/section-geometry.ts
@@ -32,24 +32,30 @@ export interface SectionRect {
 }
 
 /** Callback type for geometry change listeners */
-export type GeometryListener = (rects: SectionRect[]) => void;
+export type GeometryListener = (rects: SectionRect[], docVersion: number) => void;
 
 // ── Plugin ───────────────────────────────────────────────────────────
 
 class SectionGeometryPlugin {
   rects: SectionRect[] = [];
+  /** Increments only on `update.docChanged` — safe to use as a memo dep. */
+  docVersion: number = 0;
   private listeners: Set<GeometryListener> = new Set();
+  private pendingNotify: number | null = null;
 
   constructor(private view: EditorView) {
     this.measure();
   }
 
   update(update: ViewUpdate) {
-    if (
-      update.docChanged ||
-      update.viewportChanged ||
-      update.geometryChanged
-    ) {
+    // viewportChanged fires on scroll but rects are document-space coordinates
+    // (lineBlockAt returns positions relative to scroll content, not viewport).
+    // Scroll cannot change rect values — skip remeasure to avoid a render storm
+    // on every scroll tick. geometryChanged covers resize/line-height changes.
+    if (update.docChanged) {
+      this.docVersion++;
+    }
+    if (update.docChanged || update.geometryChanged) {
       this.measure();
     }
   }
@@ -58,7 +64,7 @@ class SectionGeometryPlugin {
   addListener(fn: GeometryListener): () => void {
     this.listeners.add(fn);
     // Deliver current state immediately
-    fn(this.rects);
+    fn(this.rects, this.docVersion);
     return () => this.listeners.delete(fn);
   }
 
@@ -101,12 +107,20 @@ class SectionGeometryPlugin {
   }
 
   private notify() {
-    for (const fn of this.listeners) {
-      fn(this.rects);
-    }
+    // Debounce via RAF: multiple CM6 updates within one frame (e.g. scroll +
+    // viewport change) coalesce into a single listener call, preventing a
+    // render storm that would feed back into scroll events.
+    if (this.pendingNotify !== null) return;
+    this.pendingNotify = requestAnimationFrame(() => {
+      this.pendingNotify = null;
+      for (const fn of this.listeners) {
+        fn(this.rects, this.docVersion);
+      }
+    });
   }
 
   destroy() {
+    if (this.pendingNotify !== null) cancelAnimationFrame(this.pendingNotify);
     this.listeners.clear();
   }
 }

--- a/src/components/Editor/overlays/InlineCommandBar.tsx
+++ b/src/components/Editor/overlays/InlineCommandBar.tsx
@@ -145,6 +145,7 @@ export const InlineCommandBar: React.FC<InlineCommandBarProps> = ({
   commands,
 }) => {
   const [rects, setRects] = useState<SectionRect[]>([]);
+  const [scrollTop, setScrollTop] = useState(0);
 
   // Subscribe to geometry changes from the CM6 plugin
   useEffect(() => {
@@ -154,10 +155,32 @@ export const InlineCommandBar: React.FC<InlineCommandBarProps> = ({
     if (!plugin) return;
 
     // addListener delivers current rects immediately and returns an unsubscribe fn
+    // Second arg (docVersion) is unused here — only rects are needed.
     const unsubscribe = plugin.addListener((newRects: SectionRect[]) =>
       setRects([...newRects]),
     );
     return unsubscribe;
+  }, [view]);
+
+  // Track cm-scroller scroll to compensate rect.top (document-space) for scroll offset.
+  // RAF-throttled to prevent a setState on every scroll pixel.
+  useEffect(() => {
+    if (!view) return;
+    const scroller = view.scrollDOM;
+    let rafId: number | null = null;
+    const onScroll = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        setScrollTop(scroller.scrollTop);
+      });
+    };
+    scroller.addEventListener('scroll', onScroll, { passive: true });
+    setScrollTop(scroller.scrollTop);
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      scroller.removeEventListener('scroll', onScroll);
+    };
   }, [view]);
 
   if (!view || commands.length === 0) return null;
@@ -184,7 +207,9 @@ export const InlineCommandBar: React.FC<InlineCommandBarProps> = ({
             key={rect.sectionId}
             className="absolute right-1 z-10 flex items-center gap-1 pointer-events-auto"
             style={{
-              top: rect.top + 2,
+              // rect.top is document-space; subtract scrollTop to get the correct
+              // position relative to .cm-note-editor as the editor scrolls.
+              top: rect.top - scrollTop + 2,
             }}
           >
             {commands.map((cmd) => (

--- a/src/components/Editor/overlays/OverlayTrack.tsx
+++ b/src/components/Editor/overlays/OverlayTrack.tsx
@@ -84,6 +84,10 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
   cursorLine,
 }) => {
   const trackRef = useRef<HTMLDivElement>(null);
+  // innerRef: the scroll-synced div. We update its transform directly on scroll
+  // (bypassing React's render cycle) for smooth visual sync, and also update
+  // scrollTop state (RAF-throttled) for stickyTopOffset calculations.
+  const innerRef = useRef<HTMLDivElement>(null);
   const [rects, setRects] = useState<SectionRect[]>([]);
   const [scrollTop, setScrollTop] = useState(0);
   const [contentInsets, setContentInsets] = useState<{ left: number; right: number }>({ left: 0, right: 0 });
@@ -107,56 +111,106 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
     return () => observer.disconnect();
   }, [view]);
 
-  // MutationObserver → docVersion bump on every CM6 dispatch
-  useEffect(() => {
-    if (!view) return;
-    const observer = new MutationObserver(() => setDocVersion((v) => v + 1));
-    observer.observe(view.contentDOM, { childList: true, subtree: true, characterData: true });
-    return () => observer.disconnect();
-  }, [view]);
-
-  // Section geometry subscription
+  // Section geometry subscription — also carries docVersion (incremented only
+  // on CM6 `update.docChanged`, not on scroll-driven DOM virtualization).
+  // This replaces the old MutationObserver so docVersion no longer fires
+  // spuriously when CM6 virtualizes lines during scroll.
   useEffect(() => {
     if (!view) return;
     const plugin = view.plugin(sectionGeometry);
     if (!plugin) return;
-    return plugin.addListener(setRects);
+    return plugin.addListener((newRects, newDocVersion) => {
+      setRects(newRects);
+      setDocVersion(newDocVersion);
+    });
   }, [view]);
 
-  // Scroll sync
+  // Scroll sync — two-track approach to prevent feedback loops:
+  // 1. Direct DOM mutation on the inner div for immediate visual alignment
+  //    (bypasses React render cycle entirely, no jitter).
+  // 2. RAF-throttled state update for stickyTopOffset calculations
+  //    (can lag one frame without visible effect on strip positioning).
   useEffect(() => {
     if (!view) return;
     const scroller = view.scrollDOM;
-    const handleScroll = () => setScrollTop(scroller.scrollTop);
-    setScrollTop(scroller.scrollTop);
+    let rafId: number | null = null;
+
+    const handleScroll = () => {
+      const st = scroller.scrollTop;
+      // Immediate: keep the overlay aligned without waiting for React
+      if (innerRef.current) {
+        innerRef.current.style.transform = `translateY(${-st}px)`;
+      }
+      // Throttled: update React state for stickyTopOffset (once per frame)
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        setScrollTop(scroller.scrollTop);
+      });
+    };
+
+    // Initialise both
+    const initialSt = scroller.scrollTop;
+    if (innerRef.current) {
+      innerRef.current.style.transform = `translateY(${-initialSt}px)`;
+    }
+    setScrollTop(initialSt);
+
     scroller.addEventListener("scroll", handleScroll, { passive: true });
-    return () => scroller.removeEventListener("scroll", handleScroll);
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      scroller.removeEventListener("scroll", handleScroll);
+    };
   }, [view]);
 
   // Hover-line tracking at DOCUMENT level so events fire even when the
   // mouse is over the overlay panel (which is a sibling of the CM scroller,
   // not a child, so scroller-level listeners miss those events).
+  // Guard: only call setHoverLine when the line number actually changes to
+  // prevent re-rendering the overlay on every mousemove pixel.
   useEffect(() => {
     if (!view) return;
     const scroller = view.scrollDOM;
+    const hoverLineRef = { current: undefined as number | undefined };
     const handleMouseMove = (e: MouseEvent) => {
       const bounds = scroller.getBoundingClientRect();
       if (
         e.clientY < bounds.top || e.clientY > bounds.bottom ||
         e.clientX < bounds.left || e.clientX > bounds.right
       ) {
-        setHoverLine(undefined);
+        if (hoverLineRef.current !== undefined) {
+          hoverLineRef.current = undefined;
+          setHoverLine(undefined);
+        }
         return;
       }
       try {
         const pos = view.posAtCoords({ x: e.clientX, y: e.clientY });
-        if (pos == null) { setHoverLine(undefined); return; }
-        setHoverLine(view.state.doc.lineAt(pos).number);
+        if (pos == null) {
+          if (hoverLineRef.current !== undefined) {
+            hoverLineRef.current = undefined;
+            setHoverLine(undefined);
+          }
+          return;
+        }
+        const line = view.state.doc.lineAt(pos).number;
+        if (line !== hoverLineRef.current) {
+          hoverLineRef.current = line;
+          setHoverLine(line);
+        }
       } catch {
+        if (hoverLineRef.current !== undefined) {
+          hoverLineRef.current = undefined;
+          setHoverLine(undefined);
+        }
+      }
+    };
+    const handleMouseLeave = () => {
+      if (hoverLineRef.current !== undefined) {
+        hoverLineRef.current = undefined;
         setHoverLine(undefined);
       }
     };
-    const handleMouseLeave = () => setHoverLine(undefined);
     document.addEventListener("mousemove", handleMouseMove, { passive: true });
     scroller.addEventListener("mouseleave", handleMouseLeave);
     return () => {
@@ -188,9 +242,9 @@ export const OverlayTrack: React.FC<OverlayTrackProps> = ({
       }}
     >
       <div
+        ref={innerRef}
         style={{
           position: "relative",
-          transform: `translateY(${-scrollTop}px)`,
           willChange: "transform",
         }}
       >

--- a/src/components/ui/CalendarDatePicker.tsx
+++ b/src/components/ui/CalendarDatePicker.tsx
@@ -6,7 +6,7 @@
  * Optionally shows dots/highlights for dates that have entries.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -49,6 +49,17 @@ export const CalendarDatePicker: React.FC<CalendarDatePickerProps> = ({
   const [viewDate, setViewDate] = useState(() => selectedDate || new Date());
   const year = viewDate.getFullYear();
   const month = viewDate.getMonth();
+
+  // Navigate the calendar to match selectedDate's month when it changes (e.g. scroll-driven)
+  useEffect(() => {
+    if (!selectedDate) return;
+    setViewDate(prev => {
+      if (prev.getFullYear() !== selectedDate.getFullYear() || prev.getMonth() !== selectedDate.getMonth()) {
+        return new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1);
+      }
+      return prev;
+    });
+  }, [selectedDate]);
 
   const selectedKey = selectedDate ? toDateKey(selectedDate) : null;
 

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -100,6 +100,14 @@ export function CanvasPage({
   const programmaticScrollTargetRef = useRef<string | null>(null);
   const programmaticScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Clear any pending programmatic-scroll timeout on unmount to avoid stray timers.
+  useEffect(() => {
+    return () => {
+      if (programmaticScrollTimeoutRef.current !== null)
+        clearTimeout(programmaticScrollTimeoutRef.current);
+    };
+  }, []);
+
   // ── Sections mode: local active section tracking ───────────────────────
   const [activeSection, setActiveSection] = useState(sections?.[0]?.id ?? '');
   const sectionRefs = useRef<Map<string, HTMLDivElement>>(new Map());

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -85,25 +85,52 @@ export function CanvasPage({
   const useStickyNavMode = hasSections && !title;
 
   // ── Title-bar mode: URL-synced active section ──────────────────────────
+  // shallow:true avoids full router re-renders on scroll-driven updates.
+  // Observer-driven writes use 'replace' (no history entry per scroll step);
+  // explicit TOC clicks use 'push' (preserves browser Back navigation).
   const [activeId, setActiveId] = useQueryState('s', {
     defaultValue: activeSectionId ?? index[0]?.id ?? '',
-    shallow: false,
-    history: 'push',
+    shallow: true,
+    history: 'replace',
   });
+
+  // Ref set during programmatic smooth-scroll; suppresses observer-driven
+  // active-section updates until the target section actually becomes visible.
+  // Cleared by a timeout (smooth scroll typically finishes within 800 ms).
+  const programmaticScrollTargetRef = useRef<string | null>(null);
+  const programmaticScrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ── Sections mode: local active section tracking ───────────────────────
   const [activeSection, setActiveSection] = useState(sections?.[0]?.id ?? '');
   const sectionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
-  // IntersectionObserver — title-bar mode (tracks index links by element id)
+  // IntersectionObserver — title-bar mode (tracks index links by element id).
+  // Uses a persistent ratioMap so the winner is the most-visible of ALL currently
+  // intersecting sections, not just the batch in the current callback — prevents
+  // oscillation when multiple threshold crossings fire in quick succession.
+  // Observer-driven writes are suppressed during programmatic smooth-scroll until
+  // the target section becomes most-visible (prevents nav flicker mid-animation).
   useEffect(() => {
     if (useStickyNavMode || index.length === 0) return;
+    const ratioMap = new Map<string, number>();
+    const lastActiveRef = { current: '' };
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
-        if (visible.length > 0) setActiveId(visible[0].target.id);
+        entries.forEach((e) => {
+          if (e.isIntersecting) ratioMap.set(e.target.id, e.intersectionRatio);
+          else ratioMap.delete(e.target.id);
+        });
+        let bestId = '';
+        let bestRatio = -1;
+        ratioMap.forEach((ratio, id) => {
+          if (ratio > bestRatio) { bestRatio = ratio; bestId = id; }
+        });
+        if (!bestId || bestId === lastActiveRef.current) return;
+        // During programmatic scroll, only allow the target section to win.
+        const target = programmaticScrollTargetRef.current;
+        if (target && bestId !== target) return;
+        lastActiveRef.current = bestId;
+        setActiveId(bestId);
       },
       { rootMargin: '-10% 0px -40% 0px', threshold: [0, 0.3, 1.0] },
     );
@@ -114,17 +141,27 @@ export function CanvasPage({
     return () => observer.disconnect();
   }, [index, setActiveId, useStickyNavMode]);
 
-  // IntersectionObserver — sections mode (tracks section divs via refs)
+  // IntersectionObserver — sections mode (tracks section divs via refs).
+  // Same ratioMap pattern to prevent oscillation.
   useEffect(() => {
     if (!useStickyNavMode) return;
+    const ratioMap = new Map<string, number>();
+    const lastActiveRef = { current: '' };
     const observer = new IntersectionObserver(
       (entries) => {
-        const visible = entries
-          .filter((e) => e.isIntersecting)
-          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
-        if (visible.length > 0) {
-          const id = visible[0].target.getAttribute('data-section-id');
-          if (id) setActiveSection(id);
+        entries.forEach((e) => {
+          const id = e.target.getAttribute('data-section-id') ?? '';
+          if (e.isIntersecting) ratioMap.set(id, e.intersectionRatio);
+          else ratioMap.delete(id);
+        });
+        let bestId = '';
+        let bestRatio = -1;
+        ratioMap.forEach((ratio, id) => {
+          if (ratio > bestRatio) { bestRatio = ratio; bestId = id; }
+        });
+        if (bestId && bestId !== lastActiveRef.current) {
+          lastActiveRef.current = bestId;
+          setActiveSection(bestId);
         }
       },
       { rootMargin: '-20% 0px -50% 0px', threshold: [0, 0.25, 0.5, 0.75] },
@@ -135,7 +172,16 @@ export function CanvasPage({
 
   const scrollToSection = (id: string) => {
     onScrollToSection?.(id);
-    setActiveId(id);
+    // Push history for explicit user clicks (preserves browser Back navigation).
+    setActiveId(id, { history: 'push' });
+    // Suppress observer-driven updates until smooth scroll completes so the nav
+    // highlight doesn't flicker through intermediate sections during animation.
+    if (programmaticScrollTimeoutRef.current !== null)
+      clearTimeout(programmaticScrollTimeoutRef.current);
+    programmaticScrollTargetRef.current = id;
+    programmaticScrollTimeoutRef.current = setTimeout(() => {
+      programmaticScrollTargetRef.current = null;
+    }, 900);
     const el = document.getElementById(id);
     if (el) {
       const y = el.getBoundingClientRect().top + window.scrollY - 100;

--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -79,10 +79,12 @@ export function JournalPageShell({
   onCloseReview,
   className,
 }: JournalPageShellProps) {
+  // Use shallow:true + replace so scroll-driven IO updates don't trigger
+  // full router re-renders (same fix as CanvasPage.tsx).
   const [activeId, setActiveId] = useQueryState('s', {
     defaultValue: activeSectionId ?? index[0]?.id ?? '',
-    shallow: false,
-    history: 'push',
+    shallow: true,
+    history: 'replace',
   });
 
   // Internal scroll tracking if not controlled

--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -110,7 +110,7 @@ export function JournalPageShell({
 
   const scrollToSection = (id: string) => {
     onScrollToSection?.(id);
-    setActiveId(id);
+    setActiveId(id, { history: 'push' });
     const el = document.getElementById(id);
     if (el) {
       const y = el.getBoundingClientRect().top + window.scrollY - 100;


### PR DESCRIPTION
This pull request implements a major redesign of the journal view, replacing the old weekly list with an infinite, date-centric scroll view and improving both UX and technical architecture. It also updates the Editor overlay system for smoother, more accurate positioning during scroll, and makes several improvements to state and scroll handling.

**Journal View Redesign and Infinite Scroll**

* The `/journal` route is now a date scroll view (`JournalDateScroll`) with infinite scroll in both directions, centered on today, and with "Add note" prompts for today and future dates. The documentation is updated to reflect the new layout, scroll logic, and state management.
* `JournalWeeklyPage` is replaced by `JournalDateScroll` in the UI, with imperative scroll-to-date and visible-date reporting for URL sync. The component now receives an `onCreateEntry` callback and manages scroll suppression and sentinel logic for window extension. [[1]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaL14-R26) [[2]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaL33-R61) [[3]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaL88-L95)
* The `useJournalQueryState` hook now uses shallow routing for all params and ensures dates are always formatted as `YYYY-MM-DD`. [[1]](diffhunk://#diff-d3cc5688311e1bbebfc421b26cec27fbabf0ff3ffc0b386da00d230c0d960398L31-R31) [[2]](diffhunk://#diff-d3cc5688311e1bbebfc421b26cec27fbabf0ff3ffc0b386da00d230c0d960398L48-R51) [[3]](diffhunk://#diff-d3cc5688311e1bbebfc421b26cec27fbabf0ff3ffc0b386da00d230c0d960398L57-R60) [[4]](diffhunk://#diff-d3cc5688311e1bbebfc421b26cec27fbabf0ff3ffc0b386da00d230c0d960398L80-R83)

**Editor Overlay Improvements**

* The Editor's section geometry tracking now includes a `docVersion` for more reliable memoization, debounces listener notifications via `requestAnimationFrame`, and only remeasures on document or geometry changes (not scroll), reducing unnecessary renders. [[1]](diffhunk://#diff-2d278d014021e4cafec9d8fc584b1e1274fddcdb0df2d9bb2ab62f4e117f62f4L35-R58) [[2]](diffhunk://#diff-2d278d014021e4cafec9d8fc584b1e1274fddcdb0df2d9bb2ab62f4e117f62f4L61-R67) [[3]](diffhunk://#diff-2d278d014021e4cafec9d8fc584b1e1274fddcdb0df2d9bb2ab62f4e117f62f4R110-R123)
* The `InlineCommandBar` and `OverlayTrack` overlays now compensate for editor scroll by tracking `scrollTop` and adjusting overlay positions in real time, ensuring overlays stay visually aligned with their sections during smooth scroll. [[1]](diffhunk://#diff-7955974349d746c97496a872764057d7aa490c87f4c8fcfcde75ab6473d7860aR148) [[2]](diffhunk://#diff-7955974349d746c97496a872764057d7aa490c87f4c8fcfcde75ab6473d7860aR158-R185) [[3]](diffhunk://#diff-7955974349d746c97496a872764057d7aa490c87f4c8fcfcde75ab6473d7860aL187-R212) [[4]](diffhunk://#diff-e02f81a851a8d738e0c5982f2abf3fc952c434c46ece17719be3143a2e84759eR87-R90)

**Other Improvements**

* The `onCreateEntry` handler is now passed through from `App.tsx` to the journal scroll view, enabling direct creation of new entries for any date. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R1028-R1039) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R1241)
* Minor cleanup: removes an unused import from `types.ts`.

These changes collectively deliver a more modern, scalable journal browsing experience and a more robust Editor overlay system, with improved scroll handling and state synchronization throughout.