### PR TITLE
feat: add Google Analytics tracking script to index.html

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -8,6 +8,15 @@
   <link rel="icon" type="image/png" href="/images/wod-wiki-logo-light.png" />
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.css">
+  <!-- Google tag (gtag.js) -->
+  <!-- Dev placeholder G-PROD-ID is replaced during production build -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-PROD-ID"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-PROD-ID');
+  </script>
 </head>
 
 <body class="min-h-svh w-full bg-white dark:bg-zinc-900">


### PR DESCRIPTION
This pull request adds Google Analytics tracking to the `playground/index.html` file by including the necessary script tags and initialization code. The placeholder tracking ID `G-PROD-ID` is used for development and will be replaced during the production build.

Analytics integration:

* Added Google Analytics (`gtag.js`) script and initialization code to `playground/index.html`, using a placeholder tracking ID for development purposes.