### PR TITLE
Improve accessibility of autoFocus logic for touch devices

### DIFF
--- a/playground/src/views/queriable-list/FuzzySearchQuery.tsx
+++ b/playground/src/views/queriable-list/FuzzySearchQuery.tsx
@@ -21,7 +21,7 @@ export const FuzzySearchQuery: React.FC<QueryOrganismProps> = ({ onQueryChange, 
         placeholder="Search workouts, results, or notes..."
         value={text}
         onChange={(e) => setText(e.target.value)}
-        autoFocus
+        autoFocus={typeof window !== 'undefined' && !window.matchMedia('(pointer: coarse)').matches}
       />
     </div>
   );


### PR DESCRIPTION
This pull request makes a small usability improvement to the `FuzzySearchQuery` component. The change updates the `autoFocus` behavior so that the search input only auto-focuses on devices that do not have a coarse pointer (i.e., typically non-touch devices). This prevents the on-screen keyboard from popping up automatically on touch devices, improving the user experience.…y on touch devices