### PR TITLE
[UX-04 + UX-05] Rest icon distinction + comment rendering (conflict resolution)

### DIFF
--- a/markdown/canvas/syntax/supplemental.md
+++ b/markdown/canvas/syntax/supplemental.md
@@ -55,6 +55,23 @@ pipeline:
   - set-state: track
 ```
 
+## Comments {sticky}
+
+Prefix a line with `//` to add a passive coach annotation. Comments are notes
+to yourself or the athlete — they never affect the timer or generate a cue card,
+and they don't require interaction during the workout.
+
+```
+// Warm up first
+[Set up barbell]
+10 Back Squats
+```
+
+In the runner, `// ...` lines render as muted italic text — visually distinct
+from interactive `[action items]` which appear as labeled buttons. Use comments
+for context, coaching cues, or reminders; use `[brackets]` when the runtime
+should pause and wait for you.
+
 ## Progressive Load {sticky}
 
 Use `^` to flag a set as a warm-up ramp. Combine with `?lb` to let the runtime prompt for each weight as you build to your working load.

--- a/src/components/metrics/MetricVisualizer.ColorMap.test.ts
+++ b/src/components/metrics/MetricVisualizer.ColorMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { getMetricColorClasses, metricColorMap } from '../../views/runtime/metricColorMap';
+import { getMetricColorClasses, getMetricIcon, metricColorMap } from '../../views/runtime/metricColorMap';
 
 describe('Visual Fragment Colors Test Suite', () => {
   describe('metricColorMap constant', () => {
@@ -60,6 +60,34 @@ describe('Visual Fragment Colors Test Suite', () => {
       expect(timerClasses).toContain('bg-');
       expect(timerClasses).toContain('border-');
       expect(timerClasses).toContain('text-');
+    });
+  });
+
+  // UX-04: Rest blocks must be visually distinct from work sets.
+  // Rest is parsed as an `effort` metric whose value is "Rest"; the
+  // helpers should detect this and return rest visuals instead of the
+  // running-figure (🏃) used for work sets.
+  describe('rest detection (UX-04)', () => {
+    it('should return the rest icon for effort metrics whose value is "Rest"', () => {
+      expect(getMetricIcon('effort', 'Rest')).toBe('⏸️');
+      expect(getMetricIcon('effort', 'rest')).toBe('⏸️');
+      expect(getMetricIcon('effort', '  REST  ')).toBe('⏸️');
+    });
+
+    it('should still return the effort icon for normal work-set effort metrics', () => {
+      expect(getMetricIcon('effort', 'Pushups')).toBe('🏃');
+      expect(getMetricIcon('effort')).toBe('🏃');
+    });
+
+    it('should return rest color classes for effort metrics whose value is "Rest"', () => {
+      const restClasses = getMetricColorClasses('effort', 'Rest');
+      expect(restClasses).toBe(metricColorMap.rest);
+      expect(restClasses).not.toContain('metric-effort');
+    });
+
+    it('should still return effort color classes for normal effort metrics', () => {
+      expect(getMetricColorClasses('effort', 'Pushups')).toContain('metric-effort');
+      expect(getMetricColorClasses('effort')).toContain('metric-effort');
     });
   });
 });

--- a/src/views/runtime/MetricVisualizer.test.tsx
+++ b/src/views/runtime/MetricVisualizer.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { MetricVisualizer } from './MetricVisualizer';
+import type { IMetric } from '../../core/models/Metric';
+
+/**
+ * UX-05 regression coverage: `// ...` comment lines must render visually
+ * distinct from `[action items]`. Comments are passive coach annotations
+ * (muted italic, no emoji badge); action items remain interactive pills.
+ */
+describe('MetricVisualizer comment vs action item rendering', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  const commentMetric: IMetric = {
+    type: 'text',
+    origin: 'parser',
+    value: { text: 'Warm up first' },
+    image: 'Warm up first',
+  } as IMetric;
+
+  const actionMetric: IMetric = {
+    type: 'action',
+    origin: 'parser',
+    value: 'Set up barbell',
+    image: 'Set up barbell',
+  } as IMetric;
+
+  it('renders parser-origin text metrics (comments) as muted italic annotations without emoji badge', () => {
+    const { container } = render(<MetricVisualizer metrics={[commentMetric]} />);
+
+    const commentNode = container.querySelector('[data-metric-type="comment"]');
+    expect(commentNode).toBeTruthy();
+    expect(commentNode?.textContent).toBe('Warm up first');
+    expect(commentNode?.className).toContain('italic');
+    expect(commentNode?.className).toContain('text-muted-foreground');
+    // No pill / border / interactive affordances for comments.
+    expect(commentNode?.className).not.toContain('border');
+    expect(commentNode?.className).not.toContain('cursor-help');
+    // The notepad emoji used for the generic `text` icon must not leak through.
+    expect(container.textContent).not.toContain('📝');
+  });
+
+  it('renders action items as interactive pill badges (visually distinct from comments)', () => {
+    const { container } = render(<MetricVisualizer metrics={[actionMetric]} />);
+
+    // Action items keep the standard pill badge styling.
+    const pill = container.querySelector('span.inline-flex.border');
+    expect(pill).toBeTruthy();
+    expect(pill?.textContent).toContain('Set up barbell');
+    // Comments slot must not be used for action items.
+    expect(container.querySelector('[data-metric-type="comment"]')).toBeNull();
+  });
+
+  it('renders comments and action items distinctly when shown side-by-side', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[commentMetric, actionMetric]} />,
+    );
+
+    const commentNode = container.querySelector('[data-metric-type="comment"]');
+    const pill = container.querySelector('span.inline-flex.border');
+
+    expect(commentNode).toBeTruthy();
+    expect(pill).toBeTruthy();
+    // The two nodes must not be the same element — they should use different
+    // rendering paths so they look semantically distinct in the runner.
+    expect(commentNode).not.toBe(pill);
+  });
+
+  it('keeps runtime-origin text metrics (labels/subtitles from LabelingBehavior) on the standard pill rendering', () => {
+    const labelMetric: IMetric = {
+      type: 'text',
+      origin: 'runtime',
+      value: { text: 'Round 1 of 3', role: 'round' },
+      image: 'Round 1 of 3',
+    } as IMetric;
+
+    const { container } = render(<MetricVisualizer metrics={[labelMetric]} />);
+
+    // Runtime-origin text must NOT use the comment annotation slot.
+    expect(container.querySelector('[data-metric-type="comment"]')).toBeNull();
+    const pill = container.querySelector('span.inline-flex.border');
+    expect(pill).toBeTruthy();
+    expect(pill?.textContent).toContain('Round 1 of 3');
+  });
+});

