### PR TITLE
Refactor navigation components and enhance list views with actions

### DIFF
--- a/docs/page-navigation-contract.md
+++ b/docs/page-navigation-contract.md
@@ -1,0 +1,829 @@
+
+
+
+
+# Page Navigation Contract
+
+This document defines the **standard vocabulary and contract** for how every page in WOD Wiki sets its navigation values as it loads, and the **`INavActivation` interface** that all activatable UI elements — nav items, playground links, header action buttons, and keyboard bindings — must implement.
+
+It is the authoritative reference for:
+
+- Developers implementing new pages or refactoring existing ones
+- Developers wiring up buttons, links, or keyboard shortcuts that trigger navigation
+- Documentation authors describing what a page does
+- Anyone adding markdown canvas pages that need consistent navigation integration
+
+---
+
+## Navigation Model — Three Levels
+
+The app sidebar and header display a three-level navigation tree. Every page must declare, on load, what it contributes to each level.
+
+| Level | Name | Description | Who sets it |
+|-------|------|-------------|-------------|
+| **L1** | **Section** | Top-level app area (Home, Journal, Collections, Search) | Static — `appNavTree` |
+| **L2** | **Context** | Sub-section, filter panel, or child pages within the active L1 | Static (canvas pages) or dynamic (filter panels) |
+| **L3** | **Page Index** | Scroll anchors for the current page — headings, entries, or wod blocks | **Dynamic — set by each page at load time** |
+
+**Only L3 changes per-page load.** L1 and L2 activation is derived from the current route matching `appNavTree` entries.
+
+---
+
+## The `INavActivation` Interface
+
+Every activatable UI element — nav tree items, playground links, page-index entries, header action buttons, and keyboard bindings — must implement `INavActivation`. This creates a single, typed contract that all rendering surfaces can consume without needing to know the element's origin.
+
+### Core interface
+
+```typescript
+/**
+ * INavActivation — base contract for any activatable UI element.
+ *
+ * Implemented by: NavItem, PageNavLink, PlaygroundLink, toolbar buttons,
+ * keyboard shortcut bindings, and any future navigation surface.
+ */
+export interface INavActivation {
+  /** Unique stable identifier (used as React key and anchor id). */
+  id: string
+
+  /** Display text shown in sidebar, header, TOC panel, and tooltips. */
+  label: string
+
+  /** Optional icon component. Receives `className` for size/color. */
+  icon?: React.ComponentType<{ className?: string }>
+
+  /** What happens when this element is activated. */
+  action: INavAction
+}
+```
+
+### Action child types
+
+All action shapes are discriminated by `type`. Every rendering surface dispatches via the same `executeNavAction(action, deps)` helper so individual buttons/links carry zero routing logic.
+
+```typescript
+/**
+ * INavAction — polymorphic action attached to any INavActivation.
+ *
+ * Navigation actions:
+ *   route   — navigate to a new route
+ *   query   — update URL query params (scroll/filter state)
+ *
+ * View container actions (canvas pages):
+ *   view-source  — swap the sticky editor panel's content
+ *   view-state   — transition the panel state machine
+ *
+ * Composition:
+ *   pipeline     — execute a sequence of actions in order
+ *   call         — invoke an arbitrary handler
+ *   none         — no-op (expand/collapse only)
+ */
+export type INavAction =
+  | RouteChangeAction
+  | RouteQueryAction
+  | ViewSourceAction
+  | ViewStateAction
+  | PipelineAction
+  | CallAction
+  | NoneAction
+
+/**
+ * Navigate to a new route. Replaces the current history entry by default.
+ * Set pushHistory: true when the navigation should be undoable via Back.
+ */
+export interface RouteChangeAction {
+  type: 'route'
+  to: string
+  pushHistory?: boolean   // default: true (navigate adds an entry)
+}
+
+/**
+ * Update URL query parameters without a full route change.
+ * Used for scroll position, active section, filter state, and any
+ * transient UI state that should be shareable/bookmarkable.
+ *
+ * pushHistory defaults to false so that scroll events don't flood
+ * the browser history stack (replaceState semantics).
+ */
+export interface RouteQueryAction {
+  type: 'query'
+  /** Key/value pairs to merge into the current search string.
+   *  Pass null for a value to remove that key entirely. */
+  params: Record<string, string | null>
+  pushHistory?: boolean   // default: false (replaceState)
+}
+
+/**
+ * Swap the sticky view panel's editor source content.
+ * Replaces the current PipelineStep { action: 'set-source', value } pattern.
+ * The panel performs a fade-swap transition (180 ms opacity cross-fade).
+ */
+export interface ViewSourceAction {
+  type: 'view-source'
+  /** Resolved file path or inline wod content string. */
+  source: string
+}
+
+/**
+ * Transition the view panel's state machine.
+ * Replaces the current PipelineStep { action: 'set-state', value } pattern.
+ *
+ * States:
+ *   'note'    — show the NoteEditor (default / reset)
+ *   'track'   — compile + launch the first WOD block
+ *   'review'  — show the post-workout review panel
+ *
+ * The `open` field controls where 'track' launches the runtime:
+ *   'view'    — inline in the sticky panel (default for scroll-triggered commands)
+ *   'dialog'  — fullscreen overlay (FullscreenTimer)
+ *   'route'   — navigate to /tracker/:runtimeId (full-page tracker)
+ */
+export interface ViewStateAction {
+  type: 'view-state'
+  state: 'note' | 'track' | 'review'
+  open?: 'view' | 'dialog' | 'route'  // only relevant when state = 'track'
+}
+
+/**
+ * Execute a sequence of actions in order.
+ * Replaces the PipelineStep[] array + executePipeline() pattern.
+ * Used by canvas ButtonBlock and CommandBlock which chain multiple steps.
+ *
+ * Example — a "Try It" button that loads a source file then launches tracking:
+ *   {
+ *     type: 'pipeline',
+ *     steps: [
+ *       { type: 'view-source', source: 'markdown/canvas/syntax/sample.md' },
+ *       { type: 'view-state',  state: 'track', open: 'view' },
+ *     ]
+ *   }
+ */
+export interface PipelineAction {
+  type: 'pipeline'
+  steps: INavAction[]
+}
+
+/**
+ * Invoke an arbitrary handler. Used for toolbar actions, play buttons,
+ * and any activation that doesn't produce a URL change.
+ */
+export interface CallAction {
+  type: 'call'
+  handler: () => void
+  /** Optional tooltip / aria-label override. Defaults to parent label. */
+  label?: string
+}
+
+/**
+ * No-op — used for accordion group headers that expand/collapse only.
+ */
+export interface NoneAction {
+  type: 'none'
+}
+```
+
+### Dependency injection for action execution
+
+Child action types must not close over framework-specific hooks. Instead, a shared `NavActionDeps` object is passed at execution time by the rendering surface. Canvas pages supply the additional `view*` deps; nav-only surfaces leave them undefined.
+
+```typescript
+export interface NavActionDeps {
+  // ── Navigation ────────────────────────────────────────────────────────────
+  navigate:        (to: string, opts?: { replace?: boolean }) => void
+  setQueryParam:   (params: Record<string, string | null>, replace?: boolean) => void
+
+  // ── View container (canvas pages only) ───────────────────────────────────
+  /** Fade-swap the sticky editor panel's source content. */
+  swapSource?:     (source: string) => void
+  /** Transition the panel state machine. */
+  setPanelState?:  (state: 'note' | 'track' | 'review', open?: 'view' | 'dialog' | 'route') => void
+}
+
+/**
+ * executeNavAction — the single dispatch function used by all rendering
+ * surfaces (sidebar rows, dropdown items, keyboard bindings, canvas buttons,
+ * scroll-triggered commands).
+ *
+ * View-container actions are silently skipped on surfaces that don't supply
+ * the optional view deps, so the same INavAction shapes are safe to use
+ * everywhere.
+ */
+export function executeNavAction(action: INavAction, deps: NavActionDeps): void {
+  switch (action.type) {
+    case 'route':
+      deps.navigate(action.to, { replace: !(action.pushHistory ?? true) })
+      break
+    case 'query':
+      deps.setQueryParam(action.params, !(action.pushHistory ?? false))
+      break
+    case 'view-source':
+      deps.swapSource?.(action.source)
+      break
+    case 'view-state':
+      deps.setPanelState?.(action.state, action.open)
+      break
+    case 'pipeline':
+      action.steps.forEach(step => executeNavAction(step, deps))
+      break
+    case 'call':
+      action.handler()
+      break
+    case 'none':
+      break
+  }
+}
+```
+
+### `setLayout` — declaring nav items per level
+
+Pages declare their navigation items through a single `setLayout` call. The `target` identifies which nav level the items belong to. For L1 and L2 the call is mostly static (driven by `appNavTree`); for L3 every page calls this on load.
+
+```typescript
+type NavLevel = 'l1' | 'l2' | 'l3'
+
+/**
+ * setLayout — registers an array of INavActivation items for a given
+ * navigation level. Called by AppContent and individual page components.
+ *
+ * @param target   Which level to populate.
+ * @param items    Ordered list of activations. Pass [] to clear.
+ *
+ * Examples:
+ *
+ *   // Static L1 (called once in AppContent on bootstrap)
+ *   setLayout('l1', [
+ *     { id: 'home',        label: 'Home',        icon: HomeIcon,   action: { type: 'route', to: '/' } },
+ *     { id: 'journal',     label: 'Journal',     icon: ListIcon,   action: { type: 'route', to: '/journal' } },
+ *     { id: 'collections', label: 'Collections', icon: FolderIcon, action: { type: 'route', to: '/collections' } },
+ *     { id: 'search',      label: 'Search',      icon: SearchIcon, action: { type: 'route', to: '/search' } },
+ *   ])
+ *
+ *   // Dynamic L3 (called by each page on mount, cleared on unmount)
+ *   setLayout('l3', sections.map(s => ({
+ *     id:     s.id,
+ *     label:  s.label,
+ *     action: { type: 'query', params: { s: s.id }, pushHistory: false },
+ *   })))
+ */
+function setLayout(target: NavLevel, items: INavActivation[]): void
+```
+
+### Inheritance — how existing types map to `INavActivation`
+
+All current nav primitives are direct implementations of `INavActivation`. No breaking changes are required; the mapping is additive.
+
+| Existing type | Inherits from | Action type used | Notes |
+|---|---|---|---|
+| `NavItem` (L1/L2) | `INavActivation` | `route` or `none` | Adds `level`, `children`, `panel`, `render`, `isActive`, `zones` |
+| `NavItemL3` | `INavActivation` | `query` (replaces `scroll`) | `scroll` → `RouteQueryAction { params: { s: sectionId } }` |
+| `PageNavLink` | `INavActivation` | `query` + optional `call` | `onRun` → `secondaryAction` of type `call` |
+| `ButtonBlock` | `INavActivation` | `pipeline` | `pipeline: PipelineStep[]` → `PipelineAction { steps: INavAction[] }` |
+| `CommandBlock` | `INavAction[]` (no label/icon) | `pipeline` | Scroll-triggered; no UI label needed — `INavAction[]` directly |
+| `ViewButton` | `INavActivation` | `pipeline` | Rendered in `ViewPanelButtons` next to the sticky panel |
+| Playground link | `INavActivation` | `route` | Route targets a `/playground/:id` path |
+| Toolbar button | `INavActivation` | `call` | Icon button with label used as `aria-label` |
+| Keyboard binding | `INavActivation` | any | Fires `executeNavAction(item.action, deps)` |
+
+---
+
+## Canvas View Container Automation
+
+Canvas pages have an additional layer of automation beyond navigation: the **view container** (sticky editor/runtime panel) can have its source content and state machine driven by scroll position and button clicks. These transitions are currently expressed as `PipelineStep[]` (stringly-typed). Under the `INavAction` model they become typed, composable, and dispatchable through the same `executeNavAction` helper.
+
+### The view container state machine
+
+```
+┌──────────────┐  view-state: track (open: view)  ┌───────────────┐
+│              │ ──────────────────────────────→  │               │
+│    'editor'  │                                  │   'running'   │
+│  (NoteEditor)│ ←──────────────────────────────  │ (RuntimePanel)│
+│              │  view-state: note  OR  onClose   │               │
+└──────────────┘                                  └───────────────┘
+       ↑                                                  │
+       │  view-state: note                   runtime completes naturally
+       │                                                  ↓
+       └──────────────────────────────────  ┌─────────────────────┐
+                                            │      'review'       │
+                                            │  (FullscreenReview) │
+                                            └─────────────────────┘
+```
+
+Parallel launch targets for `view-state: track`:
+
+| `open` value | Where runtime appears |
+|---|---|
+| `'view'` | Inline in the sticky panel (default for scroll-triggered commands) |
+| `'dialog'` | `FullscreenTimer` overlay (fullscreen over current page) |
+| `'route'` | Navigate to `/tracker/:runtimeId` (dedicated full-page tracker) |
+
+### Scroll-triggered commands (`CommandBlock` → `INavAction[]`)
+
+When a canvas section enters the viewport, its `commands` array fires. Each command is a sequence of steps — a direct `PipelineAction`. The `executePipeline()` function becomes `executeNavAction()`:
+
+```typescript
+// Current (stringly-typed)
+for (const cmd of section.commands) {
+  executePipeline(cmd.pipeline, cmd.open ?? 'view')
+}
+
+// Under INavAction (typed)
+for (const action of section.scrollActions) {
+  executeNavAction(action, deps)
+}
+
+// Where section.scrollActions is built from CommandBlock at parse time:
+const scrollActions: INavAction[] = section.commands.map(cmd => ({
+  type: 'pipeline',
+  steps: cmd.pipeline.map(step => pipelineStepToNavAction(step, cmd.open ?? 'view')),
+}))
+```
+
+### Button clicks (`ButtonBlock` / `ViewButton` → `INavActivation`)
+
+Canvas buttons become full `INavActivation` items:
+
+```typescript
+// A "Try It" button that loads a source file then starts the tracker inline:
+const tryItButton: INavActivation = {
+  id:     'try-amrap',
+  label:  'Try It',
+  icon:   PlayIcon,
+  action: {
+    type: 'pipeline',
+    steps: [
+      { type: 'view-source', source: 'markdown/canvas/syntax/amrap-sample.md' },
+      { type: 'view-state',  state: 'track', open: 'view' },
+    ],
+  },
+}
+
+// A "Full Screen" button that opens the tracker on its own page:
+const fullscreenButton: INavActivation = {
+  id:     'fullscreen-amrap',
+  label:  'Full Screen',
+  icon:   ArrowsPointingOutIcon,
+  action: { type: 'view-state', state: 'track', open: 'route' },
+}
+
+// A navigation button that moves to the next doc page:
+const nextButton: INavActivation = {
+  id:     'next-timers',
+  label:  'Next: Timers',
+  icon:   ChevronRightIcon,
+  action: { type: 'route', to: '/syntax/timers', pushHistory: true },
+}
+```
+
+### Mapping `PipelineStep` to `INavAction`
+
+The migration from the current stringly-typed system is a one-to-one mapping:
+
+| `PipelineStep` (current) | `INavAction` (standard) |
+|---|---|
+| `{ action: 'set-source', value: 'path/to/file.md' }` | `{ type: 'view-source', source: 'path/to/file.md' }` |
+| `{ action: 'set-state', value: 'note' }` | `{ type: 'view-state', state: 'note' }` |
+| `{ action: 'set-state', value: 'review' }` | `{ type: 'view-state', state: 'review' }` |
+| `{ action: 'set-state', value: 'track' }` + `open: 'view'` | `{ type: 'view-state', state: 'track', open: 'view' }` |
+| `{ action: 'set-state', value: 'track' }` + `open: 'dialog'` | `{ type: 'view-state', state: 'track', open: 'dialog' }` |
+| `{ action: 'set-state', value: 'track' }` + `open: 'route'` | `{ type: 'view-state', state: 'track', open: 'route' }` |
+| `{ action: 'navigate', value: '/syntax/timers' }` | `{ type: 'route', to: '/syntax/timers' }` |
+| Multiple steps in `pipeline[]` | `{ type: 'pipeline', steps: [...] }` |
+
+### Building `NavActionDeps` inside `MarkdownCanvasPage`
+
+The canvas page constructs the deps object once and passes it down to all rendering surfaces:
+
+```typescript
+// Inside MarkdownCanvasPage
+const deps: NavActionDeps = useMemo(() => ({
+  navigate,
+  setQueryParam: (params, replace) => {
+    setHeadingParam(params['h'] ?? null, { history: replace ? 'replace' : 'push' })
+  },
+  swapSource,
+  setPanelState: (state, open) => {
+    if (state === 'note') {
+      closeViewRuntime()
+    } else if (state === 'review') {
+      setPanelMode('review')
+    } else if (state === 'track') {
+      const block = wodBlocksRef.current[0] ?? null
+      if (!block) return
+      if (open === 'view')   launchViewRuntime(block)
+      if (open === 'dialog') setFullscreenBlock(block)
+      if (open === 'route') {
+        const runtimeId = uuidv4()
+        pendingRuntimes.set(runtimeId, { block, noteId: '' })
+        navigate(`/tracker/${runtimeId}`)
+      }
+    }
+  },
+}), [navigate, swapSource, closeViewRuntime, launchViewRuntime])
+```
+
+### Scroll-position query param (`?h=`)
+
+The active canvas section heading is tracked as a `RouteQueryAction` — the same interface used by L3 items — so the URL stays in sync with the viewport:
+
+```typescript
+// Fired by IntersectionObserver when the most-visible section changes
+executeNavAction(
+  { type: 'query', params: { h: bestId }, pushHistory: false },
+  deps
+)
+```
+
+This replaces the direct `setHeadingParamRef.current(bestId)` call, unifying scroll tracking across both nav-level L3 and canvas-level section tracking behind a single `RouteQueryAction`.
+
+---
+
+### Secondary actions
+
+Some items carry a secondary activation (e.g. a ▶ Play button alongside a section link). Secondary actions are expressed as a second `INavActivation` embedded in the item:
+
+```typescript
+export interface INavActivationWithSecondary extends INavActivation {
+  /** Optional secondary action rendered inline (e.g. Play button on a WOD block). */
+  secondaryAction?: INavActivation
+}
+```
+
+---
+
+## Terminology
+
+The following terms are used consistently throughout the codebase and all documentation:
+
+| Term | Definition |
+|------|-----------|
+| **`INavActivation`** | The base interface for every activatable UI element. Has `id`, `label`, `icon?`, and `action`. |
+| **`INavAction`** | The discriminated union of all action types (`route`, `query`, `call`, `none`). |
+| **`RouteChangeAction`** | An action that navigates to a new path via the router. |
+| **`RouteQueryAction`** | An action that updates URL query params without a route change. Used for scroll position, section tracking, and filter state. |
+| **`setLayout(target, items)`** | The standard API for a page to declare its nav items for a given level. |
+| **Page Title** | The string shown in the sticky header bar. Set via `CanvasPage title=` prop. |
+| **Subheader** | Optional content rendered below the title row — typically a `TextFilterStrip`. |
+| **Page Actions** | Right-side icon buttons in the sticky header (New Entry, Cast, Audio, Actions). Each implements `INavActivation` with a `call` action. |
+| **L3 Items** | The ordered list of `INavActivation` objects registered via `setLayout('l3', ...)` or `useSetNavL3()`. Displayed in the sidebar accordion and right-side TOC panel. |
+| **Active L3** | The currently visible L3 item, driven by `IntersectionObserver` on the page's scroll container. Tracked via `?s=` query param. |
+| **Page Index** | Synonym for L3 items when described in page documentation. |
+| **Canvas Page** | A page rendered from a `template: canvas` markdown file. Sections come from H2 headings. |
+| **List Page** | A page showing a scrollable, date-grouped list of entries (Journal, Search, Collections). |
+| **Editor Page** | A page showing the note editor (`JournalPageShell`). L3 comes from markdown headings in the note. |
+| **Canvas Section** | One H2 (or deeper) heading block inside a canvas markdown file. Becomes one L3 item. |
+| **Section Attributes** | `{sticky}`, `{dark}`, `{full-bleed}` suffixes on a canvas heading that control visual layout. |
+| **Scroll Anchor** | An `id` attribute on a DOM element that L3 activation scrolls to. |
+| **Active Section** | The scroll anchor whose section is currently in the viewport. Synced to `?s=` query param via `RouteQueryAction`. |
+
+---
+
+## How a Page Sets Its Navigation Values
+
+Every page load follows this sequence:
+
+```
+Route change
+  → AppContent reads location.pathname
+  → Resolves canvasPage (if any) via findCanvasPage()
+  → Computes currentNavLinks (INavActivation[])
+  → Calls setLayout('l3', items) to push L3 into NavContext
+  → Renders CanvasPage shell with title, subheader, actions, index props
+```
+
+### The `CanvasPage` shell props contract
+
+```typescript
+interface CanvasPageProps {
+  title?:              string              // page title in header bar
+  subheader?:          ReactNode           // optional filter strip under title
+  actions?:            ReactNode           // right-side header action buttons
+  index?:              INavActivation[]    // L3: page index (right TOC + sidebar)
+  onScrollToSection?:  (id: string) => void // wired to executeNavAction scroll
+  hero?:               ReactNode           // hero banner above sticky nav
+  sections?:           DocsSection[]       // sections-mode (alternative to title)
+}
+```
+
+### L3 derivation rules by page type
+
+| Page type | L3 source | L3 action type | Update trigger |
+|-----------|-----------|----------------|----------------|
+| **Canvas** | H2+ headings of the markdown file | `RouteQueryAction { params: { s: id } }` | Route change |
+| **List** (Journal, Search) | Most recent 10 dates with activity | `RouteQueryAction { params: { s: date } }` | Results refresh |
+| **Editor** | Markdown headings extracted from note content | `RouteQueryAction` + optional `CallAction` (WOD blocks) | Content change |
+| **Tracker / Review** | None — full-screen, no sidebar | — | — |
+| **Load** | None | — | — |
+
+### Scroll-driven active section tracking
+
+When the user scrolls, the `IntersectionObserver` fires and the active section changes. This updates state by dispatching a `RouteQueryAction`:
+
+```typescript
+// Fired by IntersectionObserver — replaceState, no history push
+executeNavAction(
+  { type: 'query', params: { s: visibleSectionId }, pushHistory: false },
+  deps
+)
+```
+
+This keeps the `?s=` query param in sync with the viewport without flooding browser history. A back-navigation from another page restores the correct scroll position.
+
+---
+
+## Page Inventory
+
+The table below lists every page in the app and the navigation values it sets at load time.
+
+### Legend for L3 Source column
+
+- **Canvas sections** — L3 = H2 headings of the corresponding markdown file
+- **Recent dates** — L3 = up to 10 ISO dates with workout activity, formatted as "Apr 14, 2026"
+- **Note headings** — L3 = markdown headings extracted from the open note's content
+- **None** — no L3 registered; right TOC and sidebar index are empty
+
+---
+
+### Core Navigation Pages
+
+| Page | Route | L1 Active | L2 Active | Page Title | Subheader | L3 Source | L3 items |
+|------|-------|-----------|-----------|------------|-----------|-----------|---------|
+| **Home** | `/` | `home` | — | `"Home"` | — | Canvas sections | See [Home canvas sections](#home-) |
+| **Journal** | `/journal` | `journal` | `JournalNavPanel` | `"Journal"` | — | Recent dates | Up to 10 dates with entries |
+| **Search** | `/search` | `search` | `SearchNavPanel` | `"Search"` | `TextFilterStrip` ("Search workouts…") | Recent dates | Up to 10 dates with results |
+| **Collections** | `/collections` | `collections` | `CollectionsNavPanel` | `"Collections"` | `TextFilterStrip` ("Filter collections…") | — | None |
+
+---
+
+### Documentation Canvas Pages (L1: `home`)
+
+These pages are listed as L2 children under the Home L1 item in `appNavTree`.
+
+| Page | Route | L2 Active | Page Title | L3 Source | L3 items |
+|------|-------|-----------|------------|-----------|---------|
+| **Zero to Hero** | `/getting-started` | `zero-to-hero` | `"Zero to Hero"` | Canvas sections | See [Getting Started sections](#zero-to-hero-getting-started) |
+| **Syntax Reference** | `/syntax` | `syntax-/syntax` | `"Syntax Reference"` | Canvas sections | See [Syntax Overview sections](#syntax-reference-syntax) |
+| **The Basics** | `/syntax/basics` | `syntax-/syntax/basics` | `"The Basics"` | Canvas sections | See [The Basics sections](#the-basics-syntaxbasics) |
+| **Timers and Intervals** | `/syntax/timers` | `syntax-/syntax/timers` | `"Timers and Intervals"` | Canvas sections | See [Timers sections](#timers-and-intervals-syntaxtimers) |
+| **Rounds and Groups** | `/syntax/groups` | `syntax-/syntax/groups` | `"Rounds and Groups"` | Canvas sections | See [Groups sections](#rounds-and-groups-syntaxgroups) |
+| **AMRAP** | `/syntax/amrap` | `syntax-/syntax/amrap` | `"AMRAP"` | Canvas sections | See [AMRAP sections](#amrap-syntaxamrap) |
+| **EMOM** | `/syntax/emom` | `syntax-/syntax/emom` | `"EMOM"` | Canvas sections | See [EMOM sections](#emom-syntaxemom) |
+| **Tabata and Intervals** | `/syntax/tabata` | `syntax-/syntax/tabata` | `"Tabata and Intervals"` | Canvas sections | See [Tabata sections](#tabata-and-intervals-syntaxtabata) |
+| **Rep Schemes** | `/syntax/repeaters` | `syntax-/syntax/repeaters` | `"Rep Schemes"` | Canvas sections | See [Rep Schemes sections](#rep-schemes-syntaxrepeaters) |
+| **Rest Periods** | `/syntax/rest` | `syntax-/syntax/rest` | `"Rest Periods"` | Canvas sections | See [Rest sections](#rest-periods-syntaxrest) |
+| **Measurements** | `/syntax/measurements` | `syntax-/syntax/measurements` | `"Measurements"` | Canvas sections | See [Measurements sections](#measurements-syntaxmeasurements) |
+| **Supplemental Data** | `/syntax/supplemental` | `syntax-/syntax/supplemental` | `"Supplemental Data"` | Canvas sections | See [Supplemental sections](#supplemental-data-syntaxsupplemental) |
+| **Complex Workouts** | `/syntax/complex` | `syntax-/syntax/complex` | `"Complex Workouts"` | Canvas sections | See [Complex sections](#complex-workouts-syntaxcomplex) |
+
+---
+
+### Dynamic Collection Canvas Pages (L1: `collections`)
+
+| Page | Route | L1 Active | Page Title | L3 Source |
+|------|-------|-----------|------------|-----------|
+| **Collection Detail** | `/collections/:slug` | `collections` | `currentWorkout.name` | Canvas sections of the collection's markdown file |
+
+---
+
+### Editor Pages (L1: derived from prior navigation state)
+
+| Page | Route | Page Title | L3 Source | L3 items |
+|------|-------|------------|-----------|---------|
+| **Journal Entry** | `/journal/:id` | Note ID (e.g. `"2026-04-14"`) | Note headings | H1/H2/H3 from editor content + WOD blocks with ▶ run action |
+| **Playground Note** | `/playground/:id` | Note ID | Note headings | H1/H2/H3 from editor content + WOD blocks |
+| **Workout Note** | `/note/:category/:name` | Note name | Note headings | H1/H2/H3 from editor content + WOD blocks |
+
+---
+
+### Full-Screen Pages (no sidebar / no L3)
+
+| Page | Route | Notes |
+|------|-------|-------|
+| **Tracker** | `/tracker/:runtimeId` | Full-screen runtime view. No CanvasPage shell, no L3. |
+| **Review** | `/review/:runtimeId` | Full-screen review. Title: `"Workout Review"`. No L3. |
+| **Load Zip** | `/load` | Utility page. No sidebar navigation. |
+
+---
+
+## L3 Item Detail — Canvas Pages
+
+Each canvas page's L3 items are the **H2 headings** rendered as scroll anchors. The H1 is the page hero (rendered via `{sticky dark full-bleed}` attribute) and is **not** included in L3.
+
+### Home (`/`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `your-workout-written-once-run-forever` | Your workout — written once, run forever. |
+
+*(Additional H2s contribute additional L3 items as the home page is developed.)*
+
+---
+
+### Zero to Hero (`/getting-started`)
+
+| L3 ID                        | L3 Label                     |
+| ---------------------------- | ---------------------------- |
+| `step-1-your-first-movement` | Step 1 — Your First Movement |
+| `step-2-add-reps-and-load`   | Step 2 — Add Reps and Load   |
+| `step-3-your-first-timer`    | Step 3 — Your First Timer    |
+| `step-4-rounds-and-groups`   | Step 4 — Rounds and Groups   |
+| `step-5-your-first-amrap`    | Step 5 — Your First AMRAP    |
+| `step-6-save-and-review`     | Step 6 — Save and Review     |
+| `whats-next`                 | What's Next                  |
+
+---
+
+### Syntax Reference (`/syntax`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `the-basics` | The Basics |
+| `timers-and-intervals` | Timers and Intervals |
+| `rep-schemes` | Rep Schemes |
+| `rounds-and-groups` | Rounds and Groups |
+| `amrap` | AMRAP |
+| `emom` | EMOM |
+| `tabata-and-intervals` | Tabata and Intervals |
+| `rest-periods` | Rest Periods |
+| `measurements` | Measurements |
+| `supplemental-data` | Supplemental Data |
+| `complex-workouts` | Complex Workouts |
+| `start-writing` | Start Writing |
+
+---
+
+### The Basics (`/syntax/basics`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `a-single-movement` | A Single Movement |
+| `three-core-rules` | Three Core Rules |
+| `whats-next` | What's Next |
+
+---
+
+### Timers and Intervals (`/syntax/timers`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `countdown-timers` | Countdown Timers |
+| `count-up-timers` | Count-Up Timers |
+| `mixed-timers` | Mixed Timers |
+| `long-durations` | Long Durations |
+| `whats-next` | What's Next |
+
+---
+
+### Rounds and Groups (`/syntax/groups`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `simple-rounds` | Simple Rounds |
+| `named-groups` | Named Groups |
+| `nested-groups` | Nested Groups |
+| `mixed-sections` | Mixed Sections |
+| `whats-next` | What's Next |
+
+---
+
+### AMRAP (`/syntax/amrap`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `classic-amrap` | Classic AMRAP |
+| `amrap-with-a-time-cap` | AMRAP with a Time Cap |
+| `multiple-amraps` | Multiple AMRAPs |
+| `whats-next` | What's Next |
+
+---
+
+### EMOM (`/syntax/emom`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `basic-emom` | Basic EMOM |
+| `longer-intervals` | Longer Intervals |
+| `alternating-emom` | Alternating EMOM |
+| `whats-next` | What's Next |
+
+---
+
+### Tabata and Intervals (`/syntax/tabata`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `standard-tabata` | Standard Tabata |
+| `custom-intervals` | Custom Intervals |
+| `intervals-with-distance` | Intervals with Distance |
+| `whats-next` | What's Next |
+
+---
+
+### Rep Schemes (`/syntax/repeaters`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `simple-reps` | Simple Reps |
+| `descending-reps-21-15-9` | Descending Reps — (21-15-9) |
+| `multiple-sets` | Multiple Sets |
+| `whats-next` | What's Next |
+
+---
+
+### Rest Periods (`/syntax/rest`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `explicit-rest-between-sets` | Explicit Rest Between Sets |
+| `rest-inside-an-amrap` | Rest Inside an AMRAP |
+| `whats-next` | What's Next |
+
+---
+
+### Measurements (`/syntax/measurements`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `weights` | Weights |
+| `distances` | Distances |
+| `percentages` | Percentages |
+| `unknown-load` | Unknown Load |
+| `whats-next` | What's Next |
+
+---
+
+### Supplemental Data (`/syntax/supplemental`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `effort-and-rpe` | Effort and RPE |
+| `setup-actions` | Setup Actions |
+| `progressive-load` | Progressive Load |
+| `whats-next` | What's Next |
+
+---
+
+### Complex Workouts (`/syntax/complex`)
+
+| L3 ID | L3 Label |
+|-------|----------|
+| `nested-protocols` | Nested Protocols |
+| `full-training-session` | Full Training Session |
+| `barbell-cycling` | Barbell Cycling |
+| `partner-workout` | Partner Workout |
+| `finish-line` | Finish Line |
+
+---
+
+## Standard Documentation Phrases
+
+When writing inline documentation or markdown prose for a page, use these standard phrases to describe what it does on load:
+
+### Setting the page title
+> "On load, this page sets the **page title** to `"<Value>"` in the sticky header bar."
+
+### Registering L3 items (canvas page)
+> "On load, this page calls `setLayout('l3', ...)` with its **H2 section headings** as `INavActivation` items. Each section becomes a `RouteQueryAction` scroll anchor visible in the sidebar accordion and right-side TOC panel."
+
+### Registering L3 items (list page)
+> "On load, this page calls `setLayout('l3', ...)` with the **10 most recent activity dates** as `RouteQueryAction` items formatted as short month/day/year labels. Activating a date scrolls the list to that group."
+
+### Registering L3 items (editor page)
+> "The **page index** is re-registered via `setLayout('l3', ...)` whenever the note content changes. Each heading (`#`, `##`, `###`) becomes a `RouteQueryAction` scroll anchor. WOD blocks gain a `secondaryAction` of type `call` that starts the runtime."
+
+### Setting a subheader
+> "On load, this page inserts a **filter strip** in the subheader zone, rendered below the title bar on desktop and as a second sticky bar on mobile."
+
+### Activating L1
+> "Navigating to this page activates the **`<id>`** L1 item in the sidebar."
+
+### Activating L2
+> "Navigating to this page activates **`<label>`** in the L2 context panel beneath the `<L1>` section."
+
+### No page index
+> "This page does not call `setLayout('l3', ...)`. The sidebar accordion and right-side TOC panel are empty while on this page."
+
+---
+
+## Adding a New Canvas Page — Checklist
+
+When adding a new `template: canvas` markdown file, the following navigation values are automatically derived — no code changes required:
+
+- [x] **Route** — set via `route:` frontmatter field
+- [x] **Page title** — H1 heading text (after stripping `{...}` attributes)
+- [x] **L3 items** — all H2+ headings mapped to `RouteQueryAction { params: { s: id } }` items
+- [x] **L2 entry** — auto-added to the `Syntax` group in `appNavTree` by `canvasRoutes` loader
+- [x] **L1 activation** — `home` is activated for all `/getting-started` and `/syntax/*` routes
+
+The only manual step is deciding where in the L2 tree the new page should appear, which is controlled by the order of files returned by `canvasRoutes`.
+
+---
+
+## Related Documents
+
+- [`docs/nav-link-inventory.md`](nav-link-inventory.md) — full crosswalk of every link across the three screen-width tiers
+- [`docs/NAVIGATION_LAYOUT_PLAN.md`](NAVIGATION_LAYOUT_PLAN.md) — layout plan for mobile / desktop / ultra-wide nav zones
+- [`docs/layout.md`](layout.md) — visual layout specification
+- [`playground/src/nav/appNavTree.ts`](../playground/src/nav/appNavTree.ts) — L1+L2 static tree definition (implements `INavActivation`)
+- [`playground/src/nav/navTypes.ts`](../playground/src/nav/navTypes.ts) — type contracts for `NavItem`, `NavState`, `INavAction`
+- [`playground/src/nav/useSetNavL3.ts`](../playground/src/nav/useSetNavL3.ts) — hook used by pages to register L3 items via `setLayout('l3', ...)`
+

--- a/e2e/journal-entry.e2e.ts
+++ b/e2e/journal-entry.e2e.ts
@@ -1,0 +1,152 @@
+/**
+ * Journal Entry E2E Tests
+ *
+ * Validates the /journal/:date route:
+ * 1. New entries load with the default template
+ * 2. Edited content is saved when navigating away normally (≥500ms debounce)
+ * 3. Edited content is saved when navigating away before the 500ms debounce fires
+ *    (validates the flush-on-unmount fix in usePlaygroundContent)
+ * 4. Content survives a full page reload
+ *
+ * Tests run against the live app at https://pluto.forest-adhara.ts.net:5173
+ * via playwright.journal.config.ts.
+ *
+ * Test isolation: each test uses a unique stable date in 2099 that is cleared
+ * in the IndexedDB before the test begins.
+ */
+
+import { test, expect } from '@playwright/test';
+import { JournalEntryPage } from './pages/JournalEntryPage';
+
+// Stable test dates — far future so they never conflict with real entries
+const DATE_LOAD = '2099-06-01';
+const DATE_SAVE_NORMAL = '2099-06-02';
+const DATE_SAVE_QUICK = '2099-06-03';
+const DATE_RELOAD = '2099-06-04';
+
+test.describe('Journal Entry — /journal/:date', () => {
+  let journal: JournalEntryPage;
+  const errors: string[] = [];
+
+  test.beforeEach(async ({ page }) => {
+    errors.length = 0;
+    page.on('pageerror', (e) => errors.push(e.message));
+    journal = new JournalEntryPage(page);
+
+    // Navigate once to seed IndexedDB access before clearing
+    await page.goto('https://pluto.forest-adhara.ts.net:5173/', {
+      waitUntil: 'domcontentloaded',
+      timeout: 20_000,
+    });
+  });
+
+  test.afterEach(() => {
+    if (errors.length > 0) {
+      console.warn('Page errors during test:', errors);
+    }
+  });
+
+  // ── 1. New entry loads default template ──────────────────────────────────
+
+  test('loads default template for a new (unsaved) date', async () => {
+    await journal.clearStoredEntry(DATE_LOAD);
+    await journal.goto(DATE_LOAD);
+
+    // Template always contains "# My Workout" as the heading
+    await journal.expectEditorContains('My Workout');
+
+    // No page errors
+    expect(errors).toHaveLength(0);
+
+    await journal.page.screenshot({ path: 'e2e/screenshots/journal-entry-01-template.png' });
+  });
+
+  // ── 2. Content saved after normal debounce (≥500ms) ──────────────────────
+
+  test('saves content after waiting for debounce then navigating away', async () => {
+    const uniqueText = `E2E-SAVE-NORMAL-${Date.now()}`;
+    await journal.clearStoredEntry(DATE_SAVE_NORMAL);
+    await journal.goto(DATE_SAVE_NORMAL);
+
+    await journal.typeInEditor(uniqueText);
+
+    // Wait longer than the 500ms debounce so the save fires normally
+    await journal.page.waitForTimeout(700);
+
+    // Navigate away
+    await journal.gotoJournalList();
+
+    // Verify IndexedDB was written
+    const stored = await journal.storedContent(DATE_SAVE_NORMAL);
+    expect(stored).toContain(uniqueText);
+
+    // Navigate back — editor must show the saved content
+    await journal.goto(DATE_SAVE_NORMAL);
+    await journal.expectEditorContains(uniqueText);
+
+    await journal.page.screenshot({ path: 'e2e/screenshots/journal-entry-02-save-normal.png' });
+  });
+
+  // ── 3. Content saved on quick navigation (unmount flush) ──────────────────
+
+  test('saves content when navigating away before 500ms debounce fires', async () => {
+    const uniqueText = `E2E-SAVE-QUICK-${Date.now()}`;
+    await journal.clearStoredEntry(DATE_SAVE_QUICK);
+    await journal.goto(DATE_SAVE_QUICK);
+
+    await journal.typeInEditor(uniqueText);
+
+    // Navigate away immediately — well within the 500ms debounce window.
+    // usePlaygroundContent.flush() must fire on component unmount so this content is not lost.
+    await journal.gotoJournalList();
+
+    // Short pause to let any async IDB write complete
+    await journal.page.waitForTimeout(300);
+
+    // Verify IndexedDB was written despite quick navigation
+    const stored = await journal.storedContent(DATE_SAVE_QUICK);
+    expect(stored).toContain(uniqueText);
+
+    // Navigate back — content must appear
+    await journal.goto(DATE_SAVE_QUICK);
+    await journal.expectEditorContains(uniqueText);
+
+    await journal.page.screenshot({ path: 'e2e/screenshots/journal-entry-03-save-quick.png' });
+  });
+
+  // ── 4. Content survives a full page reload ────────────────────────────────
+
+  test('content persists across a hard page reload', async () => {
+    const uniqueText = `E2E-RELOAD-${Date.now()}`;
+    await journal.clearStoredEntry(DATE_RELOAD);
+    await journal.goto(DATE_RELOAD);
+
+    await journal.typeInEditor(uniqueText);
+
+    // Wait for debounce to fire
+    await journal.page.waitForTimeout(700);
+
+    // Hard reload
+    await journal.page.reload({ waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await journal.waitForEditor();
+
+    await journal.expectEditorContains(uniqueText);
+
+    await journal.page.screenshot({ path: 'e2e/screenshots/journal-entry-04-reload.png' });
+  });
+
+  // ── 5. Title shows the date ───────────────────────────────────────────────
+
+  test('page title reflects the journal date', async () => {
+    await journal.clearStoredEntry(DATE_LOAD);
+    await journal.goto(DATE_LOAD);
+
+    // The date appears somewhere in the page title / heading
+    // e.g. "June 1, 2099" or "2099-06-01"
+    const titleText = await journal.title().innerText();
+    // Accepts any format that includes the year
+    expect(titleText).toMatch(/2099/);
+
+    await journal.page.screenshot({ path: 'e2e/screenshots/journal-entry-05-title.png' });
+  });
+});

--- a/e2e/pages/JournalEntryPage.ts
+++ b/e2e/pages/JournalEntryPage.ts
@@ -1,0 +1,110 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+const APP_URL = 'https://pluto.forest-adhara.ts.net:5173';
+const DB_NAME = 'wodwiki-playground';
+
+export class JournalEntryPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // ── Navigation ────────────────────────────────────────────────────────────
+
+  url(date: string) {
+    return `${APP_URL}/journal/${date}`;
+  }
+
+  async goto(date: string) {
+    await this.page.goto(this.url(date), { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForEditor();
+  }
+
+  async gotoJournalList() {
+    await this.page.goto(`${APP_URL}/journal`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+  }
+
+  // ── Editor ────────────────────────────────────────────────────────────────
+
+  editor(): Locator {
+    return this.page.locator('.cm-content[contenteditable="true"]').first();
+  }
+
+  async waitForEditor() {
+    await this.page.waitForSelector('.cm-content[contenteditable="true"]', { timeout: 15_000 });
+    // Give React time to finish loading content from IndexedDB
+    await this.page.waitForTimeout(600);
+  }
+
+  async editorText(): Promise<string> {
+    return this.editor().innerText();
+  }
+
+  async typeInEditor(text: string) {
+    // Click end of editor then type
+    const ed = this.editor();
+    await ed.click();
+    await this.page.keyboard.press('End');
+    await this.page.keyboard.type(text);
+  }
+
+  async replaceEditorContent(text: string) {
+    const ed = this.editor();
+    await ed.click();
+    await this.page.keyboard.press('Control+a');
+    await this.page.keyboard.type(text);
+  }
+
+  // ── Page title ────────────────────────────────────────────────────────────
+
+  title(): Locator {
+    return this.page.locator('h1').first();
+  }
+
+  // ── IndexedDB helpers ─────────────────────────────────────────────────────
+
+  /** Delete a journal entry from IndexedDB (resets to template on next load). */
+  async clearStoredEntry(date: string) {
+    await this.page.evaluate(async ({ dbName, pageId }) => {
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction(['pages'], 'readwrite');
+          tx.objectStore('pages').delete(pageId);
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    }, { dbName: DB_NAME, pageId: `journal/${date}` });
+  }
+
+  /** Read raw content from IndexedDB (bypasses React — confirms the actual persisted value). */
+  async storedContent(date: string): Promise<string | null> {
+    return this.page.evaluate(async ({ dbName, pageId }) => {
+      return new Promise<string | null>((resolve, reject) => {
+        const req = indexedDB.open(dbName);
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction(['pages'], 'readonly');
+          const getReq = tx.objectStore('pages').get(pageId);
+          getReq.onsuccess = () => { db.close(); resolve(getReq.result?.content ?? null); };
+          getReq.onerror = () => { db.close(); reject(getReq.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    }, { dbName: DB_NAME, pageId: `journal/${date}` });
+  }
+
+  // ── Assertions ────────────────────────────────────────────────────────────
+
+  async expectEditorContains(text: string) {
+    await expect(this.editor()).toContainText(text, { timeout: 5_000 });
+  }
+
+  async expectTitleContains(text: string) {
+    await expect(this.title()).toContainText(text, { timeout: 5_000 });
+  }
+}

--- a/markdown/collections/dan-john/README.md
+++ b/markdown/collections/dan-john/README.md
@@ -13,6 +13,8 @@ template: canvas
 
 Dan John is a legendary strength coach, author, and former discus thrower whose influence on the fitness industry spans over four decades. His approach to training is characterized by elegant simplicity - focusing on fundamental movements, clear progressions, and sustainable programming that produces real-world results. Dan John's kettlebell programs have become legendary in the fitness community for their ability to build impressive strength, muscle, and conditioning with minimal equipment and time investment.
 
+{{workouts}}
+
 Dan John's philosophy centers on several key principles: the importance of the "armor" (building a resilient body), the value of pattern over perfection, the power of simplicity in programming, and the concept that "the goal is to keep the goal the goal." His workouts often use complexes and chains - sequences of movements performed without setting the weight down - to maximize training efficiency. He emphasizes that the best program is one you'll actually do consistently, leading to his preference for straightforward, repeatable protocols.
 
 ---

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useCallback, useRef } from 'react'
+import type { MutableRefObject } from 'react'
 import * as Headless from '@headlessui/react'
 
 import {
@@ -15,7 +16,7 @@ import { Navbar, NavbarItem, NavbarSection, NavbarSpacer } from '@/components/pl
 import { NavProvider } from './nav/NavContext'
 import { useNav } from './nav/NavContext'
 import { NavSidebar } from './nav/NavSidebar'
-import { appNavTree } from './nav/appNavTree'
+import { buildAppNavTree } from './nav/appNavTree'
 import type { NavItemL3 } from './nav/navTypes'
 import { FullscreenReview } from '@/components/Editor/overlays/FullscreenReview'
 import { FullscreenTimer } from '@/components/Editor/overlays/FullscreenTimer'
@@ -50,7 +51,7 @@ import { BrowserRouter, Routes, Route, useNavigate, useParams, useLocation, useS
 import { HomeView } from './views/HomeView'
 import { findCanvasPage } from './canvas/canvasRoutes'
 import { MarkdownCanvasPage } from './canvas/MarkdownCanvasPage'
-import { JournalWeeklyPage, SearchPage } from './views/ListViews'
+import { JournalWeeklyPage } from './views/ListViews'
 import { TextFilterStrip } from './views/queriable-list/TextFilterStrip'
 import { CollectionsPage } from './views/CollectionsPage'
 import { CastButtonRpc } from '@/components/cast/CastButtonRpc'
@@ -67,7 +68,8 @@ import type { EditorView } from '@codemirror/view'
 import { EditorSelection } from '@codemirror/state'
 import newPlaygroundTemplate from './templates/new-playground.md?raw'
 import { 
-  createStatementBuilderStrategy 
+  createStatementBuilderStrategy,
+  createGlobalSearchStrategy,
 } from './services/commandStrategies'
 
 // ── Constants for Sidebar Navigation ────────────────────────────────
@@ -95,111 +97,28 @@ const SYNTAX_LINKS = [
   { id: 'document', label: 'Document', type: 'heading' as const },
 ]
 
-// ── New Journal Entry Split Button ─────────────────────────────────
+import { WorkoutActionButton } from '@/components/workout/WorkoutActionButton'
+
+// ── New Journal Entry Button ───────────────────────────────────────
 
 function NewEntryButton() {
   const navigate = useNavigate()
-  const [conflictIso, setConflictIso] = useState<string | null>(null)
-
-  const todayISO = () => new Date().toISOString().slice(0, 10)
-
-  const offsetISO = (days: number) => {
-    const d = new Date()
-    d.setDate(d.getDate() + days)
-    return d.toISOString().slice(0, 10)
-  }
-
-  const [selectedIso, setSelectedIso] = useState(todayISO)
-
-  const formatLabel = (iso: string) => {
-    const today = todayISO()
-    const yesterday = offsetISO(-1)
-    const tomorrow = offsetISO(1)
-    if (iso === today) return 'Today'
-    if (iso === yesterday) return 'Yesterday'
-    if (iso === tomorrow) return 'Tomorrow'
-    // Short date: "Mar 25"
-    return new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  }
-
-  const pick = async (iso: string) => {
-    setSelectedIso(iso)
-    const pageId = PlaygroundDBService.pageId('journal', iso)
-    const existing = await playgroundDB.getPage(pageId)
-    if (existing) {
-      setConflictIso(iso)
-      return
-    }
-    navigate(`/journal/${iso}`)
-  }
-
-  const handleOpenExisting = () => {
-    if (!conflictIso) return
-    const iso = conflictIso
-    setConflictIso(null)
-    navigate(`/journal/${iso}`)
-  }
-
-  const handleCreateNew = () => {
-    if (!conflictIso) return
-    const iso = conflictIso
-    const now = new Date()
-    const pad = (n: number) => String(n).padStart(2, '0')
-    const uniqueId = `${iso}-${pad(now.getHours())}-${pad(now.getMinutes())}`
-    setConflictIso(null)
-    navigate(`/journal/${uniqueId}`)
+  
+  const pick = (date: Date) => {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    navigate(`/journal/${y}-${m}-${d}`)
   }
 
   return (
-    <>
-      <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => pick(selectedIso)}
-          aria-label={`New journal entry for ${selectedIso}`}
-          className="gap-1.5 text-xs font-semibold"
-        >
-          <PlusIcon className="size-4 shrink-0" />
-          <span className="hidden sm:inline">{formatLabel(selectedIso)}</span>
-        </Button>
-        <Dropdown>
-          <DropdownButton plain aria-label="New entry for a specific date">
-            <CalendarDaysIcon data-slot="icon" className="size-5 text-zinc-500" />
-          </DropdownButton>
-          <DropdownMenu className="min-w-40" anchor="bottom end">
-            <DropdownItem onClick={() => pick(offsetISO(0))}>
-              <DropdownLabel>Today</DropdownLabel>
-            </DropdownItem>
-            <DropdownItem onClick={() => pick(offsetISO(-1))}>
-              <DropdownLabel>Yesterday</DropdownLabel>
-            </DropdownItem>
-            <DropdownItem onClick={() => pick(offsetISO(1))}>
-              <DropdownLabel>Tomorrow</DropdownLabel>
-            </DropdownItem>
-          </DropdownMenu>
-        </Dropdown>
-      </div>
-
-      <Headless.Dialog open={conflictIso !== null} onClose={() => setConflictIso(null)} className="relative z-50">
-        <Headless.DialogBackdrop className="fixed inset-0 bg-black/40 backdrop-blur-sm" />
-        <div className="fixed inset-0 flex items-center justify-center p-4">
-          <Headless.DialogPanel className="bg-card border border-border rounded-2xl shadow-2xl p-6 max-w-xs w-full">
-            <Headless.DialogTitle className="text-xs font-black uppercase tracking-widest text-foreground mb-2">
-              Entry already exists
-            </Headless.DialogTitle>
-            <p className="text-xs text-muted-foreground mb-5">
-              A journal entry for <span className="font-bold text-foreground">{conflictIso}</span> already exists. Open it or create a separate entry timestamped to now?
-            </p>
-            <div className="flex flex-col gap-2">
-              <Button onClick={handleOpenExisting} className="w-full justify-center">Open existing</Button>
-              <Button variant="outline" onClick={handleCreateNew} className="w-full justify-center">Create new entry</Button>
-              <Button variant="ghost" onClick={() => setConflictIso(null)} className="w-full justify-center text-muted-foreground">Cancel</Button>
-            </div>
-          </Headless.DialogPanel>
-        </div>
-      </Headless.Dialog>
-    </>
+    <WorkoutActionButton
+      mode="create"
+      label="New"
+      onAction={pick}
+      variant="ghost"
+      className="h-8"
+    />
   )
 }
 
@@ -433,6 +352,15 @@ function ActionsMenu({
 }) {
   const { theme, setTheme } = useTheme()
   const { l3Items, scrollToSection } = useNav()
+  const [debugMode, setDebugMode] = useState(
+    () => localStorage.getItem('debugMode') === 'true'
+  )
+
+  const handleToggleDebug = () => {
+    const next = !debugMode
+    setDebugMode(next)
+    localStorage.setItem('debugMode', String(next))
+  }
 
   const handleResetData = async () => {
     localStorage.clear()
@@ -477,9 +405,10 @@ function ActionsMenu({
           <ArrowDownTrayIcon data-slot="icon" />
           <DropdownLabel>Download Markdown</DropdownLabel>
         </DropdownItem>
-        <DropdownItem href="#/debug">
+        <DropdownItem onClick={handleToggleDebug}>
           <BugAntIcon data-slot="icon" />
-          <DropdownLabel>Toggle Debug Mode</DropdownLabel>
+          <DropdownLabel>Debug Mode</DropdownLabel>
+          {debugMode && <span className="col-start-5 text-blue-500">✓</span>}
         </DropdownItem>
         <DropdownDivider />
 
@@ -890,7 +819,7 @@ function JournalPage({ theme, onViewCreated }: { theme: string, onViewCreated?: 
   )
 }
 
-function AppContent() {
+function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<() => void> }) {
   const navigate = useNavigate()
   const { category: urlCategory, name: urlName, id: playgroundId } = useParams<{ category: string; name: string; id: string }>()
   const location = useLocation()
@@ -949,7 +878,6 @@ function AppContent() {
     const named: Record<string, string> = {
       '/': 'Home',
       '/journal': 'Journal',
-      '/search': 'Search',
       '/getting-started': 'Zero to Hero',
       '/syntax': 'Syntax',
       '/collections': 'Collections',
@@ -977,21 +905,88 @@ function AppContent() {
     refreshResults()
   }, [location.pathname, refreshResults])
 
+  const handleSelectWorkout = useCallback((item: any) => {
+    const workout = item as { name: string; category?: string; content?: string }
+    if (workout.name === 'Home') {
+      navigate('/')
+    } else {
+      const category = workout.category || 'General'
+      navigate(`/workout/${encodeURIComponent(category)}/${encodeURIComponent(workout.name)}`)
+    }
+  }, [navigate])
+
+  const handleCloneWorkout = useCallback((item: WorkoutItem, date: Date) => {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    const iso = `${y}-${m}-${d}`;
+    const entryId = `journal/${iso}`
+    
+    playgroundDB.savePage({
+      id: entryId,
+      name: item.name,
+      category: 'journal',
+      content: item.content,
+      updatedAt: Date.now()
+    }).then(() => {
+      navigate(`/journal/${iso}`)
+    })
+  }, [navigate])
+
   // Nav links for the current page (used in the sticky header dropdown)
   const currentNavLinks = useMemo((): PageNavLink[] => {
     // 1. Canvas pages (including Home)
     if (canvasPage) {
-      return canvasPage.sections
+      const isCollection = location.pathname.startsWith('/collections/')
+      const collectionSlug = isCollection ? location.pathname.split('/').pop() : null
+      
+      const links: PageNavLink[] = []
+      canvasPage.sections
         .filter(s => s.level > 1)
-        .map(s => ({ id: s.id, label: s.heading, type: 'heading' as const }))
+        .forEach(s => {
+          links.push({ id: s.id, label: s.heading, type: 'heading' as const })
+          
+          if (isCollection && collectionSlug && s.prose.includes('{{workouts}}')) {
+             const collectionItems = workoutItems.filter(item => 
+               item.category === collectionSlug && item.name.toLowerCase() !== 'readme'
+             )
+             collectionItems.forEach(item => {
+               links.push({
+                 id: `workout-${item.id}`,
+                 label: item.name,
+                 type: 'wod' as const,
+                 onRun: () => handleSelectWorkout(item)
+               })
+             })
+          }
+        })
+        
+        // Fallback: if it's a collection but no section has the {{workouts}} tag,
+        // we might still want to list them if they are appended at the bottom.
+        const hasWorkoutsTag = canvasPage.sections.some(s => s.prose.includes('{{workouts}}'))
+        if (isCollection && collectionSlug && !hasWorkoutsTag) {
+          links.push({ id: 'collection-workouts', label: 'Explore', type: 'heading' as const })
+          const collectionItems = workoutItems.filter(item => 
+            item.category === collectionSlug && item.name.toLowerCase() !== 'readme'
+          )
+          collectionItems.forEach(item => {
+            links.push({
+              id: `workout-${item.id}`,
+              label: item.name,
+              type: 'wod' as const,
+              onRun: () => handleSelectWorkout(item)
+            })
+          })
+        }
+      return links
     }
 
     // 2. Docs pages
     if (location.pathname === '/getting-started') return ZERO_TO_HERO_LINKS
     if (location.pathname === '/syntax') return SYNTAX_LINKS
     
-    // 3. List based pages (Journal, Search)
-    if (location.pathname === '/journal' || location.pathname === '/search') {
+    // 3. Journal list page
+    if (location.pathname === '/journal') {
       const dates = new Set<string>()
       recentResults.forEach(r => {
         const d = new Date(r.completedAt).toISOString().split('T')[0]
@@ -1013,17 +1008,7 @@ function AppContent() {
     }
 
     return []
-  }, [location.pathname, canvasPage, recentResults, workoutItems])
-
-  const handleSelectWorkout = useCallback((item: any) => {
-    const workout = item as { name: string; category?: string; content?: string }
-    if (workout.name === 'Home') {
-      navigate('/')
-    } else {
-      const category = workout.category || 'General'
-      navigate(`/workout/${encodeURIComponent(category)}/${encodeURIComponent(workout.name)}`)
-    }
-  }, [navigate])
+  }, [location.pathname, canvasPage, recentResults, workoutItems, handleSelectWorkout])
 
   /**
    * Navigate to a journal entry for the given date.
@@ -1036,6 +1021,19 @@ function AppContent() {
     const d = String(date.getDate()).padStart(2, '0')
     navigate(`/journal/${y}-${m}-${d}`)
   }, [navigate])
+
+  // Open the command palette with the global search strategy
+  const openSearchPalette = useCallback(() => {
+    const strategy = createGlobalSearchStrategy(workoutItems, handleSelectWorkout, navigate)
+    setStrategy(strategy)
+    setIsCommandPaletteOpen(true)
+  }, [workoutItems, handleSelectWorkout, setStrategy, setIsCommandPaletteOpen])
+
+  // Keep the parent's searchHandlerRef up-to-date so the nav tree CallAction always
+  // fires the latest callback (workoutItems may change after initial mount).
+  useEffect(() => {
+    searchHandlerRef.current = openSearchPalette
+  }, [openSearchPalette, searchHandlerRef])
 
   // Reset strategy when palette closes
   useEffect(() => {
@@ -1053,7 +1051,7 @@ function AppContent() {
       if ((e.key === 'k' || e.key === 'p') && (e.metaKey || e.ctrlKey)) {
         e.preventDefault()
         e.stopPropagation()
-        navigate('/search')
+        openSearchPalette()
       }
       // Ctrl/Cmd + .: Statement Builder (Interactive Segments)
       if (e.key === '.' && (e.metaKey || e.ctrlKey)) {
@@ -1077,7 +1075,7 @@ function AppContent() {
     }
     window.addEventListener('keydown', down, true)
     return () => window.removeEventListener('keydown', down, true)
-  }, [navigate, setStrategy, setIsCommandPaletteOpen])
+  }, [openSearchPalette, setStrategy, setIsCommandPaletteOpen])
 
   const [isSystemDark, setIsSystemDark] = useState(
     () => typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -1209,7 +1207,7 @@ function AppContent() {
           <NavbarSpacer />
           <NavbarSection>
             <NewEntryButton />
-            <NavbarItem href="/search" aria-label="Search">
+            <NavbarItem onClick={openSearchPalette} aria-label="Search">
               <MagnifyingGlassIcon data-slot="icon" />
             </NavbarItem>
             <div className="flex items-center">
@@ -1241,13 +1239,6 @@ function AppContent() {
                 onCreateEntry={handleCreateJournalEntry}
               />
             </CanvasPage>
-          ) : location.pathname === '/search' ? (
-            <CanvasPage title="Search" subheader={<TextFilterStrip placeholder="Search workouts, results, or notes…" autoFocus />} index={currentNavLinks} onScrollToSection={scrollToSection} actions={<div className="flex items-center gap-4"><NewEntryButton /><CastButtonRpc /><AudioToggle /><ActionsMenu currentWorkout={currentWorkout} /></div>}>
-              <SearchPage 
-                workoutItems={workoutItems}
-                onSelect={handleSelectWorkout}
-              />
-            </CanvasPage>
           ) : location.pathname === '/collections' ? (
             <CanvasPage title="Collections" subheader={<TextFilterStrip placeholder="Filter collections…" />} actions={<div className="flex items-center gap-4"><NewEntryButton /><CastButtonRpc /><AudioToggle /><ActionsMenu currentWorkout={currentWorkout} /></div>}>
               <CollectionsPage />
@@ -1260,6 +1251,7 @@ function AppContent() {
                 theme={actualTheme}
                 workoutItems={workoutItems}
                 onSelect={handleSelectWorkout}
+                onClone={handleCloneWorkout}
               />
             </CanvasPage>
           ) : (
@@ -1315,6 +1307,11 @@ import { NuqsAdapter } from 'nuqs/adapters/react-router'
 import { useQueryState } from 'nuqs'
 
 export function App() {
+  // Stable ref so AppContent can inject its openSearchPalette callback after mount.
+  // The nav tree is built once; the search item calls the ref's current value.
+  const searchHandlerRef = useRef<() => void>(() => {})
+  const navTree = useMemo(() => buildAppNavTree(() => searchHandlerRef.current()), [])
+
   return (
     <ThemeProvider defaultTheme="system" storageKey="wod-wiki-playground-theme">
       <AudioProvider>
@@ -1322,24 +1319,23 @@ export function App() {
           <NuqsAdapter>
             <ScrollToTop />
             <CommandProvider>
-              <NavProvider tree={appNavTree}>
+              <NavProvider tree={navTree}>
               <Routes>
-                <Route path="/" element={<AppContent />} />
-                <Route path="/getting-started" element={<AppContent />} />
-                <Route path="/syntax" element={<AppContent />} />
-                <Route path="/journal" element={<AppContent />} />
-                <Route path="/search" element={<AppContent />} />
-                <Route path="/collections" element={<AppContent />} />
-                <Route path="/collections/:slug" element={<AppContent />} />
-                <Route path="/workout/:category/:name" element={<AppContent />} />
+                <Route path="/" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/getting-started" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/syntax" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/journal" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/collections" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/collections/:slug" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/workout/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/load" element={<LoadZipPage />} />
                 <Route path="/playground" element={<PlaygroundRedirect />} />
-                <Route path="/playground/:id" element={<AppContent />} />
-                <Route path="/note/:category/:name" element={<AppContent />} />
-                <Route path="/journal/:id" element={<AppContent />} />
+                <Route path="/playground/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/note/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                <Route path="/journal/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/tracker/:runtimeId" element={<TrackerPage />} />
                 <Route path="/review/:runtimeId" element={<ReviewPage />} />
-                <Route path="*" element={<AppContent />} />
+                <Route path="*" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
               </Routes>
               </NavProvider>
             </CommandProvider>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -283,7 +283,7 @@ function WorkoutEditorPage({
       label: link.label,
       level: 3 as const,
       action: { type: 'scroll' as const, sectionId: link.id },
-      secondaryAction: link.onRun ? { type: 'call' as const, handler: link.onRun } : undefined,
+      secondaryAction: link.onRun ? { id: link.id + '-run', label: 'Run', action: { type: 'call' as const, handler: link.onRun } } : undefined,
     })))
     return () => setEditorL3([])
   }, [index, setEditorL3])
@@ -585,7 +585,7 @@ function PlaygroundNotePage({ theme, onViewCreated }: { theme: string, onViewCre
       label: link.label,
       level: 3 as const,
       action: { type: 'scroll' as const, sectionId: link.id },
-      secondaryAction: link.onRun ? { type: 'call' as const, handler: link.onRun } : undefined,
+      secondaryAction: link.onRun ? { id: link.id + '-run', label: 'Run', action: { type: 'call' as const, handler: link.onRun } } : undefined,
     })))
     return () => setPnpL3([])
   }, [index, setPnpL3])
@@ -825,7 +825,7 @@ function JournalPage({ theme, onViewCreated }: { theme: string, onViewCreated?: 
       label: link.label,
       level: 3 as const,
       action: { type: 'scroll' as const, sectionId: link.id },
-      secondaryAction: link.onRun ? { type: 'call' as const, handler: link.onRun } : undefined,
+      secondaryAction: link.onRun ? { id: link.id + '-run', label: 'Run', action: { type: 'call' as const, handler: link.onRun } } : undefined,
     })))
     return () => setJpL3([])
   }, [index, setJpL3])
@@ -1176,7 +1176,7 @@ function AppContent() {
       level: 3 as const,
       action: { type: 'scroll' as const, sectionId: link.id },
       secondaryAction: link.onRun
-        ? { type: 'call' as const, handler: link.onRun }
+        ? { id: link.id + '-run', label: 'Run', action: { type: 'call' as const, handler: link.onRun } }
         : undefined,
     }))
     setL3Items(l3)

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -34,6 +34,7 @@ import type { WodBlock } from '@/components/Editor/types'
 import type { WorkoutItem } from '../App'
 import { pendingRuntimes, activeRuntimes } from '../runtimeStore'
 import { CollectionWorkoutsList } from '../views/queriable-list/CollectionWorkoutsList'
+import { getCategoryForCollection } from '../config/collectionGroups'
 
 // Match the existing parallax constants exactly
 const STICKY_NAV_HEIGHT = 104
@@ -244,14 +245,18 @@ export interface MarkdownCanvasPageProps {
   theme: string
   workoutItems?: WorkoutItem[]
   onSelect?: (item: WorkoutItem) => void
+  onClone?: (item: WorkoutItem, date: Date) => void
 }
 
-export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSelect }: MarkdownCanvasPageProps) {
+export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSelect, onClone }: MarkdownCanvasPageProps) {
   const navigate = useNavigate()
   const { sections, route } = page
 
   const isCollection = route.startsWith('/collections/')
   const collectionSlug = isCollection ? route.split('/').pop() : null
+
+  // Check if any section has the {{workouts}} tag
+  const hasWorkoutsTag = sections.some(s => s.prose.includes('{{workouts}}'))
 
   // Hero = first section; content = the rest (observed by IntersectionObserver)
   const contentSections = sections.slice(1)
@@ -613,6 +618,23 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
           <div className={cn('w-full', viewDef && 'lg:w-[40%]')}>
             {mobilePanel}
 
+            {/* Category chip — collection detail pages only */}
+            {isCollection && collectionSlug && (() => {
+              const category = getCategoryForCollection(collectionSlug)
+              if (!category) return null
+              const slug = category.toLowerCase()
+              return (
+                <div className="px-6 lg:px-12 pt-6 pb-0">
+                  <button
+                    onClick={() => navigate(`/collections?categories=${slug}`)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-black uppercase tracking-widest bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
+                  >
+                    {category}
+                  </button>
+                </div>
+              )
+            })()}
+
             {contentSections.map((section, idx) => {
               const fullBleed = isFullBleed(section)
               const dark      = isDark(section)
@@ -656,11 +678,31 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
                     </h2>
 
                     {section.prose && (
-                      viewDef
-                        ? <p className="text-sm lg:text-[15px] font-medium text-muted-foreground leading-relaxed mb-6">
-                            {section.prose}
-                          </p>
-                        : <CanvasProse prose={section.prose} className="mb-6" />
+                      (() => {
+                        if (isCollection && collectionSlug && workoutItems && section.prose.includes('{{workouts}}')) {
+                          const parts = section.prose.split('{{workouts}}')
+                          return (
+                            <>
+                              {parts[0] && <CanvasProse prose={parts[0]} className="mb-6" />}
+                              <div className="h-[600px] flex flex-col mb-6">
+                                <CollectionWorkoutsList
+                                  category={collectionSlug}
+                                  workoutItems={workoutItems}
+                                  onSelect={onSelect ?? (() => {})}
+                                  onClone={onClone}
+                                />
+                              </div>
+                              {parts[1] && <CanvasProse prose={parts[1]} className="mb-6" />}
+                            </>
+                          )
+                        }
+                        
+                        return viewDef
+                          ? <p className="text-sm lg:text-[15px] font-medium text-muted-foreground leading-relaxed mb-6">
+                              {section.prose}
+                            </p>
+                          : <CanvasProse prose={section.prose} className="mb-6" />
+                      })()
                     )}
 
                     <SectionButtons
@@ -674,9 +716,12 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
               )
             })}
 
-            {/* Collection workouts list if applicable */}
-            {isCollection && collectionSlug && workoutItems && (
-              <div className="min-h-[70vh] flex flex-col py-16 lg:py-24 px-6 lg:px-10 bg-background border-t border-border/50">
+            {/* Collection workouts list fallback if tag not found in any section */}
+            {isCollection && !hasWorkoutsTag && collectionSlug && workoutItems && (
+              <div 
+                id="collection-workouts"
+                className="min-h-[70vh] flex flex-col py-16 lg:py-24 px-6 lg:px-10 bg-background border-t border-border/50"
+              >
                 <div className="max-w-sm mb-12">
                   <div className="text-[10px] font-black tracking-[0.25em] uppercase text-primary mb-4">
                     Explore
@@ -694,6 +739,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
                     category={collectionSlug}
                     workoutItems={workoutItems}
                     onSelect={onSelect ?? (() => {})}
+                    onClone={onClone}
                   />
                 </div>
               </div>

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -12,7 +12,7 @@
  * so only one command pipeline fires at a time — no flicker.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { v4 as uuidv4 } from 'uuid'
 import { ArrowLeft } from 'lucide-react'
@@ -27,7 +27,9 @@ import { MacOSChrome } from '../components/MacOSChrome'
 import { SplitRunButton } from '../components/SplitRunButton'
 import { cn } from '@/lib/utils'
 import { CanvasProse } from './CanvasProse'
-import type { ParsedCanvasPage, CanvasSection, PipelineStep, OpenMode, ViewButton } from './parseCanvasMarkdown'
+import { executeNavAction } from '../nav/navTypes'
+import type { INavActivation, NavActionDeps, INavAction } from '../nav/navTypes'
+import type { ParsedCanvasPage, CanvasSection, PipelineStep, OpenMode } from './parseCanvasMarkdown'
 import type { WodBlock } from '@/components/Editor/types'
 import type { WorkoutItem } from '../App'
 import { pendingRuntimes, activeRuntimes } from '../runtimeStore'
@@ -75,6 +77,38 @@ const hasAttr  = (s: CanvasSection, a: string) => s.attrs.includes(a)
 const isFullBleed = (s: CanvasSection) => hasAttr(s, 'full-bleed')
 const isDark      = (s: CanvasSection) => hasAttr(s, 'dark')
 
+// ── Pipeline → INavAction converter ──────────────────────────────────────────
+
+/** Convert a single stringly-typed PipelineStep to a typed INavAction. */
+function pipelineStepToNavAction(step: PipelineStep, open: OpenMode = 'dialog'): INavAction {
+  if (step.action === 'set-source') return { type: 'view-source', source: step.value }
+  if (step.action === 'navigate')   return { type: 'route', to: step.value }
+  if (step.action === 'set-state') {
+    if (step.value === 'note')   return { type: 'view-state', state: 'note' }
+    if (step.value === 'review') return { type: 'view-state', state: 'review' }
+    if (step.value === 'track')  return { type: 'view-state', state: 'track', open }
+  }
+  return { type: 'none' }
+}
+
+/** Build an INavActivation from a canvas ButtonBlock or ViewButton. */
+function buttonToActivation(btn: { label: string; pipeline: PipelineStep[]; open?: OpenMode }, idx: number): INavActivation {
+  const steps = btn.pipeline.map(s => pipelineStepToNavAction(s, btn.open))
+  return {
+    id: `btn-${idx}`,
+    label: btn.label,
+    action: steps.length === 1 ? steps[0] : { type: 'pipeline', steps },
+  }
+}
+
+/** True when an activation's action will launch the workout tracker. */
+function isRunActivation(activation: INavActivation): boolean {
+  const { action } = activation
+  if (action.type === 'view-state') return action.state === 'track'
+  if (action.type === 'pipeline')   return action.steps.some(s => s.type === 'view-state' && (s as { state?: string }).state === 'track')
+  return false
+}
+
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 interface RunButtonState {
@@ -86,24 +120,21 @@ interface RunButtonState {
 }
 
 function SectionButtons({
-  section,
+  activations,
   fullBleed,
-  onPipeline,
   runState,
+  deps,
 }: {
-  section: CanvasSection
+  activations: INavActivation[]
   fullBleed: boolean
-  onPipeline: (p: PipelineStep[], open?: OpenMode) => void
   runState?: RunButtonState
+  deps: NavActionDeps
 }) {
-  if (section.buttons.length === 0) return null
+  if (activations.length === 0) return null
 
-  // Check if any button is a run-type pipeline (set-state:track)
-  const firstBtn = section.buttons[0]
-  const isRunButton = firstBtn.pipeline.some(s => s.action === 'set-state' && s.value === 'track')
-
-  if (isRunButton && runState) {
-    const rest = section.buttons.slice(1)
+  const first = activations[0]
+  if (isRunActivation(first) && runState) {
+    const rest = activations.slice(1)
     return (
       <div className={cn('flex flex-wrap items-center gap-4 mt-8', fullBleed && 'justify-center')}>
         <SplitRunButton
@@ -111,16 +142,16 @@ function SectionButtons({
           onFullscreen={runState.onFullscreen}
           isReconnect={runState.isReconnect}
           onReconnect={runState.onReconnect}
-          label={firstBtn.label}
+          label={first.label}
           center={fullBleed}
         />
-        {rest.map((btn, i) => (
+        {rest.map((activation, i) => (
           <button
-            key={i}
-            onClick={() => onPipeline(btn.pipeline, btn.open)}
+            key={activation.id || i}
+            onClick={() => executeNavAction(activation.action, deps)}
             className="flex items-center gap-2 px-6 py-2 text-xs font-black uppercase tracking-widest rounded-full bg-background border border-border text-foreground hover:bg-muted transition-all active:scale-95"
           >
-            {btn.label}
+            {activation.label}
           </button>
         ))}
       </div>
@@ -129,10 +160,10 @@ function SectionButtons({
 
   return (
     <div className={cn('flex flex-wrap gap-4 mt-8', fullBleed && 'justify-center')}>
-      {section.buttons.map((btn, i) => (
+      {activations.map((activation, i) => (
         <button
-          key={i}
-          onClick={() => onPipeline(btn.pipeline, btn.open)}
+          key={activation.id || i}
+          onClick={() => executeNavAction(activation.action, deps)}
           className={cn(
             'flex items-center gap-2 px-8 py-4 text-xs font-black uppercase tracking-widest rounded-full transition-all active:scale-95',
             i === 0
@@ -140,7 +171,7 @@ function SectionButtons({
               : 'bg-background border border-border text-foreground hover:bg-muted',
           )}
         >
-          {btn.label}
+          {activation.label}
         </button>
       ))}
     </div>
@@ -149,21 +180,19 @@ function SectionButtons({
 
 /** Buttons rendered directly on the sticky view panel (from the view block). */
 function ViewPanelButtons({
-  buttons,
-  onPipeline,
+  activations,
   runState,
+  deps,
 }: {
-  buttons: ViewButton[]
-  onPipeline: (p: PipelineStep[], open?: OpenMode) => void
+  activations: INavActivation[]
   runState?: RunButtonState
+  deps: NavActionDeps
 }) {
-  if (buttons.length === 0) return null
+  if (activations.length === 0) return null
 
-  const firstBtn = buttons[0]
-  const isRunButton = firstBtn.pipeline.some(s => s.action === 'set-state' && s.value === 'track')
-
-  if (isRunButton && runState) {
-    const rest = buttons.slice(1)
+  const first = activations[0]
+  if (isRunActivation(first) && runState) {
+    const rest = activations.slice(1)
     return (
       <div className="flex flex-wrap items-center gap-3 justify-end pt-3 px-1">
         <SplitRunButton
@@ -171,15 +200,15 @@ function ViewPanelButtons({
           onFullscreen={runState.onFullscreen}
           isReconnect={runState.isReconnect}
           onReconnect={runState.onReconnect}
-          label={firstBtn.label}
+          label={first.label}
         />
-        {rest.map((btn, i) => (
+        {rest.map((activation, i) => (
           <button
-            key={i}
-            onClick={() => onPipeline(btn.pipeline, btn.open)}
+            key={activation.id || i}
+            onClick={() => executeNavAction(activation.action, deps)}
             className="px-5 py-2 text-[11px] font-black uppercase tracking-widest rounded-full bg-muted border border-border text-foreground hover:bg-muted/80 transition-all active:scale-95"
           >
-            {btn.label}
+            {activation.label}
           </button>
         ))}
       </div>
@@ -188,10 +217,10 @@ function ViewPanelButtons({
 
   return (
     <div className="flex flex-wrap gap-3 justify-end pt-3 px-1">
-      {buttons.map((btn, i) => (
+      {activations.map((activation, i) => (
         <button
-          key={i}
-          onClick={() => onPipeline(btn.pipeline, btn.open)}
+          key={activation.id || i}
+          onClick={() => executeNavAction(activation.action, deps)}
           className={cn(
             'px-5 py-2 text-[11px] font-black uppercase tracking-widest rounded-full transition-all active:scale-95',
             i === 0
@@ -199,7 +228,7 @@ function ViewPanelButtons({
               : 'bg-muted border border-border text-foreground hover:bg-muted/80',
           )}
         >
-          {btn.label}
+          {activation.label}
         </button>
       ))}
     </div>
@@ -309,59 +338,53 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
   // Whether any active runtime is currently tracked for view-mode reconnect
   const hasActiveViewRuntime = viewTimerBlock !== null
 
-  const executePipeline = useCallback((pipeline: PipelineStep[], openMode: OpenMode = 'dialog') => {
-    for (const step of pipeline) {
-      if (step.action === 'set-source') {
-        swapSource(resolveSource(step.value, wodFilesRef.current))
-      } else if (step.action === 'navigate') {
-        navigate(step.value)
-      } else if (step.action === 'set-state') {
-        if (step.value === 'note') {
-          // Return to editor — close any running view-mode runtime
-          closeViewRuntime()
-        } else if (step.value === 'review') {
-          // Jump directly to review panel (no new runtime needed)
-          setPanelMode('review')
-        } else if (step.value === 'track') {
-          const block = wodBlocksRef.current[0] ?? null
-          if (!block) break
-          if (openMode === 'view') {
-            launchViewRuntime(block)
-          } else if (openMode === 'dialog') {
-            setFullscreenBlock(block)
-          } else if (openMode === 'route') {
-            const runtimeId = uuidv4()
-            pendingRuntimes.set(runtimeId, { block, noteId: '' })
-            navigate(`/tracker/${runtimeId}`)
-          }
-        }
-      }
-    }
-  }, [navigate, swapSource, launchViewRuntime, closeViewRuntime])
-
-  // RunButtonState passed down to both SectionButtons and ViewPanelButtons
-  const runState: RunButtonState = {
-    isReconnect: hasActiveViewRuntime && panelMode !== 'running',
-    onReconnect: () => setPanelMode('running'),
-    onRun: () => {
-      const block = wodBlocksRef.current[0] ?? null
-      if (!block) return
-      launchViewRuntime(block)
-    },
-    onFullscreen: () => {
-      const block = wodBlocksRef.current[0] ?? null
-      if (!block) return
-      const runtimeId = uuidv4()
-      pendingRuntimes.set(runtimeId, { block, noteId: '' })
-      navigate(`/tracker/${runtimeId}`)
-    },
-  }
-
   // ── Query-param tracking: ?h=section-slug ───────────────────────────────
   const [headingParam, setHeadingParam] = useQueryState('h', {
     history: 'replace',
     shallow: true,
   })
+
+  // ── NavActionDeps — single dispatch object for all INavAction surfaces ──────
+  const deps = useMemo<NavActionDeps>(() => ({
+    navigate: (to, opts) => navigate(to, { replace: opts?.replace }),
+    setQueryParam: (params, replace) => {
+      // Only h= is managed here; other params passed through as needed
+      const h = params['h']
+      if (h !== undefined) setHeadingParam(h, { history: replace ? 'replace' : 'push' })
+    },
+    swapSource: (source: string) => swapSource(resolveSource(source, wodFilesRef.current)),
+    setPanelState: (state, open) => {
+      if (state === 'note') {
+        closeViewRuntime()
+      } else if (state === 'review') {
+        setPanelMode('review')
+      } else if (state === 'track') {
+        const block = wodBlocksRef.current[0] ?? null
+        if (!block) return
+        if (open === 'view')   launchViewRuntime(block)
+        else if (open === 'route') {
+          const runtimeId = uuidv4()
+          pendingRuntimes.set(runtimeId, { block, noteId: '' })
+          navigate(`/tracker/${runtimeId}`)
+        } else {
+          setFullscreenBlock(block)
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }), [navigate, swapSource, launchViewRuntime, closeViewRuntime])
+
+  // Stable ref so observer callbacks never close over stale deps
+  const depsRef = useRef(deps)
+  depsRef.current = deps
+
+  // RunButtonState — shortcuts for SplitRunButton's specific call signatures
+  const runState: RunButtonState = {
+    isReconnect: hasActiveViewRuntime && panelMode !== 'running',
+    onReconnect: () => setPanelMode('running'),
+    onRun:       () => deps.setPanelState?.('track', 'view'),
+    onFullscreen:() => deps.setPanelState?.('track', 'route'),
+  }
 
   // ── IntersectionObserver — ratio-map so only the most-visible section wins ──
   // This prevents the flicker of multiple sections firing simultaneously on load.
@@ -370,10 +393,6 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
   const lastActiveSectionId = useRef<string | null>(null)
   const ratioMap            = useRef(new Map<string, number>())
   const scrollDirRef        = useRef<1 | -1>(1)
-  const executePipelineRef  = useRef(executePipeline)
-  executePipelineRef.current = executePipeline
-  const setHeadingParamRef  = useRef(setHeadingParam)
-  setHeadingParamRef.current = setHeadingParam
 
   const setStepRef = useCallback((id: string) => (el: HTMLDivElement | null) => {
     if (el) stepRefs.current.set(id, el)
@@ -420,14 +439,17 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
 
         if (bestId && bestId !== lastActiveSectionId.current) {
           lastActiveSectionId.current = bestId
-          // Update ?h= query param without pushing a new history entry
-          setHeadingParamRef.current(bestId)
+          // Update ?h= via RouteQueryAction (replaceState — no history flood)
+          executeNavAction({ type: 'query', params: { h: bestId }, pushHistory: false }, depsRef.current)
           const section = contentSections.find(s => s.id === bestId)
           if (section) {
             for (const cmd of section.commands) {
-              // Scroll-triggered commands default to 'view' (inline panel),
-              // not 'dialog' (fullscreen), so set-state:track stays in the panel.
-              executePipelineRef.current(cmd.pipeline, cmd.open ?? 'view')
+              // Scroll-triggered commands default to 'view' (inline panel).
+              const steps = cmd.pipeline.map(s => pipelineStepToNavAction(s, cmd.open ?? 'view'))
+              executeNavAction(
+                steps.length === 1 ? steps[0] : { type: 'pipeline', steps },
+                depsRef.current,
+              )
             }
           }
         }
@@ -538,9 +560,9 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
       </div>
       {showPanelButtons && (
         <ViewPanelButtons
-          buttons={viewDef.buttons}
-          onPipeline={executePipeline}
+          activations={viewDef.buttons.map((b, i) => buttonToActivation(b, i))}
           runState={runState}
+          deps={deps}
         />
       )}
     </div>
@@ -559,9 +581,9 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
         </div>
         {showPanelButtons && (
           <ViewPanelButtons
-            buttons={viewDef.buttons}
-            onPipeline={executePipeline}
+            activations={viewDef.buttons.map((b, i) => buttonToActivation(b, i))}
             runState={runState}
+            deps={deps}
           />
         )}
       </div>
@@ -642,10 +664,10 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
                     )}
 
                     <SectionButtons
-                      section={section}
+                      activations={section.buttons.map((b, i) => buttonToActivation(b, i))}
                       fullBleed={fullBleed}
-                      onPipeline={executePipeline}
                       runState={viewDef ? runState : undefined}
+                      deps={deps}
                     />
                   </div>
                 </div>

--- a/playground/src/components/HomeHero.tsx
+++ b/playground/src/components/HomeHero.tsx
@@ -73,27 +73,7 @@ export function HomeHero() {
         <p className="mt-6 max-w-xl text-lg font-normal leading-[1.5] text-muted-foreground">
           Plan with Markdown, execute with a precision timer, and evolve with performance insights — all in one place.
         </p>
-
-        {/* CTA row */}
-        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
-          <button
-            onClick={() => navigate('/journal')}
-            className="inline-flex items-center gap-2 rounded-pill bg-foreground px-6 py-2.5 text-[0.94rem] font-medium text-background shadow-[rgba(0,0,0,0.06)_0px_1px_2px] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
-          >
-            Start Planning
-          </button>
-          <button
-            onClick={() => navigate('/collections')}
-            className="inline-flex items-center gap-2 rounded-pill border border-black/8 bg-background px-6 py-2.5 text-[0.94rem] font-medium text-foreground transition-opacity hover:opacity-90 dark:border-white/8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
-          >
-            Examples
-          </button>
-        </div>
-
-        <p className="mt-4 text-sm font-medium text-muted-foreground">
-          keep scrolling for Quick Start guide.
-        </p>
-
+  
         {/* Feature cards */}
         <div
           ref={scrollerRef}
@@ -119,6 +99,22 @@ export function HomeHero() {
               </p>
             </button>
           ))}
+        </div>
+
+        {/* CTA row */}
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-3">
+          <button
+            onClick={() => navigate('/journal')}
+            className="inline-flex items-center gap-2 rounded-pill bg-foreground px-6 py-2.5 text-[0.94rem] font-medium text-background shadow-[rgba(0,0,0,0.06)_0px_1px_2px] transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+          >
+            Start Planning
+          </button>
+          <button
+            onClick={() => navigate('/collections')}
+            className="inline-flex items-center gap-2 rounded-pill border border-black/8 bg-background px-6 py-2.5 text-[0.94rem] font-medium text-foreground transition-opacity hover:opacity-90 dark:border-white/8 focus-visible:outline focus-visible:outline-2 focus-visible:outline-ring"
+          >
+            See Examples
+          </button>
         </div>
 
         {/* Scroll cue */}

--- a/playground/src/config/collectionGroups.ts
+++ b/playground/src/config/collectionGroups.ts
@@ -1,0 +1,37 @@
+/**
+ * collectionGroups — shared mapping of category labels → collection IDs.
+ *
+ * Used by:
+ *   - CollectionsPage  — to group the list by category
+ *   - MarkdownCanvasPage — to show a clickable category chip on collection detail pages
+ */
+
+export const COLLECTION_GROUPS: Record<string, string[]> = {
+  Kettlebell: [
+    'kettlebell', 'dan-john', 'geoff-neupert', 'girevoy-sport',
+    'joe-daniels', 'keith-weber', 'mark-wildman', 'steve-cotter', 'strongfirst',
+  ],
+  Crossfit: [
+    'crossfit-games - 2020',
+    'crossfit-games - 2021',
+    'crossfit-games - 2022',
+    'crossfit-games - 2023',
+    'crossfit-games - 2024',
+    'crossfit-girls',
+  ],
+  Swimming: [
+    'swimming-pre-highschool', 'swimming-highschool', 'swimming-college',
+    'swimming-post-college', 'swimming-masters', 'swimming-olympic', 'swimming-triathlete',
+  ],
+  Other: ['unconventional'],
+}
+
+export const ASSIGNED = new Set(Object.values(COLLECTION_GROUPS).flat())
+
+/** Returns the category label (e.g. "Kettlebell") for a given collection id, or null. */
+export function getCategoryForCollection(collectionId: string): string | null {
+  for (const [label, ids] of Object.entries(COLLECTION_GROUPS)) {
+    if (ids.includes(collectionId)) return label
+  }
+  return null
+}

--- a/playground/src/hooks/useCollectionsQueryState.ts
+++ b/playground/src/hooks/useCollectionsQueryState.ts
@@ -1,0 +1,74 @@
+/**
+ * useCollectionsQueryState — nuqs-backed URL state for the Collections page.
+ *
+ * Manages two URL parameters:
+ *   `q`          — text search query (default: '')
+ *   `categories` — active category slugs (comma-separated, default: '')
+ *
+ * Both the CollectionsNavPanel (writer) and CollectionsPage (reader) share
+ * this hook so the URL is always the source of truth.
+ */
+
+import { useQueryState } from 'nuqs';
+import { useMemo, useCallback } from 'react';
+
+const CATEGORIES_SEPARATOR = ',';
+
+function parseCategories(raw: string): string[] {
+  if (!raw) return [];
+  return raw.split(CATEGORIES_SEPARATOR).filter(Boolean);
+}
+
+function serializeCategories(cats: string[]): string {
+  return cats.filter(Boolean).join(CATEGORIES_SEPARATOR);
+}
+
+export function useCollectionsQueryState() {
+  // ── Text search ───────────────────────────────────────────────────────
+  const [text, setText] = useQueryState('q', {
+    defaultValue: '',
+    shallow: true,
+    history: 'replace',
+  });
+
+  // ── Category filter ───────────────────────────────────────────────────
+  const [categoriesParam, setCategoriesParam] = useQueryState('categories', {
+    defaultValue: '',
+    shallow: true,
+    history: 'replace',
+  });
+
+  const selectedCategories = useMemo(
+    () => parseCategories(categoriesParam),
+    [categoriesParam],
+  );
+
+  const setSelectedCategories = useCallback(
+    (cats: string[]) => setCategoriesParam(serializeCategories(cats)),
+    [setCategoriesParam],
+  );
+
+  const toggleCategory = useCallback(
+    (slug: string) => {
+      const next = selectedCategories.includes(slug)
+        ? selectedCategories.filter(c => c !== slug)
+        : [...selectedCategories, slug];
+      setSelectedCategories(next);
+    },
+    [selectedCategories, setSelectedCategories],
+  );
+
+  const clearCategories = useCallback(
+    () => setCategoriesParam(''),
+    [setCategoriesParam],
+  );
+
+  return {
+    text,
+    setText,
+    selectedCategories,
+    setSelectedCategories,
+    toggleCategory,
+    clearCategories,
+  };
+}

--- a/playground/src/hooks/usePlaygroundContent.ts
+++ b/playground/src/hooks/usePlaygroundContent.ts
@@ -4,6 +4,8 @@
  * 1. If the page exists in IndexedDB → return the stored content.
  * 2. If not → return the original MD content and seed IndexedDB for next time.
  * 3. On edits (onChange) → persist to IndexedDB so block IDs remain stable.
+ * 4. On unmount (navigation away) → flush any pending debounced save immediately
+ *    so no edits are lost when the user navigates before the debounce fires.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
@@ -27,6 +29,8 @@ interface UsePlaygroundContentResult {
   resetToOriginal: () => void;
   /** Whether the content has been modified from the original MD */
   isModified: boolean;
+  /** Force an immediate save (skips debounce). Safe to call anytime. */
+  flush: () => void;
 }
 
 export function usePlaygroundContent({
@@ -39,6 +43,15 @@ export function usePlaygroundContent({
   const [loading, setLoading] = useState(true);
   const [isModified, setIsModified] = useState(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Tracks the latest unsaved content so the unmount flush can write the right value
+  const pendingContentRef = useRef<string | null>(null);
+  // Stable refs for use in the unmount cleanup (avoids stale closure)
+  const pageIdRef = useRef(pageId);
+  const categoryRef = useRef(category);
+  const nameRef = useRef(name);
+  useEffect(() => { pageIdRef.current = pageId; }, [pageId]);
+  useEffect(() => { categoryRef.current = category; }, [category]);
+  useEffect(() => { nameRef.current = name; }, [name]);
 
   // Load from IndexedDB on mount (or when page identity changes)
   useEffect(() => {
@@ -86,9 +99,12 @@ export function usePlaygroundContent({
     (value: string) => {
       setContent(value);
       setIsModified(value !== mdContent);
+      pendingContentRef.current = value;
 
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
+        saveTimerRef.current = null;
+        pendingContentRef.current = null;
         playgroundDB.savePage({
           id: pageId,
           category,
@@ -100,6 +116,24 @@ export function usePlaygroundContent({
     },
     [pageId, category, name, mdContent],
   );
+
+  /** Immediately persist any buffered edit (cancel + flush the debounce). */
+  const flush = useCallback(() => {
+    if (saveTimerRef.current === null) return; // nothing pending
+    clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = null;
+    const value = pendingContentRef.current;
+    pendingContentRef.current = null;
+    if (value !== null) {
+      playgroundDB.savePage({
+        id: pageIdRef.current,
+        category: categoryRef.current,
+        name: nameRef.current,
+        content: value,
+        updatedAt: Date.now(),
+      });
+    }
+  }, []);
 
   const resetToOriginal = useCallback(() => {
     setContent(mdContent);
@@ -113,12 +147,26 @@ export function usePlaygroundContent({
     });
   }, [pageId, category, name, mdContent]);
 
-  // Cleanup debounce timer
+  // Flush any pending debounced save on unmount (navigation away, route change, etc.)
+  // Uses refs so the cleanup always sees the latest pageId/category/name.
   useEffect(() => {
     return () => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      if (saveTimerRef.current !== null) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+        const value = pendingContentRef.current;
+        if (value !== null) {
+          playgroundDB.savePage({
+            id: pageIdRef.current,
+            category: categoryRef.current,
+            name: nameRef.current,
+            content: value,
+            updatedAt: Date.now(),
+          });
+        }
+      }
     };
   }, []);
 
-  return { content, loading, onChange, resetToOriginal, isModified };
+  return { content, loading, onChange, resetToOriginal, isModified, flush };
 }

--- a/playground/src/nav/NavContext.tsx
+++ b/playground/src/nav/NavContext.tsx
@@ -40,7 +40,6 @@ export const initialNavState: NavState = {
   expandedIds: new Set(),
   journalFilter: { selectedDate: null, selectedTags: [] },
   searchFilter: { scope: 'all' },
-  collectionsFilter: { categories: [] },
 }
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────
@@ -63,8 +62,6 @@ export function navReducer(state: NavState, action: NavStateAction): NavState {
       return { ...state, journalFilter: { ...state.journalFilter, selectedTags: action.tags } }
     case 'SET_SEARCH_SCOPE':
       return { ...state, searchFilter: { scope: action.scope } }
-    case 'SET_COLLECTIONS_CATEGORIES':
-      return { ...state, collectionsFilter: { categories: action.categories } }
     default:
       return state
   }

--- a/playground/src/nav/NavSidebar.tsx
+++ b/playground/src/nav/NavSidebar.tsx
@@ -26,7 +26,8 @@ import {
 import { SidebarAccordion } from '@/components/playground/SidebarAccordion'
 
 import { useNav } from './NavContext'
-import type { NavItem, NavItemL3 } from './navTypes'
+import { executeNavAction } from './navTypes'
+import type { NavItem, NavItemL3, NavActionDeps } from './navTypes'
 
 // App version injected by Vite define
 declare const __APP_VERSION__: string | undefined
@@ -34,16 +35,24 @@ const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-function useNavAction() {
+function useNavDeps(): NavActionDeps {
   const navigate = useNavigate()
   const { scrollToSection } = useNav()
 
-  return (item: NavItem | NavItemL3) => {
-    const { action } = item
-    if (action.type === 'route')  navigate(action.to)
-    if (action.type === 'scroll') scrollToSection(action.sectionId)
-    if (action.type === 'call')   action.handler()
+  return {
+    navigate: (to, opts) => navigate(to, { replace: opts?.replace }),
+    setQueryParam: (_params, _replace) => {
+      // Sidebar clicks on L3 section items use scrollToSection instead.
+      // URL query params are updated by the page's IntersectionObserver.
+    },
+    scrollToSection,
   }
+}
+
+function useNavAction() {
+  const deps = useNavDeps()
+
+  return (item: NavItem | NavItemL3) => executeNavAction(item.action, deps)
 }
 
 function isItemActive(item: NavItem, navState: ReturnType<typeof useNav>['navState'], location: ReturnType<typeof useLocation>): boolean {
@@ -54,6 +63,7 @@ function isItemActive(item: NavItem, navState: ReturnType<typeof useNav>['navSta
       : location.pathname === item.action.to
   }
   if (item.action.type === 'scroll') return navState.activeL3Id === item.action.sectionId
+  if (item.action.type === 'query') return navState.activeL3Id === item.id
   return false
 }
 
@@ -115,6 +125,7 @@ function L2ChildrenList({ items }: { items: NavItem[] }) {
 
 function L3Accordion({ items }: { items: NavItemL3[] }) {
   const { navState, scrollToSection } = useNav()
+  const deps = useNavDeps()
 
   if (items.length === 0) return null
 
@@ -142,7 +153,7 @@ function L3Accordion({ items }: { items: NavItemL3[] }) {
 
             {item.secondaryAction && (
               <button
-                onClick={item.secondaryAction.handler}
+                onClick={() => executeNavAction(item.secondaryAction!.action, deps)}
                 title={item.secondaryAction.label ?? 'Run'}
                 className="opacity-0 group-hover:opacity-100 mr-2 flex items-center justify-center size-6 rounded text-primary hover:bg-primary/10 transition-all"
               >
@@ -232,6 +243,8 @@ export function NavSidebar() {
       <SidebarBody>
         {/* L2 — context-specific panel or doc children */}
         {renderL2()}
+        {/* L3 — "On this page" index (hidden at 3xl+ where right panel takes over) */}
+        <L3Accordion items={l3Items} />
       </SidebarBody>
     </Sidebar>
   )

--- a/playground/src/nav/NavSidebar.tsx
+++ b/playground/src/nav/NavSidebar.tsx
@@ -1,19 +1,18 @@
 /**
  * NavSidebar — renders the left sidebar from NavContext.
  *
- * Replaces the inline sidebar JSX previously hardcoded in App.tsx.
- *
  * Rendering layers (top → bottom):
  *   1. App logo + version
  *   2. L1 items  (Home, Journal, Collections, Search)
  *   3. L2 panel  (children list OR custom component for the active L1)
- *   4. L3 "On this page" accordion (hidden at 3xl+ — right panel takes over)
+ *
+ * "On this page" (L3) section links are intentionally excluded here — they
+ * appear only in the "…" ActionsMenu so they don't duplicate the right TOC.
  */
 
 import { useNavigate, useLocation } from 'react-router-dom'
 import type { Location } from 'react-router-dom'
 import { Dumbbell } from 'lucide-react'
-import { DocumentTextIcon, PlayIcon } from '@heroicons/react/20/solid'
 
 import {
   Sidebar,
@@ -27,7 +26,7 @@ import { SidebarAccordion } from '@/components/playground/SidebarAccordion'
 
 import { useNav } from './NavContext'
 import { executeNavAction } from './navTypes'
-import type { NavItem, NavItemL3, NavActionDeps } from './navTypes'
+import type { NavItem, NavActionDeps } from './navTypes'
 
 // App version injected by Vite define
 declare const __APP_VERSION__: string | undefined
@@ -52,7 +51,7 @@ function useNavDeps(): NavActionDeps {
 function useNavAction() {
   const deps = useNavDeps()
 
-  return (item: NavItem | NavItemL3) => executeNavAction(item.action, deps)
+  return (item: NavItem) => executeNavAction(item.action, deps)
 }
 
 function isItemActive(item: NavItem, navState: ReturnType<typeof useNav>['navState'], location: ReturnType<typeof useLocation>): boolean {
@@ -121,56 +120,10 @@ function L2ChildrenList({ items }: { items: NavItem[] }) {
   )
 }
 
-// ─── L3 accordion ─────────────────────────────────────────────────────────────
-
-function L3Accordion({ items }: { items: NavItemL3[] }) {
-  const { navState, scrollToSection } = useNav()
-  const deps = useNavDeps()
-
-  if (items.length === 0) return null
-
-  return (
-    <SidebarAccordion
-      title="On this page"
-      count={items.length}
-      defaultOpen
-      className="3xl:hidden"
-    >
-      {items.map(item => {
-        const isActive = navState.activeL3Id === item.id
-        const sectionId = item.action.type === 'scroll' ? item.action.sectionId : item.id
-
-        return (
-          <div key={item.id} className="flex items-center group">
-            <SidebarItem
-              onClick={() => scrollToSection(sectionId)}
-              current={isActive}
-              className="flex-1"
-            >
-              <DocumentTextIcon data-slot="icon" />
-              <SidebarLabel>{item.label}</SidebarLabel>
-            </SidebarItem>
-
-            {item.secondaryAction && (
-              <button
-                onClick={() => executeNavAction(item.secondaryAction!.action, deps)}
-                title={item.secondaryAction.label ?? 'Run'}
-                className="opacity-0 group-hover:opacity-100 mr-2 flex items-center justify-center size-6 rounded text-primary hover:bg-primary/10 transition-all"
-              >
-                <PlayIcon className="size-3.5" />
-              </button>
-            )}
-          </div>
-        )
-      })}
-    </SidebarAccordion>
-  )
-}
-
 // ─── Main component ───────────────────────────────────────────────────────────
 
 export function NavSidebar() {
-  const { tree, navState, dispatch, l3Items } = useNav()
+  const { tree, navState, dispatch } = useNav()
   const location = useLocation()
   const handleAction = useNavAction()
 
@@ -243,8 +196,6 @@ export function NavSidebar() {
       <SidebarBody>
         {/* L2 — context-specific panel or doc children */}
         {renderL2()}
-        {/* L3 — "On this page" index (hidden at 3xl+ where right panel takes over) */}
-        <L3Accordion items={l3Items} />
       </SidebarBody>
     </Sidebar>
   )

--- a/playground/src/nav/appNavTree.ts
+++ b/playground/src/nav/appNavTree.ts
@@ -26,7 +26,6 @@ import type { Location } from 'react-router-dom'
 
 import { JournalNavPanel }     from './panels/JournalNavPanel'
 import { CollectionsNavPanel } from './panels/CollectionsNavPanel'
-import { SearchNavPanel }      from './panels/SearchNavPanel'
 import { canvasRoutes }        from '../canvas/canvasRoutes'
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -72,7 +71,14 @@ const homeChildren: NavItem[] = [
 
 // ─── App nav tree ─────────────────────────────────────────────────────────────
 
-export const appNavTree: NavItem[] = [
+/**
+ * Build the application navigation tree.
+ *
+ * @param openSearch - callback invoked when the Search item is activated
+ *   (sidebar click, keyboard shortcut). Replaces the old /search route.
+ */
+export function buildAppNavTree(openSearch: () => void): NavItem[] {
+  return [
   {
     id: 'home',
     label: 'Home',
@@ -113,8 +119,12 @@ export const appNavTree: NavItem[] = [
     label: 'Search',
     level: 1,
     icon: MagnifyingGlassIcon,
-    action: { type: 'route', to: '/search' },
-    isActive: isRouteActive('/search'),
-    panel: SearchNavPanel,
+    action: { type: 'call', handler: openSearch },
+    // Never marks a route as active — palette is modal, not a page
+    isActive: (_loc: Location) => false,
   },
 ]
+}
+
+/** Static default tree (no search handler) — kept for tests / storybook. */
+export const appNavTree: NavItem[] = buildAppNavTree(() => {})

--- a/playground/src/nav/navTypes.ts
+++ b/playground/src/nav/navTypes.ts
@@ -64,11 +64,6 @@ export interface SearchFilterState {
   scope: 'all' | 'collections' | 'notes' | 'results'
 }
 
-export interface CollectionsFilterState {
-  /** Active category slugs e.g. ['kettlebell'] */
-  categories: string[]
-}
-
 // ─── Global nav state ─────────────────────────────────────────────────────────
 
 export interface NavState {
@@ -81,7 +76,6 @@ export interface NavState {
   expandedIds: Set<string>
   journalFilter: JournalFilterState
   searchFilter: SearchFilterState
-  collectionsFilter: CollectionsFilterState
 }
 
 // ─── Dispatch ─────────────────────────────────────────────────────────────────
@@ -96,7 +90,6 @@ export type NavStateAction =
   | { type: 'SET_JOURNAL_DATE';            date: string | null }
   | { type: 'SET_JOURNAL_TAGS';            tags: string[] }
   | { type: 'SET_SEARCH_SCOPE';            scope: SearchFilterState['scope'] }
-  | { type: 'SET_COLLECTIONS_CATEGORIES';  categories: string[] }
 
 export type NavDispatch = React.Dispatch<NavStateAction>
 

--- a/playground/src/nav/navTypes.ts
+++ b/playground/src/nav/navTypes.ts
@@ -3,18 +3,149 @@
  *
  * All three navigation zones (mobile bar, sidebar, page header, right index)
  * consume the same NavItem tree and share one NavState object.
+ *
+ * INavActivation is the base interface for every activatable UI element:
+ *   NavItem, NavItemL3, canvas ButtonBlock/CommandBlock, toolbar buttons,
+ *   playground links, keyboard bindings.
+ *
+ * All surfaces dispatch through executeNavAction(action, deps) so no
+ * individual component carries routing or panel-state logic.
  */
 
 import type React from 'react'
 import type { Location } from 'react-router-dom'
 
-// ─── Action ──────────────────────────────────────────────────────────────────
+// ─── INavAction — discriminated union of all action types ────────────────────
 
-export type NavAction =
-  | { type: 'route';  to: string }
-  | { type: 'scroll'; sectionId: string }
-  | { type: 'call';   handler: () => void }
-  | { type: 'none' }
+/** Navigate to a new route. */
+export interface RouteChangeAction {
+  type: 'route'
+  to: string
+  /** Add a browser history entry. Default: true. */
+  pushHistory?: boolean
+}
+
+/** Update URL query params without a route change (replaceState by default). */
+export interface RouteQueryAction {
+  type: 'query'
+  params: Record<string, string | null>
+  /** Add a browser history entry. Default: false (replaceState). */
+  pushHistory?: boolean
+}
+
+/** Scroll the page to a named anchor and mark it active in the sidebar. */
+export interface ScrollAction {
+  type: 'scroll'
+  sectionId: string
+}
+
+/**
+ * Swap the sticky view panel's editor source content.
+ * Canvas pages only — silently ignored on other surfaces.
+ */
+export interface ViewSourceAction {
+  type: 'view-source'
+  source: string
+}
+
+/**
+ * Transition the view panel state machine.
+ *   'note'   → show NoteEditor (reset)
+ *   'track'  → launch the first WOD block
+ *   'review' → show post-workout review
+ * Canvas pages only — silently ignored on other surfaces.
+ */
+export interface ViewStateAction {
+  type: 'view-state'
+  state: 'note' | 'track' | 'review'
+  /** Where to launch the runtime when state='track'. Default: 'dialog'. */
+  open?: 'view' | 'dialog' | 'route'
+}
+
+/** Execute a sequence of actions in order. Replaces PipelineStep[]. */
+export interface PipelineAction {
+  type: 'pipeline'
+  steps: INavAction[]
+}
+
+/** Invoke an arbitrary handler. */
+export interface CallAction {
+  type: 'call'
+  handler: () => void
+  label?: string
+}
+
+/** No-op — for accordion group headers. */
+export interface NoneAction {
+  type: 'none'
+}
+
+export type INavAction =
+  | RouteChangeAction
+  | RouteQueryAction
+  | ScrollAction
+  | ViewSourceAction
+  | ViewStateAction
+  | PipelineAction
+  | CallAction
+  | NoneAction
+
+/** Legacy alias kept for existing NavItem/NavItemL3 usage. */
+export type NavAction = INavAction
+
+// ─── INavActivation — base interface for every activatable UI element ─────────
+
+export interface INavActivation {
+  id: string
+  label: string
+  icon?: React.ComponentType<{ className?: string; 'data-slot'?: string }>
+  action: INavAction
+}
+
+// ─── NavActionDeps — injected by each rendering surface ──────────────────────
+
+export interface NavActionDeps {
+  navigate:          (to: string, opts?: { replace?: boolean }) => void
+  setQueryParam:     (params: Record<string, string | null>, replace?: boolean) => void
+  /** Scroll to a named anchor on the current page. */
+  scrollToSection?:  (id: string) => void
+  /** Fade-swap the sticky editor panel source. Canvas pages only. */
+  swapSource?:       (source: string) => void
+  /** Transition the view panel state machine. Canvas pages only. */
+  setPanelState?:    (state: 'note' | 'track' | 'review', open?: 'view' | 'dialog' | 'route') => void
+}
+
+/**
+ * executeNavAction — single dispatch function for all rendering surfaces.
+ * View-container actions are silently skipped when their deps are absent.
+ */
+export function executeNavAction(action: INavAction, deps: NavActionDeps): void {
+  switch (action.type) {
+    case 'route':
+      deps.navigate(action.to, { replace: !(action.pushHistory ?? true) })
+      break
+    case 'query':
+      deps.setQueryParam(action.params, !(action.pushHistory ?? false))
+      break
+    case 'scroll':
+      deps.scrollToSection?.(action.sectionId)
+      break
+    case 'view-source':
+      deps.swapSource?.(action.source)
+      break
+    case 'view-state':
+      deps.setPanelState?.(action.state, action.open)
+      break
+    case 'pipeline':
+      action.steps.forEach(step => executeNavAction(step, deps))
+      break
+    case 'call':
+      action.handler()
+      break
+    case 'none':
+      break
+  }
+}
 
 // ─── Zone ────────────────────────────────────────────────────────────────────
 
@@ -91,28 +222,12 @@ export interface NavItemRenderProps {
 
 // ─── NavItem — universal link/node interface ──────────────────────────────────
 
-export interface NavItem {
-  /** Unique stable identifier */
-  id: string
-
-  /** Display label */
-  label: string
-
+export interface NavItem extends INavActivation {
   /** Hierarchy level (1 = top, 2 = context panel, 3 = page index) */
   level: 1 | 2 | 3
 
-  /** What happens when the item is activated */
-  action: NavAction
-
-  // ── Presentation ─────────────────────────────────────────────────────────
-
-  /** Icon component (receives className for sizing) */
-  icon?: React.ComponentType<{ className?: string; 'data-slot'?: string }>
-
   /** Count badge for accordions */
   badge?: string | number
-
-  // ── Active state ─────────────────────────────────────────────────────────
 
   /**
    * Override active/selected detection.
@@ -120,12 +235,8 @@ export interface NavItem {
    */
   isActive?: (location: Location, navState: NavState) => boolean
 
-  // ── Tree structure ────────────────────────────────────────────────────────
-
   /** Child items — used to build nested lists or accordion groups */
   children?: NavItem[]
-
-  // ── Custom rendering ──────────────────────────────────────────────────────
 
   /**
    * Replace child list with a custom React component (calendar picker,
@@ -147,7 +258,7 @@ export interface NavItem {
 
 export interface NavItemL3 extends NavItem {
   level: 3
-  action: { type: 'scroll'; sectionId: string } | { type: 'none' }
+  action: ScrollAction | RouteQueryAction | NoneAction
   /** Secondary inline action — rendered as a small Play button */
-  secondaryAction?: { type: 'call'; handler: () => void; label?: string }
+  secondaryAction?: INavActivation
 }

--- a/playground/src/nav/navTypes.ts
+++ b/playground/src/nav/navTypes.ts
@@ -1,8 +1,9 @@
 /**
- * navTypes.ts — Shared navigation type contract
+ * navTypes.ts — Playground navigation type contract
  *
- * All three navigation zones (mobile bar, sidebar, page header, right index)
- * consume the same NavItem tree and share one NavState object.
+ * Re-exports all core types from @/nav/navTypes (the library layer) and
+ * adds playground-specific types: NavItem, NavItemL3, NavState, NavDispatch,
+ * and filter state interfaces.
  *
  * INavActivation is the base interface for every activatable UI element:
  *   NavItem, NavItemL3, canvas ButtonBlock/CommandBlock, toolbar buttons,
@@ -15,137 +16,32 @@
 import type React from 'react'
 import type { Location } from 'react-router-dom'
 
-// ─── INavAction — discriminated union of all action types ────────────────────
-
-/** Navigate to a new route. */
-export interface RouteChangeAction {
-  type: 'route'
-  to: string
-  /** Add a browser history entry. Default: true. */
-  pushHistory?: boolean
-}
-
-/** Update URL query params without a route change (replaceState by default). */
-export interface RouteQueryAction {
-  type: 'query'
-  params: Record<string, string | null>
-  /** Add a browser history entry. Default: false (replaceState). */
-  pushHistory?: boolean
-}
-
-/** Scroll the page to a named anchor and mark it active in the sidebar. */
-export interface ScrollAction {
-  type: 'scroll'
-  sectionId: string
-}
-
-/**
- * Swap the sticky view panel's editor source content.
- * Canvas pages only — silently ignored on other surfaces.
- */
-export interface ViewSourceAction {
-  type: 'view-source'
-  source: string
-}
-
-/**
- * Transition the view panel state machine.
- *   'note'   → show NoteEditor (reset)
- *   'track'  → launch the first WOD block
- *   'review' → show post-workout review
- * Canvas pages only — silently ignored on other surfaces.
- */
-export interface ViewStateAction {
-  type: 'view-state'
-  state: 'note' | 'track' | 'review'
-  /** Where to launch the runtime when state='track'. Default: 'dialog'. */
-  open?: 'view' | 'dialog' | 'route'
-}
-
-/** Execute a sequence of actions in order. Replaces PipelineStep[]. */
-export interface PipelineAction {
-  type: 'pipeline'
-  steps: INavAction[]
-}
-
-/** Invoke an arbitrary handler. */
-export interface CallAction {
-  type: 'call'
-  handler: () => void
-  label?: string
-}
-
-/** No-op — for accordion group headers. */
-export interface NoneAction {
-  type: 'none'
-}
-
-export type INavAction =
-  | RouteChangeAction
-  | RouteQueryAction
-  | ScrollAction
-  | ViewSourceAction
-  | ViewStateAction
-  | PipelineAction
-  | CallAction
-  | NoneAction
+// Re-export all shared base types from the library layer
+export type {
+  INavAction,
+  INavActivation,
+  NavActionDeps,
+  RouteChangeAction,
+  RouteQueryAction,
+  ScrollAction,
+  ViewSourceAction,
+  ViewStateAction,
+  PipelineAction,
+  CallAction,
+  NoneAction,
+} from '@/nav/navTypes'
+export { executeNavAction } from '@/nav/navTypes'
 
 /** Legacy alias kept for existing NavItem/NavItemL3 usage. */
-export type NavAction = INavAction
+export type { INavAction as NavAction } from '@/nav/navTypes'
 
-// ─── INavActivation — base interface for every activatable UI element ─────────
-
-export interface INavActivation {
-  id: string
-  label: string
-  icon?: React.ComponentType<{ className?: string; 'data-slot'?: string }>
-  action: INavAction
-}
-
-// ─── NavActionDeps — injected by each rendering surface ──────────────────────
-
-export interface NavActionDeps {
-  navigate:          (to: string, opts?: { replace?: boolean }) => void
-  setQueryParam:     (params: Record<string, string | null>, replace?: boolean) => void
-  /** Scroll to a named anchor on the current page. */
-  scrollToSection?:  (id: string) => void
-  /** Fade-swap the sticky editor panel source. Canvas pages only. */
-  swapSource?:       (source: string) => void
-  /** Transition the view panel state machine. Canvas pages only. */
-  setPanelState?:    (state: 'note' | 'track' | 'review', open?: 'view' | 'dialog' | 'route') => void
-}
-
-/**
- * executeNavAction — single dispatch function for all rendering surfaces.
- * View-container actions are silently skipped when their deps are absent.
- */
-export function executeNavAction(action: INavAction, deps: NavActionDeps): void {
-  switch (action.type) {
-    case 'route':
-      deps.navigate(action.to, { replace: !(action.pushHistory ?? true) })
-      break
-    case 'query':
-      deps.setQueryParam(action.params, !(action.pushHistory ?? false))
-      break
-    case 'scroll':
-      deps.scrollToSection?.(action.sectionId)
-      break
-    case 'view-source':
-      deps.swapSource?.(action.source)
-      break
-    case 'view-state':
-      deps.setPanelState?.(action.state, action.open)
-      break
-    case 'pipeline':
-      action.steps.forEach(step => executeNavAction(step, deps))
-      break
-    case 'call':
-      action.handler()
-      break
-    case 'none':
-      break
-  }
-}
+// Bring into local scope for use in NavItem/NavItemL3 definitions
+import type {
+  INavActivation,
+  ScrollAction,
+  RouteQueryAction,
+  NoneAction,
+} from '@/nav/navTypes'
 
 // ─── Zone ────────────────────────────────────────────────────────────────────
 

--- a/playground/src/nav/panels/CollectionsNavPanel.tsx
+++ b/playground/src/nav/panels/CollectionsNavPanel.tsx
@@ -2,27 +2,22 @@
  * CollectionsNavPanel — L2 context panel for the Collections L1 item.
  *
  * Renders category chip toggles (Kettlebell, Crossfit, Swimming, Other).
- * Dispatches SET_COLLECTIONS_CATEGORIES to update navState.
- * The CollectionsPage reads navState.collectionsFilter.categories to filter.
+ * Reads and writes the `categories` URL param via useCollectionsQueryState
+ * so CollectionsPage stays in sync without prop-drilling.
  */
 
 import { cn } from '@/lib/utils'
 import type { NavPanelProps } from '../navTypes'
+import { useCollectionsQueryState } from '../../hooks/useCollectionsQueryState'
 
 const GROUPS = ['Kettlebell', 'Crossfit', 'Swimming', 'Other']
 
-export function CollectionsNavPanel({ navState, dispatch }: NavPanelProps) {
-  const { categories } = navState.collectionsFilter
+export function CollectionsNavPanel(_props: NavPanelProps) {
+  const { selectedCategories, toggleCategory, clearCategories } = useCollectionsQueryState()
 
-  const toggle = (group: string) => {
-    const slug = group.toLowerCase()
-    const next = categories.includes(slug)
-      ? categories.filter(c => c !== slug)
-      : [...categories, slug]
-    dispatch({ type: 'SET_COLLECTIONS_CATEGORIES', categories: next })
-  }
+  const toggle = (group: string) => toggleCategory(group.toLowerCase())
 
-  const clearAll = () => dispatch({ type: 'SET_COLLECTIONS_CATEGORIES', categories: [] })
+  const clearAll = () => clearCategories()
 
   return (
     <div className="flex flex-col gap-2 px-2 py-3">
@@ -30,7 +25,7 @@ export function CollectionsNavPanel({ navState, dispatch }: NavPanelProps) {
         <div className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/60">
           Category
         </div>
-        {categories.length > 0 && (
+        {selectedCategories.length > 0 && (
           <button
             onClick={clearAll}
             className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
@@ -43,7 +38,7 @@ export function CollectionsNavPanel({ navState, dispatch }: NavPanelProps) {
       <div className="flex flex-col gap-1">
         {GROUPS.map(group => {
           const slug = group.toLowerCase()
-          const active = categories.includes(slug)
+          const active = selectedCategories.includes(slug)
           return (
             <button
               key={group}

--- a/playground/src/nav/panels/JournalNavPanel.tsx
+++ b/playground/src/nav/panels/JournalNavPanel.tsx
@@ -5,10 +5,12 @@
  *   - Mini month-view calendar (CalendarDatePicker)
  *   - Tag chip filter
  *
- * All state is backed by nuqs URL parameters (`d`, `month`, `tags`)
- * so the URL is the single source of truth across every journal control.
+ * Context-aware date click behaviour:
+ *   - On /journal        → updates the ?d= filter query param (scroll to date)
+ *   - On /journal/:date  → navigates to the clicked date's entry page
  */
 
+import { useMatch, useNavigate } from 'react-router-dom'
 import { CalendarDatePicker } from '@/components/ui/CalendarDatePicker'
 import { cn } from '@/lib/utils'
 import { useJournalQueryState } from '../../hooks/useJournalQueryState'
@@ -20,15 +22,35 @@ export function JournalNavPanel(_props: NavPanelProps) {
   const { selectedDate, setSelectedDate, dateParam, selectedTags, toggleTag } =
     useJournalQueryState()
 
-  const selectedDateObj = dateParam ? selectedDate : null
+  // Detect if we're viewing a specific journal entry (/journal/:date)
+  const entryMatch = useMatch('/journal/:date')
+  const navigate = useNavigate()
+
+  const isEntryPage = Boolean(entryMatch)
+
+  // On the entry page, highlight the date from the URL; otherwise use the filter param
+  const selectedDateObj = isEntryPage
+    ? (() => {
+        const d = new Date((entryMatch!.params.date ?? '') + 'T00:00:00')
+        return isNaN(d.getTime()) ? null : d
+      })()
+    : dateParam
+      ? selectedDate
+      : null
 
   const handleDateSelect = (date: Date) => {
-    const iso = date.toISOString().slice(0, 10)
-    // Toggle off if same date is already selected
-    if (iso === dateParam) {
-      setSelectedDate(null)
+    const iso = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+
+    if (isEntryPage) {
+      // On the note page: navigate to the selected date's entry
+      navigate(`/journal/${iso}`)
     } else {
-      setSelectedDate(date)
+      // On the list page: toggle the ?d= filter
+      if (iso === dateParam) {
+        setSelectedDate(null)
+      } else {
+        setSelectedDate(date)
+      }
     }
   }
 
@@ -41,8 +63,8 @@ export function JournalNavPanel(_props: NavPanelProps) {
         className="scale-95 origin-top-left"
       />
 
-      {/* Active date badge */}
-      {dateParam && (
+      {/* Active date badge — only meaningful on the list page */}
+      {!isEntryPage && dateParam && (
         <div className="flex items-center gap-2 px-2">
           <span className="text-xs text-muted-foreground">Filtered to</span>
           <button

--- a/playground/src/services/commandStrategies.tsx
+++ b/playground/src/services/commandStrategies.tsx
@@ -8,7 +8,8 @@ import { indexedDBService } from '@/services/db/IndexedDBService';
  */
 export const createGlobalSearchStrategy = (
   items: { id: string; name: string; category: string; content?: string }[],
-  onNavigate: (item: any) => void
+  onNavigate: (item: any) => void,
+  navigate?: (path: string) => void
 ): CommandStrategy => ({
   id: 'global-search',
   placeholder: 'Search workouts, results, or collections...',
@@ -64,8 +65,9 @@ export const createGlobalSearchStrategy = (
     if (result.type === 'workout') {
       onNavigate(result.payload);
     } else if (result.type === 'result') {
-      // Navigate to review page
-      window.location.hash = `#/review/${result.id}`;
+      if (navigate) {
+        navigate(`/review/${result.id}`);
+      }
     }
   }
 });

--- a/playground/src/views/CollectionsPage.tsx
+++ b/playground/src/views/CollectionsPage.tsx
@@ -1,31 +1,9 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQueryState } from 'nuqs';
 import { FolderIcon, ChevronRightIcon } from 'lucide-react';
 import { getWodCollections, type WodCollection } from '@/repositories/wod-collections';
-
-/** Predefined category grouping — collections-only, hidden from user controls */
-const COLLECTION_GROUPS: Record<string, string[]> = {
-  Kettlebell: [
-    'kettlebell', 'dan-john', 'geoff-neupert', 'girevoy-sport',
-    'joe-daniels', 'keith-weber', 'mark-wildman', 'steve-cotter', 'strongfirst',
-  ],
-  Crossfit: [
-    'crossfit-games - 2020', 
-    'crossfit-games - 2021', 
-    'crossfit-games - 2022', 
-    'crossfit-games - 2023', 
-    'crossfit-games - 2024',
-    'crossfit-girls'
-  ],
-  Swimming: [
-    'swimming-pre-highschool', 'swimming-highschool', 'swimming-college',
-    'swimming-post-college', 'swimming-masters', 'swimming-olympic', 'swimming-triathlete',
-  ],
-  Other: ['unconventional'],
-};
-
-const ASSIGNED = new Set(Object.values(COLLECTION_GROUPS).flat());
+import { useCollectionsQueryState } from '../hooks/useCollectionsQueryState';
+import { COLLECTION_GROUPS, ASSIGNED } from '../config/collectionGroups';
 
 /** Special collection link component — navigates to the collection canvas route */
 function CollectionLink({ collection }: { collection: WodCollection }) {
@@ -52,33 +30,47 @@ function CollectionLink({ collection }: { collection: WodCollection }) {
 }
 
 export function CollectionsPage() {
-  const [text] = useQueryState('q', { defaultValue: '' });
+  const { text, selectedCategories } = useCollectionsQueryState();
   const allCollections = useMemo(() => getWodCollections(), []);
 
   const filtered = useMemo(() => {
-    if (!text.trim()) return allCollections;
-    const q = text.toLowerCase();
-    return allCollections.filter(c =>
-      c.name.toLowerCase().includes(q) || c.id.toLowerCase().includes(q),
-    );
+    let result = allCollections;
+    if (text.trim()) {
+      const q = text.toLowerCase();
+      result = result.filter(c =>
+        c.name.toLowerCase().includes(q) || c.id.toLowerCase().includes(q),
+      );
+    }
+    return result;
   }, [allCollections, text]);
 
   const grouped = useMemo(() => {
     const filteredMap = new Map(filtered.map(c => [c.id, c]));
     const result: { label: string; items: WodCollection[] }[] = [];
-    for (const [label, ids] of Object.entries(COLLECTION_GROUPS)) {
+
+    const activeGroups = selectedCategories.length > 0
+      ? Object.entries(COLLECTION_GROUPS).filter(([label]) =>
+          selectedCategories.includes(label.toLowerCase()),
+        )
+      : Object.entries(COLLECTION_GROUPS);
+
+    for (const [label, ids] of activeGroups) {
       const items = ids.map(id => filteredMap.get(id)).filter(Boolean) as WodCollection[];
       if (items.length > 0) result.push({ label, items });
     }
-    // Ungrouped collections not in any predefined category
-    const ungrouped = filtered.filter(c => !ASSIGNED.has(c.id));
-    if (ungrouped.length > 0) {
-      const existing = result.find(g => g.label === 'Other');
-      if (existing) existing.items.push(...ungrouped);
-      else result.push({ label: 'Other', items: ungrouped });
+
+    // Ungrouped collections — only show when no category filter is active
+    if (selectedCategories.length === 0) {
+      const ungrouped = filtered.filter(c => !ASSIGNED.has(c.id));
+      if (ungrouped.length > 0) {
+        const existing = result.find(g => g.label === 'Other');
+        if (existing) existing.items.push(...ungrouped);
+        else result.push({ label: 'Other', items: ungrouped });
+      }
     }
+
     return result;
-  }, [filtered]);
+  }, [filtered, selectedCategories]);
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-card">

--- a/playground/src/views/ListViews.tsx
+++ b/playground/src/views/ListViews.tsx
@@ -1,14 +1,13 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQueryState } from 'nuqs';
-import { FilteredList } from './queriable-list/FilteredList';
-import { JournalDateScroll, localDateKey, type JournalDateScrollHandle } from './queriable-list/JournalDateScroll';
+import { JournalDateScroll, localDateKey, type JournalDateScrollHandle, type JournalEntrySummary } from './queriable-list/JournalDateScroll';
 import { indexedDBService } from '@/services/db/IndexedDBService';
+import { playgroundDB } from '../services/playgroundDB';
 import { useJournalQueryState } from '../hooks/useJournalQueryState';
 import type { FilteredListItem } from './queriable-list/types';
 
 interface BaseProps {
-  workoutItems: { id: string; name: string; category: string; content?: string }[];
+  workoutItems?: { id: string; name: string; category: string; content?: string }[];
   onSelect: (item: any) => void;
 }
 
@@ -16,9 +15,10 @@ interface JournalWeeklyPageProps extends BaseProps {
   onCreateEntry: (date: Date) => void;
 }
 
-export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: JournalWeeklyPageProps) {
+export function JournalWeeklyPage({ onSelect, onCreateEntry }: JournalWeeklyPageProps) {
   const { selectedDate, setDateParam, selectedTags } = useJournalQueryState();
   const [results, setResults] = useState<any[]>([]);
+  const [journalEntries, setJournalEntries] = useState<Map<string, JournalEntrySummary>>(new Map());
   const scrollRef = useRef<JournalDateScrollHandle>(null);
 
   // Seed with the initial date so the first-render effect doesn't trigger a
@@ -29,6 +29,31 @@ export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: Jou
     indexedDBService.getRecentResults(100).then(setResults);
   }, []);
 
+  // Load journal entries (notes written for specific dates)
+  useEffect(() => {
+    // Fetch both casings to handle legacy data saved with category: 'Journal'
+    Promise.all([
+      playgroundDB.getPagesByCategory('journal'),
+      playgroundDB.getPagesByCategory('Journal'),
+    ]).then(([lower, upper]) => {
+      const pages = [...lower, ...upper];
+      const map = new Map<string, JournalEntrySummary>();
+      pages.forEach(page => {
+        // id is 'journal/yyyy-mm-dd' → extract the date key
+        const dateKey = page.id.replace(/^journal\//, '');
+        if (/^\d{4}-\d{2}-\d{2}$/.test(dateKey)) {
+          // Extract first # heading from content, or use the date key as title
+          const headingMatch = page.content.match(/^#\s+(.+)$/m);
+          map.set(dateKey, {
+            title: headingMatch ? headingMatch[1].trim() : dateKey,
+            updatedAt: page.updatedAt,
+          });
+        }
+      });
+      setJournalEntries(map);
+    });
+  }, []);
+
   const navigate = useNavigate();
   const handleSelect = (item: FilteredListItem) => {
     if (item.type === 'result') {
@@ -37,6 +62,10 @@ export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: Jou
       onSelect(item.payload);
     }
   };
+
+  const handleOpenEntry = useCallback((dateKey: string) => {
+    navigate(`/journal/${dateKey}`);
+  }, [navigate]);
 
   /** Called by JournalDateScroll IO as the user scrolls — updates URL only, never triggers re-scroll. */
   const handleVisibleDateChange = useCallback(
@@ -60,43 +89,35 @@ export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: Jou
   }, [selectedDate]);
 
   const allItems = useMemo(() => {
-    const combined: FilteredListItem[] = [];
-    workoutItems.forEach(item => {
-      combined.push({
-        id: item.id,
-        type: 'note',
-        title: item.name,
-        subtitle: item.category,
-        date: (item as any).targetDate || (item as any).updatedAt,
-        payload: item,
-      });
-    });
-    results.forEach(r => {
-      combined.push({
+    // Only show workout results — journal notes are handled via the journalEntries map
+    const combined: FilteredListItem[] = results.map(r => {
+      // noteId is like 'collections/geoff-neupert/fran' or 'journal/2024-01-01'
+      // Use the last path segment as the workout name, but clean up date-only entries
+      const parts = r.noteId.split('/');
+      const lastSegment = parts[parts.length - 1] || r.noteId;
+      const isDateSegment = /^\d{4}-\d{2}-\d{2}$/.test(lastSegment);
+      const title = isDateSegment
+        ? (parts[parts.length - 2] || lastSegment)
+        : lastSegment;
+      return {
         id: r.id,
-        type: 'result',
-        title: r.noteId.split('/').pop() || r.noteId,
-        subtitle: r.data?.completed ? 'Completed session' : 'Partial session',
+        type: 'result' as const,
+        title,
+        subtitle: r.data?.completed ? 'Completed' : 'Partial',
         date: r.completedAt,
         payload: r,
-      });
+      };
     });
 
-    let items = combined;
+    if (selectedTags.length === 0) return combined.sort((a, b) => (b.date || 0) - (a.date || 0));
 
-    // Filter by selected tags when present
-    if (selectedTags.length > 0) {
-      items = items.filter((item) => {
-        const category = (item.subtitle || '').toLowerCase();
+    return combined
+      .filter(item => {
         const title = item.title.toLowerCase();
-        return selectedTags.some(
-          (tag) => category.includes(tag.toLowerCase()) || title.includes(tag.toLowerCase()),
-        );
-      });
-    }
-
-    return items.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [workoutItems, results, selectedTags]);
+        return selectedTags.some(tag => title.includes(tag.toLowerCase()));
+      })
+      .sort((a, b) => (b.date || 0) - (a.date || 0));
+  }, [results, selectedTags]);
 
   return (
     <JournalDateScroll
@@ -106,66 +127,9 @@ export function JournalWeeklyPage({ workoutItems, onSelect, onCreateEntry }: Jou
       onCreateEntry={onCreateEntry}
       initialDate={selectedDate}
       onVisibleDateChange={handleVisibleDateChange}
+      journalEntries={journalEntries}
+      onOpenEntry={handleOpenEntry}
       className="flex-1 min-h-0"
     />
-  );
-}
-
-export function SearchPage({ workoutItems, onSelect }: BaseProps) {
-  const [query] = useQueryState('q', { defaultValue: '' });
-  const [results, setResults] = useState<any[]>([]);
-
-  useEffect(() => {
-    indexedDBService.getRecentResults(100).then(setResults);
-  }, []);
-
-  const navigate = useNavigate();
-  const handleSelect = (item: FilteredListItem) => {
-    if (item.type === 'result') {
-      navigate(`/review/${item.id}`);
-    } else {
-      onSelect(item.payload);
-    }
-  };
-
-  const filteredItems = useMemo(() => {
-    const combined: FilteredListItem[] = [];
-    workoutItems.forEach(item => {
-      combined.push({
-        id: item.id,
-        type: 'note',
-        title: item.name,
-        subtitle: item.category,
-        date: (item as any).targetDate || (item as any).updatedAt,
-        payload: item,
-      });
-    });
-    results.forEach(r => {
-      combined.push({
-        id: r.id,
-        type: 'result',
-        title: r.noteId.split('/').pop() || r.noteId,
-        subtitle: r.data?.completed ? 'Completed session' : 'Partial session',
-        date: r.completedAt,
-        payload: r,
-      });
-    });
-
-    const q = query.trim().toLowerCase();
-    const visible = q
-      ? combined.filter(
-          item =>
-            item.title.toLowerCase().includes(q) ||
-            item.subtitle?.toLowerCase().includes(q),
-        )
-      : combined;
-
-    return visible.sort((a, b) => (b.date || 0) - (a.date || 0));
-  }, [workoutItems, results, query]);
-
-  return (
-    <div className="flex-1 min-h-0 overflow-y-auto bg-card">
-      <FilteredList items={filteredItems} onSelect={handleSelect} />
-    </div>
   );
 }

--- a/playground/src/views/queriable-list/CollectionWorkoutsList.tsx
+++ b/playground/src/views/queriable-list/CollectionWorkoutsList.tsx
@@ -8,12 +8,14 @@ interface CollectionWorkoutsListProps {
   category: string;
   workoutItems: WorkoutItem[];
   onSelect: (item: WorkoutItem) => void;
+  onClone?: (item: WorkoutItem, date: Date) => void;
 }
 
 export const CollectionWorkoutsList: React.FC<CollectionWorkoutsListProps> = ({ 
   category, 
   workoutItems, 
-  onSelect 
+  onSelect,
+  onClone
 }) => {
   // Filter items to just this collection, excluding README files
   const collectionItems = useMemo(() => 
@@ -25,6 +27,10 @@ export const CollectionWorkoutsList: React.FC<CollectionWorkoutsListProps> = ({
     onSelect(item.payload as WorkoutItem);
   };
 
+  const handleClone = (item: FilteredListItem, date: Date) => {
+    onClone?.(item.payload as WorkoutItem, date);
+  };
+
   return (
     <div className="flex-1 min-h-0 flex flex-col rounded-3xl border border-border bg-card overflow-hidden shadow-2xl shadow-black/5 transition-all hover:border-primary/20">
       <QueriableListView
@@ -32,6 +38,7 @@ export const CollectionWorkoutsList: React.FC<CollectionWorkoutsListProps> = ({
         items={collectionItems}
         results={[]}
         onSelect={handleSelect}
+        onClone={onClone ? handleClone : undefined}
         initialQuery={{}}
         hideBackground
         className="flex-1"

--- a/playground/src/views/queriable-list/FilteredList.tsx
+++ b/playground/src/views/queriable-list/FilteredList.tsx
@@ -2,10 +2,12 @@ import React, { useMemo, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { FileTextIcon, PlayIcon, CheckCircleIcon, CalendarIcon } from 'lucide-react';
 import type { FilteredListItem } from './types';
+import { WorkoutActionButton } from '@/components/workout/WorkoutActionButton';
 
 interface FilteredListProps {
   items: FilteredListItem[];
   onSelect: (item: FilteredListItem) => void;
+  onClone?: (item: FilteredListItem, date: Date) => void;
   selectedDate?: Date;
   stickyOffset?: number;
   /** Called when the topmost visible date group changes during scroll */
@@ -20,7 +22,14 @@ const ItemIcon = ({ type }: { type: FilteredListItem['type'] }) => {
   }
 };
 
-export const FilteredList: React.FC<FilteredListProps> = ({ items, onSelect, selectedDate, stickyOffset = 0, onVisibleDateChange }) => {
+export const FilteredList: React.FC<FilteredListProps> = ({ 
+  items, 
+  onSelect, 
+  onClone,
+  selectedDate, 
+  stickyOffset = 0, 
+  onVisibleDateChange 
+}) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
@@ -125,6 +134,7 @@ export const FilteredList: React.FC<FilteredListProps> = ({ items, onSelect, sel
               {group.items.map((item) => (
                 <button
                   key={`${item.type}-${item.id}`}
+                  id={`workout-${item.id}`}
                   onClick={() => onSelect(item)}
                   className={cn(
                     "w-full flex items-center gap-4 px-6 py-4 hover:bg-muted/50 transition-colors text-left group relative",
@@ -153,6 +163,18 @@ export const FilteredList: React.FC<FilteredListProps> = ({ items, onSelect, sel
                       {item.subtitle}
                     </p>
                   </div>
+
+                  {onClone && item.type === 'note' && (
+                    <div className="flex-shrink-0 ml-4" onClick={(e) => e.stopPropagation()}>
+                      <WorkoutActionButton
+                        mode="create"
+                        label="Clone"
+                        onAction={(date) => onClone(item, date)}
+                        variant="ghost"
+                        className="h-8"
+                      />
+                    </div>
+                  )}
                 </button>
               ))}
             </div>

--- a/playground/src/views/queriable-list/JournalDateScroll.tsx
+++ b/playground/src/views/queriable-list/JournalDateScroll.tsx
@@ -8,9 +8,16 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { PlusIcon, CalendarIcon, FileTextIcon, PlayIcon, CheckCircleIcon } from 'lucide-react';
+import { PlusIcon, CalendarIcon, FileTextIcon, CheckCircleIcon, ChevronRightIcon, ClockIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { FilteredListItem } from './types';
+
+// ── Journal entry summary (note metadata for a given date) ─────────────────
+
+export interface JournalEntrySummary {
+  title: string;
+  updatedAt: number;
+}
 
 // ── Date utilities ─────────────────────────────────────────────────────────
 
@@ -45,6 +52,10 @@ interface JournalDateScrollProps {
   items: FilteredListItem[];
   onSelect: (item: FilteredListItem) => void;
   onCreateEntry: (date: Date) => void;
+  /** Metadata for dates that have an existing journal note. */
+  journalEntries?: Map<string, JournalEntrySummary>;
+  /** Called when the user clicks an existing note card. */
+  onOpenEntry?: (dateKey: string) => void;
   /**
    * Passive anchor: used only to set the initial window on first render.
    * Changing this prop does NOT trigger a scroll.
@@ -56,16 +67,6 @@ interface JournalDateScrollProps {
   className?: string;
 }
 
-// ── Item icon ──────────────────────────────────────────────────────────────
-
-const ItemIcon = ({ type }: { type: FilteredListItem['type'] }) => {
-  switch (type) {
-    case 'note':   return <FileTextIcon className="size-4 text-blue-500" />;
-    case 'block':  return <PlayIcon className="size-4 text-emerald-500" />;
-    case 'result': return <CheckCircleIcon className="size-4 text-purple-500" />;
-  }
-};
-
 // ── Component ──────────────────────────────────────────────────────────────
 
 export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDateScrollProps>(
@@ -74,6 +75,8 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       items,
       onSelect,
       onCreateEntry,
+      journalEntries,
+      onOpenEntry,
       initialDate,
       onVisibleDateChange,
       stickyOffset = 0,
@@ -411,7 +414,7 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
       [],
     );
 
-    // ── Render ────────────────────────────────────────────────────────────────
+    // ── Render helpers ────────────────────────────────────────────────────────
 
     const todayKey = localDateKey(new Date());
 
@@ -422,7 +425,11 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
         {dates.map(date => {
           const key = localDateKey(date);
           const dayItems = itemsByDate.get(key) ?? [];
+          const dayResults = dayItems.filter(i => i.type === 'result');
+          const noteEntry = journalEntries?.get(key);
           const isToday = key === todayKey;
+          // Show "Add note" ghost when no entry exists: always for today/future, or when past results exist
+          const showAddNote = !noteEntry && (key >= todayKey || dayResults.length > 0);
 
           return (
             <div
@@ -444,51 +451,83 @@ export const JournalDateScroll = forwardRef<JournalDateScrollHandle, JournalDate
                 </span>
               </div>
 
-              {/* Entries for this day */}
-              {dayItems.length > 0 && (
-                <div className="divide-y divide-border/50">
-                  {dayItems.map(item => (
-                    <button
-                      key={`${item.type}-${item.id}`}
-                      onClick={() => onSelect(item)}
-                      className="w-full flex items-center gap-4 px-6 py-4 hover:bg-muted/50 transition-colors text-left group"
-                    >
-                      <div className="flex-shrink-0 size-10 rounded-xl bg-muted flex items-center justify-center group-hover:bg-background transition-colors">
-                        <ItemIcon type={item.type} />
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between mb-0.5">
-                          <h3 className="text-sm font-bold text-foreground truncate uppercase tracking-tight">
+              <div className="flex flex-col gap-0 pb-1">
+                {/* Note card — links to the journal entry for this date */}
+                {noteEntry ? (
+                  <button
+                    onClick={() => onOpenEntry?.(key)}
+                    className="flex items-center gap-4 px-6 py-3.5 hover:bg-muted/40 transition-colors text-left group"
+                  >
+                    <div className="flex-shrink-0 size-9 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/20 transition-colors">
+                      <FileTextIcon className="size-4 text-primary" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-sm font-bold text-foreground truncate">
+                        {noteEntry.title}
+                      </h3>
+                      <p className="text-[11px] text-muted-foreground font-medium">Note</p>
+                    </div>
+                    <ChevronRightIcon className="size-4 text-muted-foreground/40 group-hover:text-primary transition-colors flex-shrink-0" />
+                  </button>
+                ) : showAddNote ? (
+                  /* Ghost "Add note" — no entry yet */
+                  <button
+                    data-testid={`add-note-${key}`}
+                    onClick={() => onCreateEntry(date)}
+                    className="flex items-center gap-3 mx-4 mt-2 mb-1 px-4 py-2.5 rounded-lg border border-dashed border-border/50 hover:border-primary/40 hover:bg-primary/5 transition-all text-left group"
+                  >
+                    <div className="flex-shrink-0 size-7 rounded-md bg-muted/50 flex items-center justify-center group-hover:bg-primary/10 transition-colors">
+                      <PlusIcon className="size-3.5 text-muted-foreground/60 group-hover:text-primary transition-colors" />
+                    </div>
+                    <span className="text-xs text-muted-foreground/60 group-hover:text-primary transition-colors font-medium">
+                      Add note for {date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                    </span>
+                  </button>
+                ) : null}
+
+                {/* Results — each with its recorded time */}
+                {dayResults.length > 0 && (
+                  <div className="flex flex-col">
+                    <div className="flex items-center gap-2 px-6 pt-2 pb-1">
+                      <div className="h-px flex-1 bg-border/40" />
+                      <span className="text-[9px] font-black uppercase tracking-[0.2em] text-muted-foreground/50">
+                        Workouts
+                      </span>
+                      <div className="h-px flex-1 bg-border/40" />
+                    </div>
+                    {dayResults.map(item => (
+                      <button
+                        key={`result-${item.id}`}
+                        onClick={() => onSelect(item)}
+                        className="flex items-center gap-4 px-6 py-3 hover:bg-muted/40 transition-colors text-left group"
+                      >
+                        {/* Time stamp — left column */}
+                        <div className="flex-shrink-0 w-14 text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            <ClockIcon className="size-2.5 text-muted-foreground/40" />
+                            <span className="text-[10px] font-black text-muted-foreground/60 tabular-nums">
+                              {item.date
+                                ? new Date(item.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                                : '—'}
+                            </span>
+                          </div>
+                        </div>
+                        <div className="flex-shrink-0 size-8 rounded-lg bg-muted flex items-center justify-center group-hover:bg-background transition-colors">
+                          <CheckCircleIcon className="size-3.5 text-emerald-500" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="text-sm font-semibold text-foreground truncate">
                             {item.title}
                           </h3>
-                          {item.date && (
-                            <span className="text-[10px] font-bold text-muted-foreground uppercase">
-                              {new Date(item.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                            </span>
+                          {item.subtitle && (
+                            <p className="text-[11px] text-muted-foreground truncate">{item.subtitle}</p>
                           )}
                         </div>
-                        <p className="text-xs text-muted-foreground truncate font-medium">{item.subtitle}</p>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {/* Ghost "Add note" row — only on today and future dates */}
-              {key >= todayKey && (
-              <button
-                data-testid={`add-note-${key}`}
-                onClick={() => onCreateEntry(date)}
-                className="flex items-center gap-3 mx-4 my-2 px-4 py-2.5 rounded-lg border border-dashed border-border/50 hover:border-primary/40 hover:bg-primary/5 transition-all text-left group w-[calc(100%-2rem)]"
-              >
-                <div className="flex-shrink-0 size-7 rounded-md bg-muted/50 flex items-center justify-center group-hover:bg-primary/10 transition-colors">
-                  <PlusIcon className="size-3.5 text-muted-foreground/60 group-hover:text-primary transition-colors" />
-                </div>
-                <span className="text-xs text-muted-foreground/60 group-hover:text-primary transition-colors font-medium">
-                  Add note for {date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
-                </span>
-              </button>
-              )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           );
         })}

--- a/playground/src/views/queriable-list/QueriableListView.tsx
+++ b/playground/src/views/queriable-list/QueriableListView.tsx
@@ -9,6 +9,7 @@ interface QueriableListViewProps {
   items: { id: string; name: string; category: string; content?: string }[];
   results: any[]; // Recent results from IndexedDB
   onSelect: (item: FilteredListItem) => void;
+  onClone?: (item: FilteredListItem, date: Date) => void;
   className?: string;
   hideBackground?: boolean;
   disableDateFiltering?: boolean;
@@ -20,6 +21,7 @@ export function QueriableListView({
   items, 
   results: historicalResults,
   onSelect,
+  onClone,
   className,
   hideBackground,
   disableDateFiltering
@@ -107,6 +109,7 @@ export function QueriableListView({
       <FilteredList 
         items={filteredItems} 
         onSelect={onSelect} 
+        onClone={onClone}
         selectedDate={query.startDate}
         stickyOffset={queryHeight}
       />

--- a/playwright.journal.config.ts
+++ b/playwright.journal.config.ts
@@ -7,7 +7,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
-  testMatch: ['**/journal-scroll.e2e.ts'],
+  testMatch: ['**/journal-scroll.e2e.ts', '**/journal-entry.e2e.ts'],
 
   timeout: 45 * 1000,
   fullyParallel: false, // scroll tests are sensitive to ordering; run serially

--- a/src/components/command-palette/CommandPalette.tsx
+++ b/src/components/command-palette/CommandPalette.tsx
@@ -3,11 +3,11 @@ import { Command } from 'cmdk';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useCommandPalette } from './CommandContext';
 import { Search } from 'lucide-react';
+import { commandToListItem } from '@/components/list';
 
 export const CommandPalette: React.FC = () => {
   const { isOpen, setIsOpen, commands, activeContext, search, setSearch, activeStrategy } = useCommandPalette();
 
-  // Initialize search value from strategy if available
   useEffect(() => {
     if (isOpen && activeStrategy?.initialInputValue) {
       setSearch(activeStrategy.initialInputValue);
@@ -16,26 +16,24 @@ export const CommandPalette: React.FC = () => {
     }
   }, [isOpen, activeStrategy, setSearch]);
 
-  // Determine which commands to show
   const displayedCommands = activeStrategy
-    ? activeStrategy.getCommands()
+    ? (activeStrategy.getCommands?.() ?? [])
     : commands.filter(cmd => !cmd.context || cmd.context === 'global' || cmd.context === activeContext);
 
-  // Group commands
-  const groups = displayedCommands.reduce((acc, cmd) => {
-    const group = cmd.group || 'General';
+  // Normalise to IListItem then re-group for cmdk rendering
+  const listItems = displayedCommands.map(commandToListItem);
+  const groups = listItems.reduce((acc, item) => {
+    const group = item.group || 'General';
     if (!acc[group]) acc[group] = [];
-    acc[group].push(cmd);
+    acc[group].push(item);
     return acc;
-  }, {} as Record<string, typeof displayedCommands>);
+  }, {} as Record<string, typeof listItems>);
 
   const handleKeyDown = useCallback(async (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && activeStrategy?.handleInput) {
       e.preventDefault();
       const shouldClose = await activeStrategy.handleInput(search);
-      if (shouldClose) {
-        setIsOpen(false);
-      }
+      if (shouldClose) setIsOpen(false);
     }
   }, [activeStrategy, search, setIsOpen]);
 
@@ -49,22 +47,14 @@ export const CommandPalette: React.FC = () => {
             Search for commands, sessions, or navigate the application.
           </Dialog.Description>
 
-
-          <Command
-            className="w-full overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground flex flex-col"
-            shouldFilter={!activeStrategy?.handleInput} // Disable internal filtering if strategy handles input (optional)
-          >
+          <Command className="w-full overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground flex flex-col">
             <div className="flex items-center border-b border-border px-3" cmdk-input-wrapper="">
               <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
               <Command.Input
                 value={search}
                 onValueChange={setSearch}
-                onKeyDown={(e) => {
-                  if (activeStrategy?.handleInput) {
-                    handleKeyDown(e);
-                  }
-                }}
-                placeholder={activeStrategy?.placeholder || "Type a command or search..."}
+                onKeyDown={activeStrategy?.handleInput ? handleKeyDown : undefined}
+                placeholder={activeStrategy?.placeholder || 'Type a command or search...'}
                 className="flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 text-foreground"
               />
             </div>
@@ -74,30 +64,27 @@ export const CommandPalette: React.FC = () => {
                 No results found.
               </Command.Empty>
 
-              {Object.entries(groups).map(([group, groupCommands]) => (
-                <Command.Group key={group} heading={group} className="overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground">
-                  {groupCommands.map((cmd) => (
+              {Object.entries(groups).map(([group, items]) => (
+                <Command.Group
+                  key={group}
+                  heading={group}
+                  className="overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground"
+                >
+                  {items.map((item) => (
                     <Command.Item
-                      key={cmd.id}
-                      value={`${cmd.id} ${cmd.label} ${cmd.keywords?.join(' ') || ''}`}
+                      key={item.id}
+                      value={`${item.id} ${item.label} ${item.keywords?.join(' ') ?? ''}`}
                       onSelect={() => {
-                        console.log('[CommandPalette] onSelect for', cmd.id);
-                        cmd.action();
+                        item.payload.action();
                         setIsOpen(false);
                       }}
-                      onPointerDown={(e) => {
-                        // Prevent focus loss from input which can break selection in some dialog setups
-                        e.preventDefault();
-                      }}
-                      className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none 
-                                 aria-selected:bg-accent aria-selected:text-accent-foreground 
-                                 data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground 
-                                 data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50"
+                      onPointerDown={(e) => e.preventDefault()}
+                      className="relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50"
                     >
-                      <span>{cmd.label}</span>
-                      {cmd.shortcut && (
+                      <span>{item.label}</span>
+                      {item.shortcut && (
                         <span className="ml-auto text-xs tracking-widest text-muted-foreground">
-                          {cmd.shortcut.join('+')}
+                          {item.shortcut.join('+')}
                         </span>
                       )}
                     </Command.Item>

--- a/src/components/history/HistoryPostList.tsx
+++ b/src/components/history/HistoryPostList.tsx
@@ -15,6 +15,8 @@ import type { HistoryEntry } from '@/types/history';
 import { AddToNotebookButton } from '@/components/notebook/AddToNotebookButton';
 import { CloneDateDropdown } from '@/components/workbench/CloneDateDropdown';
 import type { IContentProvider } from '@/types/content-provider';
+import { ListView, historyEntryToListItem } from '@/components/list';
+import type { IListItem, ListItemContext } from '@/components/list';
 
 export interface HistoryPostListProps {
   /** Workout entries to display */
@@ -70,124 +72,123 @@ export const HistoryPostList: React.FC<HistoryPostListProps> = ({
   onClone,
   provider,
 }) => {
-  if (entries.length === 0) {
+  const listItems = entries.map(entry => ({
+    ...historyEntryToListItem(entry),
+    isActive: entry.id === activeEntryId,
+  }));
+
+  const renderItem = (item: IListItem<HistoryEntry>, _ctx: ListItemContext<HistoryEntry>) => {
+    const entry = item.payload;
+    const isSelected = selectedIds.has(entry.id);
+    const isActive = entry.id === activeEntryId;
+
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm p-4">
-        No session entries found
-      </div>
-    );
-  }
-
-  return (
-    <div className="divide-y divide-border">
-      {entries.map(entry => {
-        const isSelected = selectedIds.has(entry.id);
-        const isActive = entry.id === activeEntryId;
-
-        return (
-          <div
-            key={entry.id}
-            role="button"
-            tabIndex={0}
-            onClick={(e) => onToggle(entry.id, { ctrlKey: e.ctrlKey || e.metaKey, shiftKey: e.shiftKey })}
-            onDoubleClick={(e) => {
-              e.preventDefault(); // Prevent text selection
-              if (onEdit) onEdit(entry.id);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                onToggle(entry.id, { ctrlKey: e.ctrlKey || e.metaKey, shiftKey: e.shiftKey });
-              }
-            }}
-            className={cn(
-              'w-full text-left px-3 py-2 transition-colors cursor-pointer outline-none focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset select-none',
-              'hover:bg-muted/50',
-              isSelected && 'bg-primary/10',
-              isActive && !isSelected && 'bg-accent/50 border-l-2 border-primary',
+      <div
+        key={entry.id}
+        role="button"
+        tabIndex={0}
+        onClick={(e) => onToggle(entry.id, { ctrlKey: e.ctrlKey || e.metaKey, shiftKey: e.shiftKey })}
+        onDoubleClick={(e) => {
+          e.preventDefault();
+          if (onEdit) onEdit(entry.id);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onToggle(entry.id, { ctrlKey: e.ctrlKey || e.metaKey, shiftKey: e.shiftKey });
+          }
+        }}
+        className={cn(
+          'w-full text-left px-3 py-2 transition-colors cursor-pointer outline-none focus-visible:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset select-none border-b border-border',
+          'hover:bg-muted/50',
+          isSelected && 'bg-primary/10',
+          isActive && !isSelected && 'bg-accent/50 border-l-2 border-primary',
+        )}
+      >
+        <div className="flex items-center gap-3 w-full">
+          <div className="flex-shrink-0" onClick={e => e.stopPropagation()}>
+            {entry.type === 'template' ? (
+              <CloneDateDropdown
+                onClone={(targetDate) => onClone?.(entry.id, targetDate)}
+                provider={provider}
+                variant="list-icon"
+                title="Clone to date..."
+              />
+            ) : (
+              onEdit && (
+                <button
+                  onClick={() => onEdit(entry.id, entry.type)}
+                  className="h-8 w-8 flex items-center justify-center rounded hover:bg-muted text-muted-foreground/50 hover:text-foreground transition-colors"
+                  title="Edit Note"
+                >
+                  <Edit2 className="w-4 h-4" />
+                </button>
+              )
             )}
-          >
-            <div className="flex items-center gap-3 w-full">
-              {/* Action Button: Clone (Template) or Edit (Note) on the left */}
-              <div className="flex-shrink-0" onClick={e => e.stopPropagation()}>
-                {entry.type === 'template' ? (
-                  <CloneDateDropdown
-                    onClone={(targetDate) => onClone?.(entry.id, targetDate)}
-                    provider={provider}
-                    variant="list-icon"
-                    title="Clone to date..."
-                  />
-                ) : (
-                  onEdit && (
-                    <button
-                      onClick={() => onEdit(entry.id, entry.type)}
-                      className="h-8 w-8 flex items-center justify-center rounded hover:bg-muted text-muted-foreground/50 hover:text-foreground transition-colors"
-                      title="Edit Note"
-                    >
-                      <Edit2 className="w-4 h-4" />
-                    </button>
-                  )
-                )}
-              </div>
+          </div>
 
-              {/* Content area that fills available space */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-baseline gap-2">
-                  <span className={cn(
-                    'font-medium truncate text-sm',
-                    isSelected ? 'text-foreground' : 'text-foreground/80',
-                  )}>
-                    {entry.title}
-                  </span>
-                </div>
-
-                <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                  <span>{formatDate(entry.targetDate, enriched)}</span>
-                  {entry.results && (
-                    <>
-                      <span>·</span>
-                      <span>{formatDuration(entry.results.duration)}</span>
-                    </>
-                  )}
-                </div>
-              </div>
-
-              {/* Right Side: Tags + Notebook Button + Checkbox */}
-              <div className="flex items-center gap-3 flex-shrink-0">
-                {/* Tags (moved to right side, shown in enriched mode) */}
-                {enriched && entry.tags.length > 0 && (
-                  <div className="hidden sm:flex gap-1 flex-wrap justify-end max-w-[150px]">
-                    {entry.tags
-                      .filter(tag => !tag.startsWith('notebook:'))
-                      .map(tag => (
-                        <span
-                          key={tag}
-                          className="text-[9px] px-1 py-0.5 rounded-full bg-muted/60 text-muted-foreground/80 border border-border/50"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                  </div>
-                )}
-
-                {/* Add to Notebook button */}
-                {onNotebookToggle && (
-                  <div className="flex-shrink-0" onClick={e => e.stopPropagation()}>
-                    <AddToNotebookButton
-                      entryTags={entry.tags}
-                      onToggle={(notebookId, isAdding) => onNotebookToggle(entry.id, notebookId, isAdding)}
-                      variant="icon"
-                      className="h-8 w-8 text-muted-foreground/30 hover:text-foreground hover:bg-muted transition-all"
-                    />
-                  </div>
-                )}
-
-
-              </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-baseline gap-2">
+              <span className={cn(
+                'font-medium truncate text-sm',
+                isSelected ? 'text-foreground' : 'text-foreground/80',
+              )}>
+                {entry.title}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+              <span>{formatDate(entry.targetDate, enriched)}</span>
+              {entry.results && (
+                <>
+                  <span>·</span>
+                  <span>{formatDuration(entry.results.duration)}</span>
+                </>
+              )}
             </div>
           </div>
-        );
-      })}
-    </div>
+
+          <div className="flex items-center gap-3 flex-shrink-0">
+            {enriched && entry.tags.length > 0 && (
+              <div className="hidden sm:flex gap-1 flex-wrap justify-end max-w-[150px]">
+                {entry.tags
+                  .filter(tag => !tag.startsWith('notebook:'))
+                  .map(tag => (
+                    <span
+                      key={tag}
+                      className="text-[9px] px-1 py-0.5 rounded-full bg-muted/60 text-muted-foreground/80 border border-border/50"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+              </div>
+            )}
+            {onNotebookToggle && (
+              <div className="flex-shrink-0" onClick={e => e.stopPropagation()}>
+                <AddToNotebookButton
+                  entryTags={entry.tags}
+                  onToggle={(notebookId, isAdding) => onNotebookToggle(entry.id, notebookId, isAdding)}
+                  variant="icon"
+                  className="h-8 w-8 text-muted-foreground/30 hover:text-foreground hover:bg-muted transition-all"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <ListView
+      items={listItems}
+      multi
+      onSelect={(item) => onToggle(item.id, { ctrlKey: false, shiftKey: false })}
+      renderItem={renderItem}
+      emptyState={
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm p-4">
+          No session entries found
+        </div>
+      }
+    />
   );
 };

--- a/src/components/history/HistoryPostList.tsx
+++ b/src/components/history/HistoryPostList.tsx
@@ -77,7 +77,7 @@ export const HistoryPostList: React.FC<HistoryPostListProps> = ({
     isActive: entry.id === activeEntryId,
   }));
 
-  const renderItem = (item: IListItem<HistoryEntry>, _ctx: ListItemContext<HistoryEntry>) => {
+  const renderItem = (item: IListItem<HistoryEntry>, _ctx: ListItemContext) => {
     const entry = item.payload;
     const isSelected = selectedIds.has(entry.id);
     const isActive = entry.id === activeEntryId;

--- a/src/components/history/NewPostButton.tsx
+++ b/src/components/history/NewPostButton.tsx
@@ -1,18 +1,8 @@
-
 import React, { useState } from 'react';
-import { Plus, ChevronDown, Calendar, FileText } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuTrigger,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuItem,
-} from '@/components/ui/dropdown-menu';
-import { CalendarDatePicker } from '@/components/ui/CalendarDatePicker';
+import { FileText } from 'lucide-react';
 import { ImportMarkdownDialog } from './ImportMarkdownDialog';
 import { cn } from '@/lib/utils';
+import { WorkoutActionButton } from '@/components/workout/WorkoutActionButton';
 
 interface NewPostButtonProps {
     onCreate: (date?: Date) => Promise<void>;
@@ -25,90 +15,32 @@ export const NewPostButton: React.FC<NewPostButtonProps> = ({
     onImportMarkdown,
     className,
 }) => {
-    const [open, setOpen] = useState(false);
     const [showImportDialog, setShowImportDialog] = useState(false);
 
-    // Handle direct click on the main "New" button (create for today)
-    const handleMainClick = async () => {
-        await onCreate();
-    };
-
-    // Handle date selection from calendar
-    const handleDateSelect = async (date: Date) => {
-        // Set to noon to avoid timezone edge cases, similar to CloneDateDropdown
-        date.setHours(12, 0, 0, 0);
-        setOpen(false);
-        await onCreate(date);
-    };
-
-    // Handle import from markdown
-    const handleImportMarkdown = async (markdown: string) => {
-        if (onImportMarkdown) {
-            await onImportMarkdown(markdown);
+    const secondaryActions = onImportMarkdown ? [
+        {
+            label: 'Import from Markdown',
+            icon: <FileText className="h-4 w-4" />,
+            onClick: () => setShowImportDialog(true),
         }
-    };
+    ] : [];
 
     return (
         <>
-            <div className={cn("flex items-center", className)}>
-                <Button
-                    variant="default"
-                    size="sm"
-                    onClick={handleMainClick}
-                    className="rounded-r-none gap-2 px-3 border-r border-primary-foreground/20"
-                >
-                    <Plus className="h-4 w-4" />
-                    New
-                </Button>
-
-                <DropdownMenu open={open} onOpenChange={setOpen}>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="default"
-                            size="sm"
-                            className="rounded-l-none px-2"
-                        >
-                            <ChevronDown className="h-4 w-4" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="w-auto" onClick={(e) => e.stopPropagation()}>
-                        <div className="p-2">
-                            <DropdownMenuLabel className="flex items-center gap-2 px-2 py-1.5">
-                                <Calendar className="h-3.5 w-3.5" />
-                                Create on Date
-                            </DropdownMenuLabel>
-                            <DropdownMenuSeparator />
-                            <CalendarDatePicker
-                                onDateSelect={handleDateSelect}
-                            // We could pass entryDates here if we want to show existing entries
-                            // For now, let's keep it simple as requested
-                            />
-                        </div>
-
-                        {onImportMarkdown && (
-                            <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem
-                                    onClick={() => {
-                                        setOpen(false);
-                                        setShowImportDialog(true);
-                                    }}
-                                    className="gap-2"
-                                >
-                                    <FileText className="h-4 w-4" />
-                                    Import from Markdown
-                                </DropdownMenuItem>
-                            </>
-                        )}
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            </div>
+            <WorkoutActionButton
+                mode="create"
+                label="New"
+                onAction={(date) => onCreate(date)}
+                secondaryActions={secondaryActions}
+                className={className}
+                variant="default"
+            />
 
             {onImportMarkdown && (
                 <ImportMarkdownDialog
                     open={showImportDialog}
                     onOpenChange={setShowImportDialog}
-                    onImport={handleImportMarkdown}
+                    onImport={onImportMarkdown}
                 />
             )}
         </>

--- a/src/components/list/ActionBarView.tsx
+++ b/src/components/list/ActionBarView.tsx
@@ -1,0 +1,50 @@
+import { cn } from '@/lib/utils';
+import type { IListItem } from './types';
+
+export interface ActionBarViewProps<TPayload> {
+  items: IListItem<TPayload>[];
+  onSelect: (item: IListItem<TPayload>) => void;
+  orientation?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+export function ActionBarView<TPayload>({
+  items,
+  onSelect,
+  orientation = 'horizontal',
+  className,
+}: ActionBarViewProps<TPayload>) {
+  return (
+    <div
+      role="toolbar"
+      className={cn(
+        'flex items-center gap-1',
+        orientation === 'vertical' && 'flex-col',
+        className,
+      )}
+    >
+      {items.map(item => {
+        const isPrimary = (item.payload as { primary?: boolean })?.primary ?? false;
+
+        return (
+          <button
+            key={item.id}
+            title={item.label}
+            disabled={item.isDisabled}
+            onClick={() => onSelect(item)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors',
+              isPrimary
+                ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                : 'border border-zinc-300 bg-white text-zinc-700 hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700',
+              item.isDisabled && 'opacity-40 cursor-not-allowed',
+            )}
+          >
+            {item.icon && <span className="h-3 w-3">{item.icon}</span>}
+            {item.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/list/CommandListView.tsx
+++ b/src/components/list/CommandListView.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Search } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useListState } from './useListState';
 import { DefaultListItem } from './DefaultListItem';
+import { executeNavAction } from '@/nav/navTypes';
+import type { NavActionDeps } from '@/nav/navTypes';
 import type { IListItem, IItemAction, ListItemContext } from './types';
 
 export interface CommandListViewProps<TPayload> {
@@ -15,10 +18,10 @@ export interface CommandListViewProps<TPayload> {
   /** Optional custom header rendered below search input (e.g. statement builder) */
   header?: React.ReactNode;
   placeholder?: string;
-  /** Per-item actions */
-  actions?: (item: IListItem<TPayload>) => IItemAction<TPayload>[];
+  /** Per-item actions — merged with item.actions at render time */
+  actions?: (item: IListItem<TPayload>) => IItemAction[];
   /** Override item renderer */
-  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext<TPayload>) => React.ReactNode;
+  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext) => React.ReactNode;
   /** Shown when there are no results */
   emptyState?: React.ReactNode;
   className?: string;
@@ -39,7 +42,40 @@ export function CommandListView<TPayload>({
   className,
 }: CommandListViewProps<TPayload>) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const state = useListState({ items, onSelect });
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const navDeps: NavActionDeps = useMemo(() => ({
+    navigate: (to, opts) => navigate(to, opts),
+    setQueryParam: (params, replace) => {
+      const sp = new URLSearchParams(searchParams);
+      Object.entries(params).forEach(([k, v]) => {
+        if (v === null) sp.delete(k); else sp.set(k, v);
+      });
+      setSearchParams(sp, { replace });
+    },
+  }), [navigate, searchParams, setSearchParams]);
+
+  const execAction = useCallback(
+    (action: Parameters<typeof executeNavAction>[0]) => executeNavAction(action, navDeps),
+    [navDeps],
+  );
+
+  /** Activation: execute primary action if present, otherwise fire host onSelect */
+  const handleActivate = useCallback(
+    (item: IListItem<TPayload>) => {
+      const allActions = [...(item.actions ?? []), ...(actions?.(item) ?? [])];
+      const primary = allActions.find(a => a.isPrimary);
+      if (primary) {
+        execAction(primary.action);
+      } else {
+        onSelect(item);
+      }
+    },
+    [actions, onSelect, execAction],
+  );
+
+  const state = useListState({ items, onSelect: handleActivate });
 
   // Focus input when opened
   useEffect(() => {
@@ -107,13 +143,14 @@ export function CommandListView<TPayload>({
                   </div>
                 )}
                 {groupItems.map(item => {
-                  const itemActions = actions?.(item) ?? [];
-                  const ctx: ListItemContext<TPayload> = {
+                  const itemActions: IItemAction[] = [...(item.actions ?? []), ...(actions?.(item) ?? [])];
+                  const ctx: ListItemContext = {
                     isSelected: state.selectedIds.has(item.id),
                     isActive: state.activeId === item.id,
                     depth: item.depth ?? 0,
                     actions: itemActions,
                     onSelect: () => state.selectItem(item),
+                    executeAction: execAction,
                   };
                   return (
                     <div

--- a/src/components/list/CommandListView.tsx
+++ b/src/components/list/CommandListView.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useRef } from 'react';
+import { Search } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useListState } from './useListState';
+import { DefaultListItem } from './DefaultListItem';
+import type { IListItem, IItemAction, ListItemContext } from './types';
+
+export interface CommandListViewProps<TPayload> {
+  items: IListItem<TPayload>[];
+  query: string;
+  onQueryChange: (q: string) => void;
+  onSelect: (item: IListItem<TPayload>) => void;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Optional custom header rendered below search input (e.g. statement builder) */
+  header?: React.ReactNode;
+  placeholder?: string;
+  /** Per-item actions */
+  actions?: (item: IListItem<TPayload>) => IItemAction<TPayload>[];
+  /** Override item renderer */
+  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext<TPayload>) => React.ReactNode;
+  /** Shown when there are no results */
+  emptyState?: React.ReactNode;
+  className?: string;
+}
+
+export function CommandListView<TPayload>({
+  items,
+  query,
+  onQueryChange,
+  onSelect,
+  isOpen,
+  onClose,
+  header,
+  placeholder = 'Search…',
+  actions,
+  renderItem,
+  emptyState,
+  className,
+}: CommandListViewProps<TPayload>) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const state = useListState({ items, onSelect });
+
+  // Focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  // Sync external query into list state filter
+  useEffect(() => {
+    state.setQuery(query);
+  }, [query]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!isOpen) return null;
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Escape') {
+      onClose();
+      return;
+    }
+    state.onKeyDown(e);
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className={cn(
+        'flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white shadow-2xl dark:border-zinc-700 dark:bg-zinc-900',
+        className,
+      )}
+      onKeyDown={handleKeyDown}
+    >
+      {/* Search row */}
+      <div className="flex items-center gap-2 border-b border-zinc-200 px-3 dark:border-zinc-700">
+        <Search className="h-4 w-4 shrink-0 text-zinc-400" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={e => onQueryChange(e.target.value)}
+          placeholder={placeholder}
+          className="flex-1 bg-transparent py-3 text-sm outline-none placeholder:text-zinc-400"
+        />
+        <kbd className="hidden rounded border border-zinc-200 px-1.5 py-0.5 text-[10px] text-zinc-400 sm:inline dark:border-zinc-600">
+          esc
+        </kbd>
+      </div>
+
+      {/* Optional contextual header (e.g. statement builder segment UI) */}
+      {header}
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto p-1" role="listbox">
+        {/* Group headers */}
+        {state.visibleItems.length === 0
+          ? (emptyState ?? (
+              <div className="py-8 text-center text-sm text-zinc-400">No results</div>
+            ))
+          : Array.from(state.groups.entries()).map(([group, groupItems]) => (
+              <div key={group} className="mb-1">
+                {group && (
+                  <div className="px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                    {group}
+                  </div>
+                )}
+                {groupItems.map(item => {
+                  const itemActions = actions?.(item) ?? [];
+                  const ctx: ListItemContext<TPayload> = {
+                    isSelected: state.selectedIds.has(item.id),
+                    isActive: state.activeId === item.id,
+                    depth: item.depth ?? 0,
+                    actions: itemActions,
+                    onSelect: () => state.selectItem(item),
+                  };
+                  return (
+                    <div
+                      key={item.id}
+                      data-item-id={item.id}
+                      className="group"
+                      onMouseEnter={() => state.setActiveId(item.id)}
+                    >
+                      {renderItem ? renderItem(item, ctx) : <DefaultListItem item={item} ctx={ctx} />}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/list/DefaultListItem.tsx
+++ b/src/components/list/DefaultListItem.tsx
@@ -3,7 +3,7 @@ import type { IListItem, ListItemContext } from './types';
 
 interface DefaultListItemProps<TPayload> {
   item: IListItem<TPayload>;
-  ctx: ListItemContext<TPayload>;
+  ctx: ListItemContext;
 }
 
 function ShortcutBadge({ tokens }: { tokens: string[] }) {
@@ -79,7 +79,7 @@ export function DefaultListItem<TPayload>({ item, ctx }: DefaultListItemProps<TP
               className="rounded p-0.5 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-400 hover:text-zinc-600"
               onClick={e => {
                 e.stopPropagation();
-                action.onClick(item);
+                ctx.executeAction(action.action);
               }}
             >
               {action.icon ?? action.label}
@@ -95,7 +95,7 @@ export function DefaultListItem<TPayload>({ item, ctx }: DefaultListItemProps<TP
           className="shrink-0 rounded px-2 py-1 text-xs bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
           onClick={e => {
             e.stopPropagation();
-            primaryAction.onClick(item);
+            ctx.executeAction(primaryAction.action);
           }}
         >
           {primaryAction.icon ?? primaryAction.label}

--- a/src/components/list/DefaultListItem.tsx
+++ b/src/components/list/DefaultListItem.tsx
@@ -1,0 +1,106 @@
+import { cn } from '@/lib/utils';
+import type { IListItem, ListItemContext } from './types';
+
+interface DefaultListItemProps<TPayload> {
+  item: IListItem<TPayload>;
+  ctx: ListItemContext<TPayload>;
+}
+
+function ShortcutBadge({ tokens }: { tokens: string[] }) {
+  return (
+    <span className="flex items-center gap-0.5 ml-auto shrink-0">
+      {tokens.map((token, i) => (
+        <kbd
+          key={i}
+          className="inline-flex items-center rounded border border-zinc-300 bg-zinc-100 px-1 py-0.5 text-[10px] font-mono text-zinc-500 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+        >
+          {token === 'meta' ? '⌘' : token === 'shift' ? '⇧' : token === 'alt' ? '⌥' : token}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+export function DefaultListItem<TPayload>({ item, ctx }: DefaultListItemProps<TPayload>) {
+  const primaryAction = ctx.actions.find(a => a.isPrimary);
+  const secondaryActions = ctx.actions.filter(a => !a.isPrimary);
+
+  return (
+    <div
+      role="option"
+      aria-selected={ctx.isSelected}
+      className={cn(
+        'flex items-center gap-2 px-3 py-2 rounded-md cursor-pointer select-none',
+        'text-sm transition-colors',
+        ctx.isActive || ctx.isSelected
+          ? 'bg-primary/10 text-primary'
+          : 'hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300',
+      item.isDisabled && 'opacity-40 pointer-events-none',
+        item.depth && item.depth > 0 ? `pl-${Math.min(item.depth * 4 + 3, 16)}` : '',
+      )}
+      onClick={item.isDisabled ? undefined : ctx.onSelect}
+    >
+      {/* Leading icon */}
+      {item.icon && (
+        <span className="shrink-0 text-zinc-400 dark:text-zinc-500 w-4 h-4 flex items-center justify-center">
+          {item.icon}
+        </span>
+      )}
+
+      {/* Label + subtitle */}
+      <span className="flex flex-col min-w-0 flex-1">
+        <span className="truncate font-medium leading-tight">{item.label}</span>
+        {item.subtitle && (
+          <span className="truncate text-xs text-zinc-500 dark:text-zinc-400 leading-tight mt-0.5">
+            {item.subtitle}
+          </span>
+        )}
+      </span>
+
+      {/* Badge */}
+      {item.badge !== undefined && (
+        <span className="shrink-0 rounded-full bg-zinc-200 dark:bg-zinc-700 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:text-zinc-300">
+          {item.badge}
+        </span>
+      )}
+
+      {/* Shortcut */}
+      {item.shortcut && item.shortcut.length > 0 && (
+        <ShortcutBadge tokens={item.shortcut} />
+      )}
+
+      {/* Secondary actions (shown on hover via group) */}
+      {secondaryActions.length > 0 && (
+        <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity ml-1">
+          {secondaryActions.map(action => (
+            <button
+              key={action.id}
+              title={action.label}
+              className="rounded p-0.5 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-400 hover:text-zinc-600"
+              onClick={e => {
+                e.stopPropagation();
+                action.onClick(item);
+              }}
+            >
+              {action.icon ?? action.label}
+            </button>
+          ))}
+        </span>
+      )}
+
+      {/* Primary action button */}
+      {primaryAction && (
+        <button
+          title={primaryAction.label}
+          className="shrink-0 rounded px-2 py-1 text-xs bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+          onClick={e => {
+            e.stopPropagation();
+            primaryAction.onClick(item);
+          }}
+        >
+          {primaryAction.icon ?? primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/list/ListView.tsx
+++ b/src/components/list/ListView.tsx
@@ -1,0 +1,118 @@
+import React, { useRef, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import { useListState } from './useListState';
+import { DefaultListItem } from './DefaultListItem';
+import type { IListItem, IItemAction, ListItemContext } from './types';
+
+export interface ListViewProps<TPayload> {
+  items: IListItem<TPayload>[];
+  onSelect?: (item: IListItem<TPayload>) => void;
+  /** Derive per-item actions from the host — keeps domain objects free of UI concerns */
+  actions?: (item: IListItem<TPayload>) => IItemAction<TPayload>[];
+  /** Render items grouped by item.group */
+  grouped?: boolean;
+  /** Show a search/filter input above the list */
+  searchable?: boolean;
+  /** Allow multi-select via ctrl/shift click */
+  multi?: boolean;
+  /** Override item renderer */
+  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext<TPayload>) => React.ReactNode;
+  /** Shown when visibleItems is empty */
+  emptyState?: React.ReactNode;
+  /** Slot rendered above the list (outside scroll area) */
+  header?: React.ReactNode;
+  /** Scroll the active item into view automatically */
+  autoScroll?: boolean;
+  className?: string;
+}
+
+export function ListView<TPayload>({
+  items,
+  onSelect,
+  actions,
+  grouped = false,
+  searchable = false,
+  multi = false,
+  renderItem,
+  emptyState,
+  header,
+  autoScroll = false,
+  className,
+}: ListViewProps<TPayload>) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const state = useListState({ items, multi, onSelect });
+
+  // Auto-scroll active item into view
+  useEffect(() => {
+    if (!autoScroll || !state.activeId || !listRef.current) return;
+    const el = listRef.current.querySelector(`[data-item-id="${state.activeId}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [autoScroll, state.activeId]);
+
+  function renderListItem(item: IListItem<TPayload>) {
+    const itemActions = actions?.(item) ?? [];
+    const ctx: ListItemContext<TPayload> = {
+      isSelected: state.selectedIds.has(item.id),
+      isActive: state.activeId === item.id,
+      depth: item.depth ?? 0,
+      actions: itemActions,
+      onSelect: () => state.selectItem(item),
+    };
+
+    return (
+      <div
+        key={item.id}
+        data-item-id={item.id}
+        className="group"
+        onMouseEnter={() => state.setActiveId(item.id)}
+      >
+        {renderItem ? renderItem(item, ctx) : <DefaultListItem item={item} ctx={ctx} />}
+      </div>
+    );
+  }
+
+  const content = grouped ? (
+    Array.from(state.groups.entries()).map(([group, groupItems]) => (
+      <div key={group} className="mb-2">
+        {group && (
+          <div className="px-3 py-1 text-xs font-semibold uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+            {group}
+          </div>
+        )}
+        {groupItems.map(renderListItem)}
+      </div>
+    ))
+  ) : (
+    state.visibleItems.map(renderListItem)
+  );
+
+  return (
+    <div
+      className={cn('flex flex-col', className)}
+      onKeyDown={state.onKeyDown}
+      tabIndex={0}
+    >
+      {header}
+
+      {searchable && (
+        <div className="px-3 py-2 border-b border-zinc-200 dark:border-zinc-700">
+          <input
+            type="text"
+            value={state.query}
+            onChange={e => state.setQuery(e.target.value)}
+            placeholder="Filter…"
+            className="w-full rounded-md border border-zinc-300 dark:border-zinc-600 bg-transparent px-2 py-1 text-sm outline-none focus:ring-1 focus:ring-primary"
+          />
+        </div>
+      )}
+
+      <div ref={listRef} className="flex-1 overflow-y-auto" role="listbox">
+        {state.visibleItems.length === 0
+          ? (emptyState ?? (
+              <div className="px-4 py-6 text-center text-sm text-zinc-400">No items</div>
+            ))
+          : content}
+      </div>
+    </div>
+  );
+}

--- a/src/components/list/ListView.tsx
+++ b/src/components/list/ListView.tsx
@@ -1,14 +1,17 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { useListState } from './useListState';
 import { DefaultListItem } from './DefaultListItem';
+import { executeNavAction } from '@/nav/navTypes';
+import type { NavActionDeps } from '@/nav/navTypes';
 import type { IListItem, IItemAction, ListItemContext } from './types';
 
 export interface ListViewProps<TPayload> {
   items: IListItem<TPayload>[];
   onSelect?: (item: IListItem<TPayload>) => void;
-  /** Derive per-item actions from the host — keeps domain objects free of UI concerns */
-  actions?: (item: IListItem<TPayload>) => IItemAction<TPayload>[];
+  /** Derive per-item actions from the host — merged with item.actions at render time */
+  actions?: (item: IListItem<TPayload>) => IItemAction[];
   /** Render items grouped by item.group */
   grouped?: boolean;
   /** Show a search/filter input above the list */
@@ -16,7 +19,7 @@ export interface ListViewProps<TPayload> {
   /** Allow multi-select via ctrl/shift click */
   multi?: boolean;
   /** Override item renderer */
-  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext<TPayload>) => React.ReactNode;
+  renderItem?: (item: IListItem<TPayload>, ctx: ListItemContext) => React.ReactNode;
   /** Shown when visibleItems is empty */
   emptyState?: React.ReactNode;
   /** Slot rendered above the list (outside scroll area) */
@@ -40,7 +43,40 @@ export function ListView<TPayload>({
   className,
 }: ListViewProps<TPayload>) {
   const listRef = useRef<HTMLDivElement>(null);
-  const state = useListState({ items, multi, onSelect });
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const navDeps: NavActionDeps = useMemo(() => ({
+    navigate: (to, opts) => navigate(to, opts),
+    setQueryParam: (params, replace) => {
+      const sp = new URLSearchParams(searchParams);
+      Object.entries(params).forEach(([k, v]) => {
+        if (v === null) sp.delete(k); else sp.set(k, v);
+      });
+      setSearchParams(sp, { replace });
+    },
+  }), [navigate, searchParams, setSearchParams]);
+
+  const execAction = useCallback(
+    (action: Parameters<typeof executeNavAction>[0]) => executeNavAction(action, navDeps),
+    [navDeps],
+  );
+
+  /** Activation: execute primary action if present, otherwise fire host onSelect */
+  const handleActivate = useCallback(
+    (item: IListItem<TPayload>) => {
+      const allActions = [...(item.actions ?? []), ...(actions?.(item) ?? [])];
+      const primary = allActions.find(a => a.isPrimary);
+      if (primary) {
+        execAction(primary.action);
+      } else {
+        onSelect?.(item);
+      }
+    },
+    [actions, onSelect, execAction],
+  );
+
+  const state = useListState({ items, multi, onSelect: handleActivate });
 
   // Auto-scroll active item into view
   useEffect(() => {
@@ -50,13 +86,14 @@ export function ListView<TPayload>({
   }, [autoScroll, state.activeId]);
 
   function renderListItem(item: IListItem<TPayload>) {
-    const itemActions = actions?.(item) ?? [];
-    const ctx: ListItemContext<TPayload> = {
+    const itemActions: IItemAction[] = [...(item.actions ?? []), ...(actions?.(item) ?? [])];
+    const ctx: ListItemContext = {
       isSelected: state.selectedIds.has(item.id),
       isActive: state.activeId === item.id,
       depth: item.depth ?? 0,
       actions: itemActions,
       onSelect: () => state.selectItem(item),
+      executeAction: execAction,
     };
 
     return (

--- a/src/components/list/adapters/collectionAdapter.ts
+++ b/src/components/list/adapters/collectionAdapter.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { FileText } from 'lucide-react';
+import type { WodCollectionItem } from '@/repositories/wod-collections';
+import type { IListItem } from '../types';
+
+export function collectionItemToListItem(item: WodCollectionItem): IListItem<WodCollectionItem> {
+  return {
+    id: item.id,
+    label: item.name,
+    subtitle: item.path,
+    icon: React.createElement(FileText, { className: 'w-4 h-4' }),
+    keywords: [item.name, item.path],
+    payload: item,
+  };
+}

--- a/src/components/list/adapters/commandAdapter.ts
+++ b/src/components/list/adapters/commandAdapter.ts
@@ -1,0 +1,37 @@
+import type { Command, CommandPaletteResult } from '@/components/command-palette/types';
+import type { WodCommand } from '@/components/Editor/overlays/WodCommand';
+import type { IListItem } from '../types';
+
+export function commandToListItem(cmd: Command): IListItem<Command> {
+  return {
+    id: cmd.id,
+    label: cmd.label,
+    group: cmd.group,
+    shortcut: cmd.shortcut,
+    keywords: cmd.keywords,
+    payload: cmd,
+  };
+}
+
+export function paletteResultToListItem(
+  result: CommandPaletteResult,
+): IListItem<CommandPaletteResult> {
+  return {
+    id: result.id,
+    label: result.name,
+    subtitle: result.subtitle ?? result.category,
+    group: result.category,
+    keywords: [result.name, result.category],
+    payload: result,
+  };
+}
+
+export function wodCommandToListItem(cmd: WodCommand): IListItem<WodCommand> {
+  return {
+    id: cmd.id,
+    label: cmd.label,
+    icon: cmd.icon,
+    isDisabled: false,
+    payload: cmd,
+  };
+}

--- a/src/components/list/adapters/fragmentSourceAdapter.ts
+++ b/src/components/list/adapters/fragmentSourceAdapter.ts
@@ -1,0 +1,21 @@
+import type { FragmentSourceEntry } from '@/components/metrics/MetricSourceRow';
+import type { IListItem } from '../types';
+
+export function fragmentSourceToListItem(
+  entry: FragmentSourceEntry,
+  index: number,
+): IListItem<FragmentSourceEntry> {
+  const label = entry.label ?? `Item ${index}`;
+  const duration = entry.duration;
+  const durationStr = duration != null ? `${Math.round(duration / 1000)}s` : undefined;
+
+  return {
+    id: String(entry.source?.id ?? `frag-${index}`),
+    label,
+    subtitle: durationStr,
+    depth: entry.depth,
+    isActive: entry.isLeaf,
+    isDisabled: false,
+    payload: entry,
+  };
+}

--- a/src/components/list/adapters/historyAdapter.ts
+++ b/src/components/list/adapters/historyAdapter.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Calendar } from 'lucide-react';
+import type { HistoryEntry } from '@/types/history';
+import type { IListItem } from '../types';
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const mins = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
+  return secs > 0 ? `${mins}:${String(secs).padStart(2, '0')}` : `${mins}:00`;
+}
+
+export function historyEntryToListItem(entry: HistoryEntry): IListItem<HistoryEntry> {
+  const duration = entry.results?.duration;
+  const durationStr = duration ? formatDuration(duration) : undefined;
+  const dateStr = formatDate(entry.targetDate);
+
+  return {
+    id: entry.id,
+    label: entry.title || 'Untitled workout',
+    subtitle: durationStr ? `${dateStr} · ${durationStr}` : dateStr,
+    icon: React.createElement(Calendar, { className: 'w-4 h-4' }),
+    group: new Date(entry.targetDate).toLocaleDateString('en-US', {
+      month: 'long',
+      year: 'numeric',
+    }),
+    keywords: entry.tags,
+    badge: entry.tags.length > 0 ? entry.tags[0] : undefined,
+    payload: entry,
+  };
+}

--- a/src/components/list/adapters/statementAdapter.ts
+++ b/src/components/list/adapters/statementAdapter.ts
@@ -1,0 +1,21 @@
+import type { ICodeStatement } from '@/core/models/CodeStatement';
+import type { IListItem } from '../types';
+
+export function statementToListItem(
+  statement: ICodeStatement,
+  lineNumber?: number,
+): IListItem<ICodeStatement> {
+  const label = statement.metrics
+    .map(m => String(m))
+    .join(' ')
+    || `Statement ${statement.id}`;
+
+  return {
+    id: String(statement.id),
+    label,
+    subtitle: lineNumber !== undefined ? `Line ${lineNumber}` : undefined,
+    badge: lineNumber,
+    depth: 0,
+    payload: statement,
+  };
+}

--- a/src/components/list/index.ts
+++ b/src/components/list/index.ts
@@ -1,0 +1,30 @@
+// Types
+export type { IListItem, IItemAction, ListItemContext } from './types';
+
+// Hook
+export { useListState } from './useListState';
+export type { UseListStateOptions, ListState } from './useListState';
+
+// Variant hosts
+export { ListView } from './ListView';
+export type { ListViewProps } from './ListView';
+
+export { CommandListView } from './CommandListView';
+export type { CommandListViewProps } from './CommandListView';
+
+export { ActionBarView } from './ActionBarView';
+export type { ActionBarViewProps } from './ActionBarView';
+
+// Default item renderer
+export { DefaultListItem } from './DefaultListItem';
+
+// Adapters
+export { historyEntryToListItem } from './adapters/historyAdapter';
+export { collectionItemToListItem } from './adapters/collectionAdapter';
+export { statementToListItem } from './adapters/statementAdapter';
+export { fragmentSourceToListItem } from './adapters/fragmentSourceAdapter';
+export {
+  commandToListItem,
+  paletteResultToListItem,
+  wodCommandToListItem,
+} from './adapters/commandAdapter';

--- a/src/components/list/types.ts
+++ b/src/components/list/types.ts
@@ -1,0 +1,63 @@
+import type React from 'react';
+
+/**
+ * Shared view-model for any selectable list item.
+ *
+ * Domain types are never made to implement this directly — use adapter
+ * functions in ./adapters/ to map domain objects to IListItem<T>.
+ */
+export interface IListItem<TPayload = unknown> {
+  /** Stable unique identifier */
+  id: string;
+  /** Primary display text */
+  label: string;
+  /** Secondary display text (date, category, subtitle) */
+  subtitle?: string;
+  /** Leading icon */
+  icon?: React.ReactNode;
+  /** Grouping key — rendered as a group header when ListView grouped=true */
+  group?: string;
+  /** Extra search terms beyond label/subtitle */
+  keywords?: string[];
+  /** Keyboard shortcut tokens, e.g. ['meta', 'k'] */
+  shortcut?: string[];
+  /** Badge text or count displayed trailing */
+  badge?: string | number;
+  /** Nesting depth for indented lists (0 = root) */
+  depth?: number;
+  /** Whether this item is pre-selected / highlighted */
+  isActive?: boolean;
+  /** Whether this item is non-interactive */
+  isDisabled?: boolean;
+  /** Strongly-typed original domain object — never cast to unknown */
+  payload: TPayload;
+}
+
+/**
+ * A single action that can be performed on a list item.
+ * Actions are supplied by the host via an `actions` prop, not stored on items,
+ * so they can depend on ambient state/permissions.
+ */
+export interface IItemAction<TPayload = unknown> {
+  id: string;
+  label: string;
+  icon?: React.ReactNode;
+  /** Render as the primary (filled) call-to-action */
+  isPrimary?: boolean;
+  onClick: (item: IListItem<TPayload>) => void;
+  /** Optional secondary split-action (e.g. copy-to-clipboard) */
+  splitIcon?: React.ReactNode;
+  onSplitClick?: (item: IListItem<TPayload>) => void | Promise<void>;
+}
+
+/**
+ * Context passed to renderItem overrides so custom renderers can access
+ * the host's state without prop-drilling.
+ */
+export interface ListItemContext<TPayload = unknown> {
+  isSelected: boolean;
+  isActive: boolean;
+  depth: number;
+  actions: IItemAction<TPayload>[];
+  onSelect: () => void;
+}

--- a/src/components/list/types.ts
+++ b/src/components/list/types.ts
@@ -1,4 +1,5 @@
 import type React from 'react';
+import type { INavAction } from '@/nav/navTypes';
 
 /**
  * Shared view-model for any selectable list item.
@@ -31,33 +32,45 @@ export interface IListItem<TPayload = unknown> {
   isDisabled?: boolean;
   /** Strongly-typed original domain object — never cast to unknown */
   payload: TPayload;
+  /**
+   * Item-owned actions. Escape hatch for when actions are naturally
+   * part of the domain object (e.g. from adapters). Host-provided
+   * `actions(item)` is merged on top at render time.
+   *
+   * 0 actions = host `onSelect` is the only interaction.
+   * ≥1 actions = shown as buttons; `isPrimary` action fires on keyboard Enter.
+   */
+  actions?: IItemAction[];
 }
 
 /**
  * A single action that can be performed on a list item.
- * Actions are supplied by the host via an `actions` prop, not stored on items,
- * so they can depend on ambient state/permissions.
+ *
+ * Uses `INavAction` so actions compose with the app's navigation system —
+ * route changes, callbacks, pipelines — without raw `onClick` coupling.
+ * Actions are payload-independent; handlers capture context via closure.
  */
-export interface IItemAction<TPayload = unknown> {
+export interface IItemAction {
   id: string;
   label: string;
   icon?: React.ReactNode;
-  /** Render as the primary (filled) call-to-action */
+  /** Render as the primary call-to-action; also triggered by keyboard Enter. */
   isPrimary?: boolean;
-  onClick: (item: IListItem<TPayload>) => void;
-  /** Optional secondary split-action (e.g. copy-to-clipboard) */
-  splitIcon?: React.ReactNode;
-  onSplitClick?: (item: IListItem<TPayload>) => void | Promise<void>;
+  action: INavAction;
 }
 
 /**
  * Context passed to renderItem overrides so custom renderers can access
  * the host's state without prop-drilling.
  */
-export interface ListItemContext<TPayload = unknown> {
+export interface ListItemContext {
   isSelected: boolean;
   isActive: boolean;
   depth: number;
-  actions: IItemAction<TPayload>[];
+  /** Merged item-owned + host-provided actions */
+  actions: IItemAction[];
+  /** Fires when item is activated with no primary action (row click / keyboard Enter) */
   onSelect: () => void;
+  /** Execute a nav action using surface-injected deps (navigate, setQueryParam, etc.) */
+  executeAction: (action: INavAction) => void;
 }

--- a/src/components/list/useListState.ts
+++ b/src/components/list/useListState.ts
@@ -1,0 +1,148 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import type { IListItem } from './types';
+
+export interface UseListStateOptions<TPayload> {
+  items: IListItem<TPayload>[];
+  defaultActiveId?: string;
+  multi?: boolean;
+  searchable?: boolean;
+  onSelect?: (item: IListItem<TPayload>) => void;
+}
+
+export interface ListState<TPayload> {
+  /** Filtered + grouped items ready for rendering */
+  visibleItems: IListItem<TPayload>[];
+  /** Grouped items map (group label → items), only populated when grouped=true */
+  groups: Map<string, IListItem<TPayload>[]>;
+  /** Currently keyboard-focused item id */
+  activeId: string | null;
+  setActiveId: (id: string | null) => void;
+  /** Selected item ids (multi-select) */
+  selectedIds: Set<string>;
+  toggleSelected: (id: string, modifiers?: { shift?: boolean; ctrl?: boolean }) => void;
+  clearSelection: () => void;
+  /** Search query */
+  query: string;
+  setQuery: (q: string) => void;
+  /** Keyboard handler — attach to the list container's onKeyDown */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  /** Call when an item is activated (click or Enter) */
+  selectItem: (item: IListItem<TPayload>) => void;
+}
+
+function matchesQuery<T>(item: IListItem<T>, q: string): boolean {
+  if (!q) return true;
+  const lower = q.toLowerCase();
+  if (item.label.toLowerCase().includes(lower)) return true;
+  if (item.subtitle?.toLowerCase().includes(lower)) return true;
+  if (item.keywords?.some(k => k.toLowerCase().includes(lower))) return true;
+  return false;
+}
+
+export function useListState<TPayload>(
+  options: UseListStateOptions<TPayload>,
+): ListState<TPayload> {
+  const { items, defaultActiveId, multi = false, onSelect } = options;
+
+  const [activeId, setActiveId] = useState<string | null>(defaultActiveId ?? null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState('');
+  const lastSelectedRef = useRef<string | null>(null);
+
+  // Reset active item when items list changes identity
+  useEffect(() => {
+    if (defaultActiveId !== undefined) setActiveId(defaultActiveId);
+  }, [defaultActiveId]);
+
+  const visibleItems = useMemo(() => {
+    if (!query) return items;
+    return items.filter(item => matchesQuery(item, query));
+  }, [items, query]);
+
+  const groups = useMemo(() => {
+    const map = new Map<string, IListItem<TPayload>[]>();
+    for (const item of visibleItems) {
+      const key = item.group ?? '';
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(item);
+    }
+    return map;
+  }, [visibleItems]);
+
+  const toggleSelected = useCallback(
+    (id: string, modifiers?: { shift?: boolean; ctrl?: boolean }) => {
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        if (multi && modifiers?.shift && lastSelectedRef.current) {
+          const fromIdx = visibleItems.findIndex(i => i.id === lastSelectedRef.current);
+          const toIdx = visibleItems.findIndex(i => i.id === id);
+          if (fromIdx !== -1 && toIdx !== -1) {
+            const [lo, hi] = fromIdx < toIdx ? [fromIdx, toIdx] : [toIdx, fromIdx];
+            visibleItems.slice(lo, hi + 1).forEach(i => next.add(i.id));
+          }
+        } else if (multi && modifiers?.ctrl) {
+          if (next.has(id)) next.delete(id);
+          else next.add(id);
+        } else {
+          next.clear();
+          next.add(id);
+        }
+        return next;
+      });
+      lastSelectedRef.current = id;
+    },
+    [multi, visibleItems],
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    lastSelectedRef.current = null;
+  }, []);
+
+  const selectItem = useCallback(
+    (item: IListItem<TPayload>) => {
+      setActiveId(item.id);
+      toggleSelected(item.id);
+      onSelect?.(item);
+    },
+    [onSelect, toggleSelected],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!visibleItems.length) return;
+      const currentIdx = visibleItems.findIndex(i => i.id === activeId);
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = visibleItems[Math.min(currentIdx + 1, visibleItems.length - 1)];
+        setActiveId(next.id);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = visibleItems[Math.max(currentIdx - 1, 0)];
+        setActiveId(prev.id);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const active = visibleItems.find(i => i.id === activeId);
+        if (active) selectItem(active);
+      } else if (e.key === 'Escape') {
+        clearSelection();
+      }
+    },
+    [visibleItems, activeId, selectItem, clearSelection],
+  );
+
+  return {
+    visibleItems,
+    groups,
+    activeId,
+    setActiveId,
+    selectedIds,
+    toggleSelected,
+    clearSelection,
+    query,
+    setQuery,
+    onKeyDown,
+    selectItem,
+  };
+}

--- a/src/components/playground/CommandPalette.tsx
+++ b/src/components/playground/CommandPalette.tsx
@@ -1,11 +1,9 @@
-import React, { useState, useMemo, useEffect } from 'react'
-import * as Headless from '@headlessui/react'
+import { useState, useEffect } from 'react'
 import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react'
-import { MagnifyingGlassIcon } from '@heroicons/react/20/solid'
-import { ComboboxOption, ComboboxLabel, ComboboxDescription } from './combobox'
 import { useCommandPalette } from '../command-palette/CommandContext'
 import type { CommandPaletteResult } from '../command-palette/types'
-import clsx from 'clsx'
+import { CommandListView, paletteResultToListItem } from '@/components/list'
+import type { IListItem } from '@/components/list'
 
 interface CommandPaletteProps {
   isOpen: boolean
@@ -19,165 +17,70 @@ export function CommandPalette({ isOpen, onClose, items, onSelect, initialCatego
   const { search: query, setSearch: setQuery, activeStrategy } = useCommandPalette()
   const [strategyResults, setStrategyResults] = useState<CommandPaletteResult[]>([])
 
-  // Default filtering when no strategy is active
-  const filteredItems = useMemo(() => {
-    if (activeStrategy) return []
-
-    // If there's a search query, filter items by name
-    if (query !== '') {
-      return items.filter((item) => {
-        const matchesQuery = item.name.toLowerCase().includes(query.toLowerCase())
-        return matchesQuery
-      })
-    }
-    
-    // If no query but initial category is set, show items in that category
-    if (initialCategory) {
-      return items.filter(item => item.category === initialCategory)
-    }
-
-    return []
-  }, [query, items, initialCategory, activeStrategy])
-
   // Fetch results from active strategy
   useEffect(() => {
     if (!activeStrategy) {
       setStrategyResults([])
       return
     }
-
     let cancelled = false
     const fetchResults = async () => {
-      const results = await activeStrategy.getResults(query)
-      if (!cancelled) {
-        setStrategyResults(results)
-      }
+      const results = await Promise.resolve(activeStrategy.getResults(query))
+      if (!cancelled) setStrategyResults(results)
     }
-
     fetchResults()
     return () => { cancelled = true }
   }, [query, activeStrategy])
 
-  // Reset query when dialog is closed to ensure a clean start next time
+  // Reset query when dialog closes
   useEffect(() => {
     if (!isOpen) {
-      const timer = setTimeout(() => {
-        setQuery('')
-        setStrategyResults([])
-      }, 300)
+      const timer = setTimeout(() => { setQuery(''); setStrategyResults([]) }, 300)
       return () => clearTimeout(timer)
     }
-  }, [isOpen])
+  }, [isOpen, setQuery])
 
-  const handleSelect = (item: any) => {
+  // Build list items from whichever source is active
+  const listItems = activeStrategy
+    ? strategyResults.map(paletteResultToListItem)
+    : items
+        .filter(item => {
+          if (query) return item.name.toLowerCase().includes(query.toLowerCase())
+          if (initialCategory) return item.category === initialCategory
+          return false
+        })
+        .map(item => paletteResultToListItem({ ...item, type: 'workout' as const }))
+
+  const handleSelect = (listItem: IListItem<CommandPaletteResult>) => {
     if (activeStrategy) {
-      activeStrategy.onSelect(item as CommandPaletteResult)
+      activeStrategy.onSelect(listItem.payload)
     } else {
-      onSelect(item)
+      onSelect(listItem.payload)
     }
     onClose()
   }
 
-  const results = activeStrategy ? strategyResults : filteredItems
-
   return (
-    <Dialog 
+    <Dialog
       as="div"
-      open={isOpen} 
-      onClose={onClose} 
+      open={isOpen}
+      onClose={onClose}
       className="relative z-50 focus:outline-none"
     >
-      <DialogBackdrop
-        className="fixed inset-0 bg-zinc-950/25 backdrop-blur-sm"
-      />
+      <DialogBackdrop className="fixed inset-0 bg-zinc-950/25 backdrop-blur-sm" />
 
       <div className="fixed inset-0 z-10 w-screen overflow-y-auto p-4 sm:p-6 md:p-20">
-        <DialogPanel
-          className="mx-auto max-w-xl transform divide-y divide-border overflow-hidden rounded-xl bg-card shadow-2xl ring-1 ring-border"
-        >
-          <div className="flex flex-col min-h-0">
-            <Headless.Combobox 
-              as="div"
-              onChange={handleSelect}
-            >
-            <div className="flex items-center px-4 h-14">
-              <MagnifyingGlassIcon
-                className="size-5 text-muted-foreground"
-                aria-hidden="true"
-              />
-              <Headless.ComboboxInput
-                autoFocus
-                as="input"
-                className="h-full w-full border-0 bg-transparent pl-3 pr-4 text-foreground placeholder:text-muted-foreground focus:ring-0 sm:text-base font-medium outline-hidden"
-                placeholder={activeStrategy?.placeholder || (initialCategory ? `Search in ${initialCategory}...` : "Search workouts...")}
-                onChange={(event) => setQuery(event.target.value)}
-                onKeyDown={(e) => {
-                  if (activeStrategy?.onKeyDown) {
-                    activeStrategy.onKeyDown(e)
-                  }
-                }}
-              />
-            </div>
-
-            {activeStrategy?.renderHeader && (
-              <div className="border-b border-border bg-muted/5">
-                {activeStrategy.renderHeader()}
-              </div>
-            )}
-
-            {(query === '' || results.length > 0) && (
-              <Headless.ComboboxOptions
-                as="div"
-                static
-                className="max-h-96 scroll-py-2 overflow-y-auto py-4 text-sm text-foreground"
-              >
-                {activeStrategy ? (
-                  // Strategy Results (No Collection Header)
-                  results.map((item) => (
-                    <ComboboxOption key={item.id} value={item} className="mx-2">
-                      <ComboboxLabel className="font-bold">{item.name}</ComboboxLabel>
-                      <ComboboxDescription className="font-medium opacity-70 tracking-tight">
-                        {(item as CommandPaletteResult).subtitle || item.category}
-                      </ComboboxDescription>
-                    </ComboboxOption>
-                  ))
-                ) : results.length > 0 ? (
-                  <>
-                    {(query === '' && initialCategory) && (
-                      <div className="px-4 py-2 text-[10px] font-black text-primary uppercase tracking-[0.2em]">
-                        {initialCategory} Collection
-                      </div>
-                    )}
-                    {results.map((item) => (
-                      <ComboboxOption key={item.id} value={item} className="mx-2">
-                        <ComboboxLabel className="font-bold">{item.name}</ComboboxLabel>
-                        <ComboboxDescription className="font-medium opacity-70 tracking-tight">
-                          {item.category}
-                        </ComboboxDescription>
-                      </ComboboxOption>
-                    ))}
-                  </>
-                ) : query !== '' ? (
-                   <div className="px-4 py-14 text-center sm:px-14">
-                    <p className="text-sm font-medium text-muted-foreground">No results found for this search.</p>
-                  </div>
-                ) : (
-                  <>
-                    <div className="px-4 py-2 text-[10px] font-black text-primary uppercase tracking-[0.2em]">
-                      Recent Workouts
-                    </div>
-                    {items.slice(0, 5).map((item) => (
-                      <ComboboxOption key={item.id} value={item} className="mx-2">
-                        <ComboboxLabel className="font-bold">{item.name}</ComboboxLabel>
-                        <ComboboxDescription className="font-medium opacity-70 tracking-tight">{item.category}</ComboboxDescription>
-                      </ComboboxOption>
-                    ))}
-                  </>
-                )}
-              </Headless.ComboboxOptions>
-            )}
-          </Headless.Combobox>
-          </div>
+        <DialogPanel className="mx-auto max-w-xl transform overflow-hidden rounded-xl bg-card shadow-2xl ring-1 ring-border">
+          <CommandListView
+            items={listItems}
+            query={query}
+            onQueryChange={setQuery}
+            onSelect={handleSelect}
+            isOpen={true}
+            onClose={onClose}
+            placeholder={activeStrategy?.placeholder ?? (initialCategory ? `Search in ${initialCategory}…` : 'Search workouts…')}
+            header={activeStrategy?.renderHeader ? activeStrategy.renderHeader() : undefined}
+          />
         </DialogPanel>
       </div>
     </Dialog>

--- a/src/components/playground/PageNavDropdown.tsx
+++ b/src/components/playground/PageNavDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import {
   Dropdown,
   DropdownButton,

--- a/src/components/playground/sidebar-layout.tsx
+++ b/src/components/playground/sidebar-layout.tsx
@@ -59,31 +59,33 @@ export function SidebarLayout({
   }, [location])
 
   return (
-    <div className="relative isolate flex min-h-svh w-full bg-zinc-50 dark:bg-zinc-950 max-lg:flex-col lg:flex-row">
-      {/* Sidebar — always visible on lg, overlay on mobile */}
-      <nav className="hidden lg:flex lg:w-64 lg:shrink-0 lg:sticky lg:top-0 lg:self-start lg:max-h-screen lg:overflow-y-auto">
-        {sidebar}
-      </nav>
-      <MobileSidebar open={showSidebar} close={() => setShowSidebar(false)}>
-        {sidebar}
-      </MobileSidebar>
+    <div className="relative isolate flex min-h-svh w-full bg-zinc-50 dark:bg-zinc-950 max-lg:flex-col lg:flex-row lg:justify-center">
+      <div className="flex flex-1 w-full max-lg:flex-col lg:flex-row lg:max-w-[100rem]">
+        {/* Sidebar — always visible on lg, overlay on mobile */}
+        <nav className="hidden lg:flex lg:w-64 lg:shrink-0 lg:sticky lg:top-0 lg:self-start lg:max-h-screen lg:overflow-y-auto lg:bg-zinc-50/72 lg:backdrop-blur-sm dark:lg:bg-zinc-950/72">
+          {sidebar}
+        </nav>
+        <MobileSidebar open={showSidebar} close={() => setShowSidebar(false)}>
+          {sidebar}
+        </MobileSidebar>
 
-      {/* Mobile header with hamburger + navbar */}
-      <header className="sticky top-0 z-20 flex items-center px-2 sm:px-4 bg-white dark:bg-zinc-900 lg:hidden overflow-hidden">
-        <div className="py-2.5 shrink-0">
-          <NavbarItem onClick={() => setShowSidebar(true)} aria-label="Open navigation">
-            <OpenMenuIcon />
-          </NavbarItem>
-        </div>
-        <div className="min-w-0 flex-1 overflow-hidden">{navbar}</div>
-      </header>
+        {/* Mobile header with hamburger + navbar */}
+        <header className="sticky top-0 z-20 flex items-center px-2 sm:px-4 bg-white dark:bg-zinc-900 lg:hidden overflow-hidden">
+          <div className="py-2.5 shrink-0">
+            <NavbarItem onClick={() => setShowSidebar(true)} aria-label="Open navigation">
+              <OpenMenuIcon />
+            </NavbarItem>
+          </div>
+          <div className="min-w-0 flex-1 overflow-hidden">{navbar}</div>
+        </header>
 
-      {/* Content */}
-      <main className="flex flex-1 flex-col lg:min-w-0 lg:pt-2 lg:pr-2 lg:pb-2">
-        <div className="grow w-full lg:overflow-clip">
-          {children}
-        </div>
-      </main>
+        {/* Content */}
+        <main className="flex flex-1 flex-col lg:min-w-0 lg:pt-2 lg:pr-2 lg:pb-2">
+          <div className="grow w-full lg:overflow-visible">
+            {children}
+          </div>
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/components/workbench/CloneDateDropdown.tsx
+++ b/src/components/workbench/CloneDateDropdown.tsx
@@ -5,20 +5,10 @@
  * fires onClone(selectedDate) so the caller can clone the entry
  * to that specific target date.
  */
-
-import React, { useState, useEffect } from 'react';
-import { Copy, Calendar, Loader2 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-} from '@/components/ui/dropdown-menu';
-import { CalendarDatePicker } from '@/components/ui/CalendarDatePicker';
+import React from 'react';
 import { cn } from '@/lib/utils';
 import type { IContentProvider } from '@/types/content-provider';
+import { WorkoutActionButton } from '@/components/workout/WorkoutActionButton';
 
 export interface CloneDateDropdownProps {
   /** Callback when a date is selected. Receives the target date timestamp. */
@@ -46,136 +36,19 @@ export const CloneDateDropdown: React.FC<CloneDateDropdownProps> = ({
   className,
   title = 'Clone to date...',
 }) => {
-  const [open, setOpen] = useState(false);
-  const [entryDates, setEntryDates] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(false);
-
-  // Load entry dates when dropdown opens
-  useEffect(() => {
-    if (!open || !provider) return;
-
-    const loadEntryDates = async () => {
-      setLoading(true);
-      try {
-        const entries = await provider.getEntries();
-        const dates = new Set(
-          entries
-            .filter(e => e.type !== 'template')
-            .map(e => new Date(e.targetDate).toISOString().split('T')[0])
-        );
-        setEntryDates(dates);
-      } catch (err) {
-        console.error('Failed to load entry dates:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadEntryDates();
-  }, [open, provider]);
-
-  const handleDateSelect = (date: Date) => {
-    // Set to noon to avoid timezone edge cases
-    date.setHours(12, 0, 0, 0);
+  const handleAction = (date: Date) => {
     onClone(date.getTime());
-    setOpen(false);
   };
 
-  const handleMainAction = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onClone(Date.now());
-  };
-
-  const menuContent = (
-    <DropdownMenuContent align="end" className="w-64" onClick={(e) => e.stopPropagation()}>
-      <DropdownMenuLabel className="flex items-center gap-2">
-        <Calendar className="h-3.5 w-3.5" />
-        {label === 'Use Template' ? 'Clone to Date' : label}
-      </DropdownMenuLabel>
-      <DropdownMenuSeparator />
-
-      {loading ? (
-        <div className="flex items-center justify-center py-6">
-          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-        </div>
-      ) : (
-        <CalendarDatePicker
-          onDateSelect={handleDateSelect}
-          entryDates={entryDates}
-        />
-      )}
-
-      <DropdownMenuSeparator />
-      <div className="px-2 py-1.5 text-[10px] text-muted-foreground text-center">
-        Select a date to clone this workout to
-      </div>
-    </DropdownMenuContent>
-  );
-
-  if (variant === 'button') {
-    return (
-      <div className={cn("flex items-center", className)} onClick={(e) => e.stopPropagation()}>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleMainAction}
-          className="rounded-r-none gap-2 px-3 h-8 border-r-0 font-medium whitespace-nowrap"
-          title="Use Template (clone to today)"
-        >
-          <Copy className="h-3.5 w-3.5 text-primary" />
-          {showLabel && <span>{label}</span>}
-        </Button>
-
-        <DropdownMenu open={open} onOpenChange={setOpen}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              className="rounded-l-none px-2 h-8 border-l border-primary/10"
-              title={title}
-            >
-              <Calendar className="h-3.5 w-3.5 text-muted-foreground hover:text-primary transition-colors" />
-            </Button>
-          </DropdownMenuTrigger>
-          {menuContent}
-        </DropdownMenu>
-      </div>
-    );
-  }
-
-  // Handle icon-only variants (list-icon, icon) as split buttons
-  // Left part: Clone to today, Right part: Calendar dropdown
   return (
-    <div className={cn("flex items-center", className)} onClick={(e) => e.stopPropagation()}>
-      <button
-        onClick={handleMainAction}
-        className={cn(
-          "flex items-center justify-center rounded-l transition-colors",
-          variant === 'list-icon'
-            ? "h-8 w-8 hover:bg-muted text-muted-foreground/50 hover:text-blue-500"
-            : "h-8 w-8 hover:bg-muted text-muted-foreground hover:text-foreground"
-        )}
-        title="Clone to today"
-      >
-        <Copy className="h-4 w-4" />
-      </button>
-
-      <DropdownMenu open={open} onOpenChange={setOpen}>
-        <DropdownMenuTrigger asChild>
-          <button
-            className={cn(
-              "flex items-center justify-center rounded-r border-l border-border/10 transition-colors",
-              variant === 'list-icon'
-                ? "h-8 w-7 hover:bg-muted text-muted-foreground/30 hover:text-blue-400"
-                : "h-8 w-7 hover:bg-muted text-muted-foreground/50 hover:text-foreground"
-            )}
-            title={title}
-          >
-            <Calendar className="h-3.5 w-3.5" />
-          </button>
-        </DropdownMenuTrigger>
-        {menuContent}
-      </DropdownMenu>
-    </div>
+    <WorkoutActionButton
+        mode="clone"
+        label={showLabel ? label : ""}
+        onAction={handleAction}
+        provider={provider}
+        variant={variant === 'button' ? 'outline' : 'ghost'}
+        className={cn(className, variant === 'list-icon' && "text-muted-foreground/50")}
+        title={title}
+    />
   );
 };

--- a/src/components/workbench/CollectionItemList.tsx
+++ b/src/components/workbench/CollectionItemList.tsx
@@ -4,8 +4,9 @@
  */
 import React from 'react';
 import { cn } from '@/lib/utils';
-import { FileText } from 'lucide-react';
 import type { WodCollectionItem } from '@/repositories/wod-collections';
+import { ListView, collectionItemToListItem } from '@/components/list';
+import type { IListItem } from '@/components/list';
 
 export interface CollectionItemListProps {
     items: WodCollectionItem[];
@@ -20,31 +21,22 @@ export const CollectionItemList: React.FC<CollectionItemListProps> = ({
     onSelectItem,
     className,
 }) => {
+    const listItems = items.map(collectionItemToListItem).map(item => ({
+        ...item,
+        isActive: item.id === activeItemId,
+    }));
+
     return (
-        <div className={cn("flex flex-col h-full", className)}>
-            <div className="flex-1 overflow-y-auto">
-                {items.length === 0 && (
+        <div className={cn('flex flex-col h-full', className)}>
+            <ListView
+                items={listItems}
+                onSelect={(item: IListItem<WodCollectionItem>) => onSelectItem(item.payload)}
+                emptyState={
                     <div className="text-sm text-muted-foreground text-center py-8">
                         No sessions in this collection
                     </div>
-                )}
-                {items.map(item => (
-                    <button
-                        key={item.id}
-                        onClick={() => onSelectItem(item)}
-                        className={cn(
-                            "w-full text-left px-4 py-3 border-b border-border transition-colors",
-                            "hover:bg-muted/50 flex items-center gap-3",
-                            activeItemId === item.id
-                                ? "bg-accent/50 border-l-2 border-l-primary"
-                                : ""
-                        )}
-                    >
-                        <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
-                        <span className="text-sm font-medium truncate">{item.name}</span>
-                    </button>
-                ))}
-            </div>
+                }
+            />
         </div>
     );
 };

--- a/src/components/workout/WorkoutActionButton.tsx
+++ b/src/components/workout/WorkoutActionButton.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Copy, Calendar, Loader2, ChevronDown } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuItem,
+} from '@/components/ui/dropdown-menu';
+import { CalendarDatePicker } from '@/components/ui/CalendarDatePicker';
+import { cn } from '@/lib/utils';
+import type { IContentProvider } from '@/types/content-provider';
+
+export interface WorkoutActionButtonProps {
+    /** Primary action (creating or cloning). Receives the target date. */
+    onAction: (date: Date) => void | Promise<void>;
+    /** Optional content provider for entry highlights in calendar */
+    provider?: IContentProvider;
+    /** 'create' (Plus icon) or 'clone' (Copy icon) */
+    mode?: 'create' | 'clone';
+    /** Label for the main button */
+    label?: string;
+    /** Button variant ('default', 'outline', 'ghost') */
+    variant?: 'default' | 'outline' | 'ghost';
+    /** Additional class names */
+    className?: string;
+    /** Tooltip or title for the main button */
+    title?: string;
+    /** Optional secondary actions (e.g. Import) */
+    secondaryActions?: {
+        label: string;
+        icon: React.ReactNode;
+        onClick: () => void;
+    }[];
+}
+
+/**
+ * WorkoutActionButton
+ * 
+ * A reusable split button:
+ * [ (Icon) Label ] | [ (Calendar Icon) ]
+ * 
+ * Main button triggers onAction for today.
+ * Dropdown trigger opens a calendar to pick a specific date.
+ */
+export const WorkoutActionButton: React.FC<WorkoutActionButtonProps> = ({
+    onAction,
+    provider,
+    mode = 'create',
+    label,
+    variant = 'outline',
+    className,
+    title,
+    secondaryActions = [],
+}) => {
+    const [open, setOpen] = useState(false);
+    const [entryDates, setEntryDates] = useState<Set<string>>(new Set());
+    const [loading, setLoading] = useState(false);
+
+    const Icon = mode === 'create' ? Plus : Copy;
+    const defaultLabel = mode === 'create' ? 'New' : 'Clone';
+    const effectiveLabel = label || defaultLabel;
+    const effectiveTitle = title || (mode === 'create' ? 'Create for today' : 'Clone to today');
+
+    // Load entry dates when dropdown opens to show highlights in calendar
+    useEffect(() => {
+        if (!open || !provider) return;
+
+        const loadEntryDates = async () => {
+            setLoading(true);
+            try {
+                const entries = await provider.getEntries();
+                const dates = new Set(
+                    entries
+                        .filter(e => e.type !== 'template')
+                        .map(e => new Date(e.targetDate).toISOString().split('T')[0])
+                );
+                setEntryDates(dates);
+            } catch (err) {
+                console.error('Failed to load entry dates:', err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadEntryDates();
+    }, [open, provider]);
+
+    const handleMainAction = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onAction(new Date());
+    };
+
+    const handleDateSelect = (date: Date) => {
+        // Set to noon to avoid timezone edge cases
+        date.setHours(12, 0, 0, 0);
+        onAction(date);
+        setOpen(false);
+    };
+
+    return (
+        <div className={cn("flex items-center -space-x-px", className)} onClick={(e) => e.stopPropagation()}>
+            <Button
+                variant={variant}
+                size="sm"
+                onClick={handleMainAction}
+                className={cn(
+                    "rounded-r-none gap-2 px-3 h-9 font-semibold whitespace-nowrap z-10",
+                    variant === 'default' ? "border-r border-primary-foreground/20" : "border-r-0"
+                )}
+                title={effectiveTitle}
+            >
+                <Icon className="h-4 w-4" />
+                <span className="hidden sm:inline">{effectiveLabel}</span>
+            </Button>
+
+            <DropdownMenu open={open} onOpenChange={setOpen}>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        variant={variant}
+                        size="sm"
+                        className={cn(
+                            "rounded-l-none px-2 h-9 transition-all",
+                            variant === 'ghost' ? "border-l hover:bg-accent" : "border-l"
+                        )}
+                        title="Pick a date"
+                    >
+                        <Calendar className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-colors" />
+                    </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-auto p-0" onClick={(e) => e.stopPropagation()}>
+                    <div className="p-3">
+                        <DropdownMenuLabel className="flex items-center gap-2 px-1 py-1 text-xs uppercase tracking-wider text-muted-foreground">
+                            <Calendar className="h-3 w-3" />
+                            {mode === 'create' ? 'Create on Date' : 'Clone to Date'}
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator className="my-2" />
+                        {loading ? (
+                            <div className="flex items-center justify-center py-10 w-[240px]">
+                                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                            </div>
+                        ) : (
+                            <CalendarDatePicker
+                                onDateSelect={handleDateSelect}
+                                entryDates={entryDates}
+                                className="p-0"
+                            />
+                        )}
+                    </div>
+
+                    {secondaryActions.length > 0 && (
+                        <>
+                            <DropdownMenuSeparator />
+                            <div className="p-1">
+                                {secondaryActions.map((action, idx) => (
+                                    <DropdownMenuItem
+                                        key={idx}
+                                        onClick={() => {
+                                            setOpen(false);
+                                            action.onClick();
+                                        }}
+                                        className="gap-2 text-sm"
+                                    >
+                                        <div className="text-muted-foreground group-hover:text-foreground">
+                                            {action.icon}
+                                        </div>
+                                        {action.label}
+                                    </DropdownMenuItem>
+                                ))}
+                            </div>
+                        </>
+                    )}
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </div>
+    );
+};

--- a/src/hooks/useWodCollections.ts
+++ b/src/hooks/useWodCollections.ts
@@ -2,7 +2,8 @@
  * useWodCollections — React hook for accessing WOD collections
  * derived from markdown/collections/ subdirectories.
  */
-import { useState, useMemo, useCallback } from 'react';
+import { useMemo, useCallback } from 'react';
+import { useQueryState } from 'nuqs';
 import { getWodCollections, getWodCollection } from '@/repositories/wod-collections';
 import type { WodCollection, WodCollectionItem } from '@/repositories/wod-collections';
 
@@ -23,7 +24,10 @@ export interface UseWodCollectionsReturn {
 
 export function useWodCollections(): UseWodCollectionsReturn {
     const collections = useMemo(() => getWodCollections(), []);
-    const [activeCollectionId, setActiveCollectionId] = useState<string | null>(null);
+    const [activeCollectionId, setActiveCollectionId] = useQueryState('col', {
+        defaultValue: null,
+        clearOnDefault: true,
+    });
 
     const activeCollection = useMemo(() => {
         if (!activeCollectionId) return null;

--- a/src/nav/navTypes.ts
+++ b/src/nav/navTypes.ts
@@ -1,0 +1,122 @@
+/**
+ * navTypes.ts — Core navigation type contract (library layer)
+ *
+ * These types are used by library components (e.g. StickyNavPanel).
+ * The playground extends this with route-change and view-state action types
+ * in playground/src/nav/navTypes.ts.
+ */
+
+import type React from 'react'
+
+// ─── INavAction — discriminated union of all action types ────────────────────
+
+/** Navigate to a new route. */
+export interface RouteChangeAction {
+  type: 'route'
+  to: string
+  pushHistory?: boolean
+}
+
+/** Update URL query params without a route change. */
+export interface RouteQueryAction {
+  type: 'query'
+  params: Record<string, string | null>
+  pushHistory?: boolean
+}
+
+/** Scroll the page to a named anchor. */
+export interface ScrollAction {
+  type: 'scroll'
+  sectionId: string
+}
+
+/** Swap the sticky view panel's editor source content. */
+export interface ViewSourceAction {
+  type: 'view-source'
+  source: string
+}
+
+/** Transition the view panel state machine. */
+export interface ViewStateAction {
+  type: 'view-state'
+  state: 'note' | 'track' | 'review'
+  open?: 'view' | 'dialog' | 'route'
+}
+
+/** Execute a sequence of actions in order. */
+export interface PipelineAction {
+  type: 'pipeline'
+  steps: INavAction[]
+}
+
+/** Invoke an arbitrary handler. */
+export interface CallAction {
+  type: 'call'
+  handler: () => void
+  label?: string
+}
+
+/** No-op — for group headers. */
+export interface NoneAction {
+  type: 'none'
+}
+
+export type INavAction =
+  | RouteChangeAction
+  | RouteQueryAction
+  | ScrollAction
+  | ViewSourceAction
+  | ViewStateAction
+  | PipelineAction
+  | CallAction
+  | NoneAction
+
+// ─── INavActivation — base interface for every activatable UI element ─────────
+
+export interface INavActivation {
+  id: string
+  label: string
+  icon?: React.ComponentType<{ className?: string; 'data-slot'?: string }>
+  action: INavAction
+}
+
+// ─── NavActionDeps — injected by each rendering surface ──────────────────────
+
+export interface NavActionDeps {
+  navigate:         (to: string, opts?: { replace?: boolean }) => void
+  setQueryParam:    (params: Record<string, string | null>, replace?: boolean) => void
+  scrollToSection?: (id: string) => void
+  swapSource?:      (source: string) => void
+  setPanelState?:   (state: 'note' | 'track' | 'review', open?: 'view' | 'dialog' | 'route') => void
+}
+
+/**
+ * executeNavAction — single dispatch function for all rendering surfaces.
+ */
+export function executeNavAction(action: INavAction, deps: NavActionDeps): void {
+  switch (action.type) {
+    case 'route':
+      deps.navigate(action.to, { replace: !(action.pushHistory ?? true) })
+      break
+    case 'query':
+      deps.setQueryParam(action.params, !(action.pushHistory ?? false))
+      break
+    case 'scroll':
+      deps.scrollToSection?.(action.sectionId)
+      break
+    case 'view-source':
+      deps.swapSource?.(action.source)
+      break
+    case 'view-state':
+      deps.setPanelState?.(action.state, action.open)
+      break
+    case 'pipeline':
+      action.steps.forEach(step => executeNavAction(step, deps))
+      break
+    case 'call':
+      action.handler()
+      break
+    case 'none':
+      break
+  }
+}

--- a/src/panels/page-shells/CalendarPageShell.tsx
+++ b/src/panels/page-shells/CalendarPageShell.tsx
@@ -13,6 +13,7 @@ import { useState, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { useScreenMode } from '@/panels/panel-system/useScreenMode';
 import type { CalendarTab } from './types';
+import { PAGE_SHELL_CONTENT_SURFACE_CLASS } from './contentSurface';
 
 export interface CalendarPageShellProps {
   /** Calendar / date-selection widget */
@@ -80,7 +81,13 @@ export function CalendarPageShell({
       </div>
 
       {/* Detail area */}
-      <div className="flex-1 flex flex-col min-h-0">
+      <div
+        className={cn(
+          'flex-1 flex flex-col min-h-0',
+          !isMobile && 'lg:rounded-[2rem]',
+          !isMobile && PAGE_SHELL_CONTENT_SURFACE_CLASS,
+        )}
+      >
         {/* Tab bar */}
         <div className="flex items-center gap-1 px-4 py-2 border-b border-border/50 bg-muted/20 overflow-x-auto">
           {tabs.map((tab) => (

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -259,7 +259,7 @@ export function CanvasPage({
 
   // ── Title-bar mode render ──────────────────────────────────────────────
   return (
-    <div className={cn('relative flex w-full min-h-screen justify-start items-start', className)}>
+    <div className={cn('relative flex w-full min-h-screen justify-center items-start', className)}>
       <div className={cn(
         'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
         PAGE_SHELL_CONTENT_SURFACE_CLASS,

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -35,8 +35,10 @@ import { cn } from '@/lib/utils';
 import { useQueryState } from 'nuqs';
 import type { PageNavLink } from '@/components/playground/PageNavDropdown';
 import type { DocsSection } from './types';
+import { PAGE_SHELL_CONTENT_SURFACE_CLASS } from './contentSurface';
 import { StickyNavPanel } from './StickyNavPanel';
 import { ScopedRuntimeProvider } from './ScopedRuntimeProvider';
+import type { NavActionDeps } from '@/nav/navTypes';
 
 export interface CanvasPageProps {
   // ── Title-bar mode ──────────────────────────────────────────────────────
@@ -199,15 +201,32 @@ export function CanvasPage({
 
   // ── Sections mode render ───────────────────────────────────────────────
   if (useStickyNavMode) {
-    const navSections = sections!.map((s) => ({ id: s.id, label: s.label }));
+    const stickyActivations = sections!.map((s) => ({
+      id: s.id,
+      label: s.label,
+      action: { type: 'scroll' as const, sectionId: s.id },
+    }))
+
+    const stickyDeps: NavActionDeps = {
+      navigate: () => { /* sections mode doesn't navigate */ },
+      setQueryParam: () => { /* sections mode doesn't update query */ },
+      scrollToSection: (id: string) => {
+        const el = document.getElementById(id)
+        if (el) {
+          const y = el.getBoundingClientRect().top + window.scrollY - 64
+          window.scrollTo({ top: y, behavior: 'smooth' })
+        }
+      },
+    }
 
     return (
       <div className={cn('flex flex-col min-h-screen bg-background', className)}>
         {hero}
         <StickyNavPanel
-          sections={navSections}
+          activations={stickyActivations}
           activeSection={activeSection}
           variant="top-fixed"
+          deps={stickyDeps}
         />
         <div className="flex-1">
           {sections!.map((section) => {
@@ -241,7 +260,10 @@ export function CanvasPage({
   // ── Title-bar mode render ──────────────────────────────────────────────
   return (
     <div className={cn('relative flex w-full min-h-screen justify-start items-start', className)}>
-      <div className="flex flex-col flex-1 min-w-0 3xl:max-w-7xl bg-background shadow-xl dark:shadow-none ring-1 ring-zinc-950/5 dark:ring-white/10 min-h-screen lg:rounded-[2.5rem]">
+      <div className={cn(
+        'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
+        PAGE_SHELL_CONTENT_SURFACE_CLASS,
+      )}>
         {/* Sticky header — hidden on mobile (SidebarLayout navbar covers it), sticky on desktop */}
         <div className="hidden lg:block lg:sticky lg:top-0 lg:z-30 lg:bg-background/80 lg:backdrop-blur-md lg:pt-8">
           <div className="flex items-center justify-between px-6 lg:px-10">

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -33,6 +33,7 @@
 import { useState, useEffect, useRef, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { useQueryState } from 'nuqs';
+import { PlayIcon } from '@heroicons/react/20/solid';
 import type { PageNavLink } from '@/components/playground/PageNavDropdown';
 import type { DocsSection } from './types';
 import { PAGE_SHELL_CONTENT_SURFACE_CLASS } from './contentSurface';
@@ -259,7 +260,7 @@ export function CanvasPage({
 
   // ── Title-bar mode render ──────────────────────────────────────────────
   return (
-    <div className={cn('relative flex w-full min-h-screen justify-center items-start', className)}>
+    <div className={cn('relative flex w-full min-h-screen justify-start items-start', className)}>
       <div className={cn(
         'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
         PAGE_SHELL_CONTENT_SURFACE_CLASS,
@@ -301,18 +302,30 @@ export function CanvasPage({
           </div>
           <nav className="flex flex-col gap-1 border-l border-border/40 ml-1">
             {index.map((link) => (
-              <button
-                key={link.id}
-                onClick={() => scrollToSection(link.id)}
-                className={cn(
-                  'text-left px-4 py-2 text-sm transition-all border-l -ml-px',
-                  activeId === link.id
-                    ? 'font-bold text-foreground border-primary'
-                    : 'text-muted-foreground hover:text-foreground border-transparent hover:border-border',
+              <div key={link.id} className="flex items-center group -ml-px">
+                <button
+                  onClick={() => { if (link.type !== 'wod') scrollToSection(link.id) }}
+                  className={cn(
+                    'flex-1 text-left px-4 py-2 text-sm transition-all border-l',
+                    link.type === 'wod'
+                      ? 'text-muted-foreground/70 border-transparent pl-6 text-xs cursor-default'
+                      : activeId === link.id
+                        ? 'font-bold text-foreground border-primary'
+                        : 'text-muted-foreground hover:text-foreground border-transparent hover:border-border'
+                  )}
+                >
+                  {link.label}
+                </button>
+                {link.onRun && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); link.onRun?.(); }}
+                    title="View workout"
+                    className="opacity-0 group-hover:opacity-100 mr-2 flex items-center justify-center size-6 rounded text-primary hover:bg-primary/10 transition-all"
+                  >
+                    <PlayIcon className="size-3.5" />
+                  </button>
                 )}
-              >
-                {link.label}
-              </button>
+              </div>
             ))}
           </nav>
         </aside>

--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -129,8 +129,8 @@ export function JournalPageShell({
         'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
         PAGE_SHELL_CONTENT_SURFACE_CLASS,
       )}>
-        {/* Sticky header — only sticky on desktop where main navbar is hidden */}
-        <div className="lg:sticky lg:top-0 lg:z-30 lg:bg-background/80 lg:backdrop-blur-md pt-4 lg:pt-8">
+        {/* Sticky header — hidden on mobile (SidebarLayout navbar covers it), sticky on desktop */}
+        <div className="hidden lg:block lg:sticky lg:top-0 lg:z-30 lg:bg-background/80 lg:backdrop-blur-md pt-4 lg:pt-8">
           <div className="flex items-center justify-between px-6 lg:px-10">
             <div className="flex items-center gap-4 truncate">
               <div className="h-10 w-2 shrink-0 rounded-full bg-primary" />

--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -14,6 +14,7 @@ import React, { useState, useEffect, useRef, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { useQueryState } from 'nuqs';
 import { PlayIcon } from '@heroicons/react/20/solid';
+import { PAGE_SHELL_CONTENT_SURFACE_CLASS } from './contentSurface';
 
 export interface JournalPageShellProps {
   /** Editor panel content — typically a PlanPanel with stored note */
@@ -124,7 +125,10 @@ export function JournalPageShell({
         Note Column — Constrained to 3xl max-width on large screens.
         Everything inside (Header + Editor) has the background and shadow.
       */}
-      <div className="flex flex-col flex-1 min-w-0 3xl:max-w-7xl bg-background shadow-xl dark:shadow-none ring-1 ring-zinc-950/5 dark:ring-white/10 min-h-screen lg:rounded-[2.5rem]">
+      <div className={cn(
+        'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
+        PAGE_SHELL_CONTENT_SURFACE_CLASS,
+      )}>
         {/* Sticky header — only sticky on desktop where main navbar is hidden */}
         <div className="lg:sticky lg:top-0 lg:z-30 lg:bg-background/80 lg:backdrop-blur-md pt-4 lg:pt-8">
           <div className="flex items-center justify-between px-6 lg:px-10">

--- a/src/panels/page-shells/StickyNavPanel.tsx
+++ b/src/panels/page-shells/StickyNavPanel.tsx
@@ -5,21 +5,20 @@
  * via scroll position. Supports two visual variants:
  * - 'hero-follow': floats below a hero banner
  * - 'top-fixed': pinned to the top of the viewport
+ *
+ * Each button is an INavActivation — the click is dispatched through
+ * executeNavAction so all surfaces share the same action model.
  */
 
 import { cn } from '@/lib/utils';
+import { executeNavAction } from '@/nav/navTypes';
+import type { INavActivation, NavActionDeps } from '@/nav/navTypes';
 
-export interface StickyNavSection {
-  /** Unique section identifier (matches anchor id) */
-  id: string;
-
-  /** Display label */
-  label: string;
-}
+export type { INavActivation as StickyNavSection };
 
 export interface StickyNavPanelProps {
-  /** Available sections */
-  sections: StickyNavSection[];
+  /** Activatable section items — id, label, and action to dispatch on click. */
+  activations: INavActivation[];
 
   /** Currently active section id */
   activeSection: string;
@@ -27,8 +26,11 @@ export interface StickyNavPanelProps {
   /** Visual variant */
   variant: 'hero-follow' | 'top-fixed';
 
-  /** Click handler for section navigation */
-  onSectionClick?: (id: string) => void;
+  /**
+   * Dependencies injected by the host page.
+   * `scrollToSection` should handle any viewport offset required by the variant.
+   */
+  deps: NavActionDeps;
 
   /** Additional CSS classes */
   className?: string;
@@ -42,22 +44,12 @@ export interface StickyNavPanelProps {
  * below a hero banner (hero-follow).
  */
 export function StickyNavPanel({
-  sections,
+  activations,
   activeSection,
   variant,
-  onSectionClick,
+  deps,
   className,
 }: StickyNavPanelProps) {
-  const handleClick = (id: string) => {
-    onSectionClick?.(id);
-    const el = document.getElementById(id);
-    if (el) {
-      const offset = variant === 'top-fixed' ? 64 : 120;
-      const y = el.getBoundingClientRect().top + window.scrollY - offset;
-      window.scrollTo({ top: y, behavior: 'smooth' });
-    }
-  };
-
   return (
     <nav
       className={cn(
@@ -66,18 +58,18 @@ export function StickyNavPanel({
         className,
       )}
     >
-      {sections.map((section) => (
+      {activations.map((activation) => (
         <button
-          key={section.id}
-          onClick={() => handleClick(section.id)}
+          key={activation.id}
+          onClick={() => executeNavAction(activation.action, deps)}
           className={cn(
             'px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-[0.12em] whitespace-nowrap transition-all ring-1',
-            activeSection === section.id
+            activeSection === activation.id
               ? 'bg-primary text-primary-foreground ring-primary/30 shadow-md'
               : 'bg-muted/50 text-muted-foreground ring-transparent hover:bg-muted hover:ring-border',
           )}
         >
-          {section.label}
+          {activation.label}
         </button>
       ))}
     </nav>

--- a/src/panels/page-shells/contentSurface.ts
+++ b/src/panels/page-shells/contentSurface.ts
@@ -1,0 +1,2 @@
+export const PAGE_SHELL_CONTENT_SURFACE_CLASS =
+  'bg-background ring-1 ring-zinc-950/5 shadow-sm lg:shadow-[-18px_0_36px_-28px_rgba(15,23,42,0.16),18px_0_36px_-28px_rgba(15,23,42,0.16)] dark:shadow-none dark:ring-white/10';

--- a/src/panels/page-shells/index.ts
+++ b/src/panels/page-shells/index.ts
@@ -10,6 +10,8 @@ export * from './types';
 // Layout Primitives
 export { ParallaxSection, type ParallaxSectionProps, type ParallaxStepDescriptor } from './ParallaxSection';
 export { StickyNavPanel, type StickyNavPanelProps, type StickyNavSection } from './StickyNavPanel';
+export type { INavActivation, NavActionDeps, INavAction } from '@/nav/navTypes';
+export { executeNavAction } from '@/nav/navTypes';
 export { HeroBanner, type HeroBannerProps } from './HeroBanner';
 export { ScrollSection, type ScrollSectionProps } from './ScrollSection';
 export { ScopedRuntimeProvider, type ScopedRuntimeProviderProps } from './ScopedRuntimeProvider';

--- a/stories/DesignSystem/molecules/ListView.stories.tsx
+++ b/stories/DesignSystem/molecules/ListView.stories.tsx
@@ -65,9 +65,9 @@ export const Grouped: ListStory = {
 
 export const WithActions: ListStory = {
   render: () => {
-    const actions = (_item: IListItem<{ wod: string }>): IItemAction<{ wod: string }>[] => [
-      { id: 'edit', label: 'Edit', icon: <Edit2 className="w-3 h-3" />, onClick: i => alert(`Edit ${i.label}`) },
-      { id: 'run', label: 'Run', icon: <Play className="w-3 h-3" />, isPrimary: true, onClick: i => alert(`Run ${i.label}`) },
+    const actions = (_item: IListItem<{ wod: string }>): IItemAction[] => [
+      { id: 'edit', label: 'Edit', icon: <Edit2 className="w-3 h-3" />, action: { type: 'call', handler: () => alert(`Edit`) } },
+      { id: 'run', label: 'Run', icon: <Play className="w-3 h-3" />, isPrimary: true, action: { type: 'call', handler: () => alert(`Run`) } },
     ];
     return (
       <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">

--- a/stories/DesignSystem/molecules/ListView.stories.tsx
+++ b/stories/DesignSystem/molecules/ListView.stories.tsx
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Calendar, FileText, Dumbbell, Play, Copy, Edit2 } from 'lucide-react';
+import { ListView } from '@/components/list/ListView';
+import { CommandListView } from '@/components/list/CommandListView';
+import { ActionBarView } from '@/components/list/ActionBarView';
+import type { IListItem, IItemAction } from '@/components/list/types';
+import { useState } from 'react';
+
+// ─── Sample data ────────────────────────────────────────────────────────────
+
+const workoutItems: IListItem<{ wod: string }>[] = [
+  { id: '1', label: 'Fran', subtitle: '21-15-9 Thrusters / Pull-ups', group: 'Benchmark', icon: <Dumbbell className="w-4 h-4" />, badge: 'Hero', payload: { wod: 'fran' } },
+  { id: '2', label: 'Grace', subtitle: '30 Clean & Jerks for time', group: 'Benchmark', icon: <Dumbbell className="w-4 h-4" />, payload: { wod: 'grace' } },
+  { id: '3', label: 'EMOM 10', subtitle: '10 burpees every minute', group: 'Custom', icon: <Calendar className="w-4 h-4" />, payload: { wod: 'emom10' } },
+  { id: '4', label: 'Tuesday AM', subtitle: 'Apr 14 · 22:00', group: 'Custom', icon: <Calendar className="w-4 h-4" />, payload: { wod: 'tue' } },
+];
+
+const commandItems: IListItem<{ action: string }>[] = [
+  { id: 'c1', label: 'Go to Notebook', group: 'Navigation', shortcut: ['g', 'n'], keywords: ['notebook', 'journal'], payload: { action: 'nav-notebook' } },
+  { id: 'c2', label: 'Go to Playground', group: 'Navigation', shortcut: ['g', 'h'], payload: { action: 'nav-home' } },
+  { id: 'c3', label: 'New Entry', group: 'Actions', shortcut: ['⌘', 'n'], payload: { action: 'new' } },
+  { id: 'c4', label: 'Search workouts', group: 'Actions', shortcut: ['⌘', 'k'], payload: { action: 'search' } },
+];
+
+const toolbarItems: IListItem<{ cmd: string }>[] = [
+  { id: 't1', label: 'Run', icon: <Play className="w-3 h-3 fill-current" />, payload: { cmd: 'run', primary: true } as { cmd: string; primary: boolean } },
+  { id: 't2', label: 'Copy link', icon: <Copy className="w-3 h-3" />, payload: { cmd: 'copy' } },
+  { id: 't3', label: 'Edit', icon: <Edit2 className="w-3 h-3" />, payload: { cmd: 'edit' } },
+];
+
+// ─── ListView stories ────────────────────────────────────────────────────────
+
+const listMeta: Meta<typeof ListView> = {
+  title: 'DesignSystem/molecules/ListView',
+  component: ListView,
+  parameters: { layout: 'padded' },
+};
+export default listMeta;
+
+type ListStory = StoryObj<typeof ListView>;
+
+export const Default: ListStory = {
+  render: () => (
+    <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">
+      <ListView items={workoutItems} onSelect={item => alert(item.label)} />
+    </div>
+  ),
+};
+
+export const Searchable: ListStory = {
+  render: () => (
+    <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">
+      <ListView items={workoutItems} searchable onSelect={item => alert(item.label)} />
+    </div>
+  ),
+};
+
+export const Grouped: ListStory = {
+  render: () => (
+    <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">
+      <ListView items={workoutItems} grouped onSelect={item => alert(item.label)} />
+    </div>
+  ),
+};
+
+export const WithActions: ListStory = {
+  render: () => {
+    const actions = (_item: IListItem<{ wod: string }>): IItemAction<{ wod: string }>[] => [
+      { id: 'edit', label: 'Edit', icon: <Edit2 className="w-3 h-3" />, onClick: i => alert(`Edit ${i.label}`) },
+      { id: 'run', label: 'Run', icon: <Play className="w-3 h-3" />, isPrimary: true, onClick: i => alert(`Run ${i.label}`) },
+    ];
+    return (
+      <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">
+        <ListView items={workoutItems} actions={actions} onSelect={() => {}} />
+      </div>
+    );
+  },
+};
+
+export const EmptyState: ListStory = {
+  render: () => (
+    <div className="w-72 border border-zinc-200 rounded-lg overflow-hidden">
+      <ListView
+        items={[]}
+        emptyState={
+          <div className="py-10 flex flex-col items-center gap-2 text-zinc-400">
+            <FileText className="w-8 h-8" />
+            <span className="text-sm">No workouts yet</span>
+          </div>
+        }
+      />
+    </div>
+  ),
+};
+
+// ─── CommandListView story ───────────────────────────────────────────────────
+
+export const CommandPalette: ListStory = {
+  render: () => {
+    const [query, setQuery] = useState('');
+    const [open, setOpen] = useState(true);
+    return (
+      <div className="w-[480px]">
+        <button
+          className="mb-4 rounded px-3 py-1 border text-sm"
+          onClick={() => setOpen(o => !o)}
+        >
+          Toggle palette
+        </button>
+        <CommandListView
+          items={commandItems}
+          query={query}
+          onQueryChange={setQuery}
+          onSelect={item => alert(item.label)}
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          placeholder="Type a command…"
+        />
+      </div>
+    );
+  },
+};
+
+// ─── ActionBarView story ─────────────────────────────────────────────────────
+
+export const ActionBar: ListStory = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4">
+      <div>
+        <p className="text-xs text-zinc-400 mb-2">Horizontal (default)</p>
+        <ActionBarView items={toolbarItems} onSelect={item => alert(item.label)} />
+      </div>
+      <div>
+        <p className="text-xs text-zinc-400 mb-2">Vertical</p>
+        <ActionBarView items={toolbarItems} onSelect={item => alert(item.label)} orientation="vertical" />
+      </div>
+    </div>
+  ),
+};

--- a/stories/DesignSystem/molecules/StickyNavPanel.stories.tsx
+++ b/stories/DesignSystem/molecules/StickyNavPanel.stories.tsx
@@ -2,43 +2,51 @@
  * DesignSystem / Molecules / StickyNavPanel
  *
  * Sticky top-of-panel navigation bar for canvas / scroll-section pages.
- * Sections are buttons; clicking fires the onSectionClick callback.
+ * Each item is an INavActivation; clicking dispatches through executeNavAction.
  */
 
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { StickyNavPanel } from '@/panels/page-shells/StickyNavPanel';
+import type { INavActivation, NavActionDeps } from '@/nav/navTypes';
 
-const SECTIONS_SHORT = [
-  { id: 'intro', label: 'Intro' },
-  { id: 'workouts', label: 'Workouts' },
-  { id: 'schedule', label: 'Schedule' },
-  { id: 'results', label: 'Results' },
+const SECTIONS_SHORT: INavActivation[] = [
+  { id: 'intro',    label: 'Intro',    action: { type: 'scroll', sectionId: 'intro' } },
+  { id: 'workouts', label: 'Workouts', action: { type: 'scroll', sectionId: 'workouts' } },
+  { id: 'schedule', label: 'Schedule', action: { type: 'scroll', sectionId: 'schedule' } },
+  { id: 'results',  label: 'Results',  action: { type: 'scroll', sectionId: 'results' } },
 ];
 
-const SECTIONS_LONG = [
-  { id: 's1', label: 'Overview' },
-  { id: 's2', label: 'Warm-up' },
-  { id: 's3', label: 'Strength' },
-  { id: 's4', label: 'Conditioning' },
-  { id: 's5', label: 'Accessory' },
-  { id: 's6', label: 'Cool-down' },
-  { id: 's7', label: 'Recovery' },
-  { id: 's8', label: 'Notes' },
+const SECTIONS_LONG: INavActivation[] = [
+  { id: 's1', label: 'Overview',     action: { type: 'scroll', sectionId: 's1' } },
+  { id: 's2', label: 'Warm-up',      action: { type: 'scroll', sectionId: 's2' } },
+  { id: 's3', label: 'Strength',     action: { type: 'scroll', sectionId: 's3' } },
+  { id: 's4', label: 'Conditioning', action: { type: 'scroll', sectionId: 's4' } },
+  { id: 's5', label: 'Accessory',    action: { type: 'scroll', sectionId: 's5' } },
+  { id: 's6', label: 'Cool-down',    action: { type: 'scroll', sectionId: 's6' } },
+  { id: 's7', label: 'Recovery',     action: { type: 'scroll', sectionId: 's7' } },
+  { id: 's8', label: 'Notes',        action: { type: 'scroll', sectionId: 's8' } },
 ];
 
 const Controlled: React.FC<{
-  sections: typeof SECTIONS_SHORT;
+  activations: INavActivation[];
   initialActive: string;
   variant: 'hero-follow' | 'top-fixed';
-}> = ({ sections, initialActive, variant }) => {
+}> = ({ activations, initialActive, variant }) => {
   const [active, setActive] = useState(initialActive);
+
+  const deps: NavActionDeps = {
+    navigate: () => {},
+    setQueryParam: () => {},
+    scrollToSection: (id) => setActive(id),
+  };
+
   return (
     <StickyNavPanel
-      sections={sections}
+      activations={activations}
       activeSection={active}
       variant={variant}
-      onSectionClick={setActive}
+      deps={deps}
     />
   );
 };
@@ -61,20 +69,20 @@ type Story = StoryObj<typeof meta>;
 export const HeroFollow: Story = {
   name: 'hero-follow — 4 sections, first active',
   render: () => (
-    <Controlled sections={SECTIONS_SHORT} initialActive="intro" variant="hero-follow" />
+    <Controlled activations={SECTIONS_SHORT} initialActive="intro" variant="hero-follow" />
   ),
 };
 
 export const TopFixed: Story = {
   name: 'top-fixed — 4 sections, second active',
   render: () => (
-    <Controlled sections={SECTIONS_SHORT} initialActive="workouts" variant="top-fixed" />
+    <Controlled activations={SECTIONS_SHORT} initialActive="workouts" variant="top-fixed" />
   ),
 };
 
 export const ManySections: Story = {
   name: 'Many sections (overflow behaviour)',
   render: () => (
-    <Controlled sections={SECTIONS_LONG} initialActive="s3" variant="hero-follow" />
+    <Controlled activations={SECTIONS_LONG} initialActive="s3" variant="hero-follow" />
   ),
 };


### PR DESCRIPTION
This pull request introduces comprehensive end-to-end (E2E) tests for the journal entry feature, refactors the new journal entry button to use a new `WorkoutActionButton` component, and makes several improvements and cleanups in the `App.tsx` file. The E2E tests validate key journal behaviors, while the UI changes simplify and modernize the new entry creation flow. Additional codebase improvements include a new debug mode toggle and minor navigation and action handler adjustments.

**Key changes:**

### End-to-End Testing

- Added a complete E2E test suite (`journal-entry.e2e.ts`) using Playwright to validate the `/journal/:date` route, covering template loading, content saving (with and without debounce), persistence across reloads, and UI correctness. A supporting page object (`JournalEntryPage.ts`) was also introduced for robust test interactions. [[1]](diffhunk://#diff-90afd2b19794441560da311b4796b73285a623061f1c971d782ad515751a67a2R1-R152) [[2]](diffhunk://#diff-4572f53b9cc1bb4cfcc2bec4014ac4d6fb69a6eb03719cef4c398398f86195deR1-R110)

### Journal Entry Creation Refactor

- Replaced the old split-button logic for creating new journal entries with the new `WorkoutActionButton` component, streamlining the UI and removing manual conflict handling code from `App.tsx`. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L98-R121) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L18-R19)

### Navigation and Action Handler Improvements

- Updated imports and usage to support a dynamically built navigation tree (`buildAppNavTree`), and removed unused imports for cleaner code. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L18-R19) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L53-R54)
- Standardized the shape of `secondaryAction` for navigation items to always include an `id`, `label`, and explicit `action` object, improving consistency for editor, note, and journal pages. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L286-R205) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L588-R517) [[3]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L828-R757)

### Debug Mode Toggle

- Added a toggle for debug mode in the actions menu, persisting its state in `localStorage` and displaying a checkmark when enabled. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R355-R363) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L480-R411)

### Minor Cleanups

- Removed the `/search` route from the named routes map and made minor import and type improvements for clarity and maintainability. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L952) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R2) [[3]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L70-R72) [[4]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L893-R822)

(References: [[1]](diffhunk://#diff-90afd2b19794441560da311b4796b73285a623061f1c971d782ad515751a67a2R1-R152) [[2]](diffhunk://#diff-4572f53b9cc1bb4cfcc2bec4014ac4d6fb69a6eb03719cef4c398398f86195deR1-R110) [[3]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L98-R121) [[4]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L18-R19) [[5]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L286-R205) [[6]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L588-R517) [[7]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L828-R757) [[8]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R355-R363) [[9]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L480-R411) [[10]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L952) [[11]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R2) [[12]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L70-R72) [[13]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L893-R822)