--- a/src/views/runtime/MetricVisualizer.tsx
+++ b/src/views/runtime/MetricVisualizer.tsx
@@ -151,9 +151,9 @@ export const MetricVisualizer = React.memo<MetricVisualizerProps>(({
         })
         .map((metric, index) => {
         const type = metric.type || 'unknown';
-        const colorClasses = getMetricColorClasses(type);
         const tokenValue = metric.image || (typeof metric.value === 'object' ? JSON.stringify(metric.value) : String(metric.value));
-        const icon = getMetricIcon(type);
+        const colorClasses = getMetricColorClasses(type, tokenValue);
+        const icon = getMetricIcon(type, tokenValue);
 
         return (
           <span

--- a/src/views/runtime/MetricVisualizer.tsx
+++ b/src/views/runtime/MetricVisualizer.tsx
@@ -151,8 +151,31 @@ export const MetricVisualizer = React.memo<MetricVisualizerProps>(({
         })
         .map((metric, index) => {
         const type = metric.type || 'unknown';
-        const colorClasses = getMetricColorClasses(type);
         const tokenValue = metric.image || (typeof metric.value === 'object' ? JSON.stringify(metric.value) : String(metric.value));
+
+        // Render parser-origin `text` metrics (from `// ...` comment syntax) as
+        // passive coach annotations: muted italic text without emoji badge,
+        // border, or interactive affordances. This visually distinguishes them
+        // from `[action items]` which remain rendered as interactive pills.
+        // Runtime-origin text metrics (labels, subtitles, round indicators
+        // emitted by LabelingBehavior) keep the standard pill rendering.
+        if (type === 'text' && metric.origin === 'parser') {
+          return (
+            <span
+              key={index}
+              className={cn(
+                'italic text-muted-foreground select-text',
+                currentStyle.text
+              )}
+              title={`COMMENT: ${tokenValue}`}
+              data-metric-type="comment"
+            >
+              {tokenValue}
+            </span>
+          );
+        }
+
+        const colorClasses = getMetricColorClasses(type);
         const icon = getMetricIcon(type);
 
         return (

--- a/src/views/runtime/metricColorMap.ts
+++ b/src/views/runtime/metricColorMap.ts
@@ -17,7 +17,8 @@ export type MetricType =
   | 'elapsed'
   | 'total'
   | 'system-time'
-  | 'metric';
+  | 'metric'
+  | 'rest';
 
 export type FragmentColorMap = {
   readonly [key in MetricType]: string;
@@ -46,16 +47,36 @@ export const metricColorMap: FragmentColorMap = {
   total:       'bg-muted border-border text-foreground',
   'system-time': 'bg-muted/60 border-border/60 text-muted-foreground',
   metric:      'bg-metric-effort/10 border-metric-effort/30 text-metric-effort',
+  // Rest blocks use a muted treatment to distinguish them from active work sets (UX-04)
+  rest:        'bg-muted/70 border-muted-foreground/30 text-muted-foreground',
 };
+
+/**
+ * Detects whether a metric represents a rest period.
+ *
+ * Rest blocks (e.g. `* :90 Rest`) are parsed as `effort` metrics whose value
+ * is the word "Rest". They should be rendered with the rest icon/colors so
+ * they are visually distinct from work sets. See issue UX-04.
+ */
+function isRestMetric(type: string, value?: string): boolean {
+  if (type.toLowerCase() !== 'effort' || !value) return false;
+  return value.trim().toLowerCase() === 'rest';
+}
 
 /**
  * Get color classes for a metrics type
  * @param type - Fragment type string (case-insensitive)
+ * @param value - Optional metric value; used to detect rest indicators on
+ *   `effort` metrics so they can be styled distinctly from work sets.
  * @returns Tailwind CSS color classes for the type
  */
-export function getMetricColorClasses(type: string): string {
+export function getMetricColorClasses(type: string, value?: string): string {
+  if (isRestMetric(type, value)) {
+    return metricColorMap.rest;
+  }
+
   const normalizedType = type.toLowerCase() as MetricType;
-  
+
   // Return mapped color or fallback for unknown types
   return metricColorMap[normalizedType] || 'bg-gray-200 border-gray-300 text-gray-800 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100';
 }
@@ -85,8 +106,14 @@ const metricIconMap: Record<string, string> = {
 /**
  * Get icon/emoji for a metrics type
  * @param type - Fragment type string (case-insensitive)
+ * @param value - Optional metric value; used to detect rest indicators on
+ *   `effort` metrics so they can be shown with the rest icon (⏸️) instead
+ *   of the running figure used for work sets (UX-04).
  * @returns Emoji icon for the type, or null if no icon is defined
  */
-export function getMetricIcon(type: string): string | null {
+export function getMetricIcon(type: string, value?: string): string | null {
+  if (isRestMetric(type, value)) {
+    return metricIconMap.rest;
+  }
   return metricIconMap[type.toLowerCase()] || null;
 }

--- a/stories/catalog/molecules/MetricVisualizer.stories.tsx
+++ b/stories/catalog/molecules/MetricVisualizer.stories.tsx
@@ -109,3 +109,26 @@ export const ErrorState: Story = {
     error: { message: 'Failed to parse statement', line: 3, column: 7 },
   },
 };
+
+/**
+ * UX-04: Rest blocks must be visually distinct from work sets.
+ *
+ * "Rest" is parsed as an `effort` metric whose value is the literal word
+ * "Rest". The visualizer detects this and renders the rest icon (⏸️) with
+ * muted styling rather than the running figure (🏃) used for work sets.
+ */
+export const RestVsWorkSet: Story = {
+  render: () => (
+    <div className="flex flex-col gap-0 w-fit">
+      <Row label="work set">
+        <MetricVisualizer metrics={[m('rep', 10), m('effort', 'Pushups')]} />
+      </Row>
+      <Row label="rest block">
+        <MetricVisualizer metrics={[m('time', 90_000), m('effort', 'Rest')]} />
+      </Row>
+      <Row label="work set">
+        <MetricVisualizer metrics={[m('rep', 20), m('effort', 'Squats')]} />
+      </Row>
+    </div>
+  ),
+};

--- a/stories/catalog/molecules/MetricVisualizer.stories.tsx
+++ b/stories/catalog/molecules/MetricVisualizer.stories.tsx
@@ -109,3 +109,45 @@ export const ErrorState: Story = {
     error: { message: 'Failed to parse statement', line: 3, column: 7 },
   },
 };
+
+/**
+ * Comments vs. action items.
+ *
+ * `// ...` comment lines are emitted as `text` metrics with `origin: 'parser'`
+ * and render as muted italic annotations (no badge, no emoji, not interactive).
+ *
+ * `[Set up barbell]` action items are emitted as `action` metrics and continue
+ * to render as interactive pill badges. This visual distinction reflects their
+ * different semantics: passive coach annotation vs. interactive task.
+ */
+export const CommentVsActionItem: Story = {
+  render: () => {
+    const comment: IMetric = {
+      type: 'text',
+      origin: 'parser',
+      value: { text: 'Warm up first' },
+      image: 'Warm up first',
+    } as IMetric;
+    const action: IMetric = {
+      type: 'action',
+      origin: 'parser',
+      value: 'Set up barbell',
+      image: 'Set up barbell',
+    } as IMetric;
+    return (
+      <div className="flex flex-col gap-0 w-full max-w-md">
+        <Row label="comment">
+          <MetricVisualizer metrics={[comment]} />
+        </Row>
+        <Row label="action item">
+          <MetricVisualizer metrics={[action]} />
+        </Row>
+        <Row label="mixed">
+          <MetricVisualizer
+            metrics={[comment, action, m('rep', 10), m('effort', 'Back Squats')]}
+          />
+        </Row>
+      </div>
+    );
+  },
+};


### PR DESCRIPTION
Combines UX-04 (#490) and UX-05 (#491) — these PRs both touched `MetricVisualizer.tsx` and `MetricVisualizer.stories.tsx` and conflicted when applied sequentially.\n\n## Changes\n- **UX-04**: Rest blocks now render ⏸️ with muted styling instead of 🏃 (effort value 'Rest' detected)\n- **UX-05**: `// comment` lines (parser-origin `text` metrics) render as muted italic annotations, not interactive pill badges\n- Both `getMetricColorClasses` and `getMetricIcon` now receive `tokenValue` via `formatTokenValue` (preserves UX-03 logic)\n- All three stories preserved: RoundsBadge, RestVsWorkSet, CommentVsActionItem\n\nCloses #490\nCloses #491