### PR TITLE
Add sync script for Storybook MDX to Obsidian vault

### DIFF
--- a/e2e/acceptance/comment-vs-action-item.e2e.ts
+++ b/e2e/acceptance/comment-vs-action-item.e2e.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * UX-05 acceptance: `// ...` comments must render visually distinct from
+ * `[action items]` in the runner. Comments are passive coach annotations
+ * (muted italic, no badge); action items remain interactive pill badges.
+ *
+ * Drives the `CommentVsActionItem` story in the Storybook MetricVisualizer
+ * catalog so the distinction is asserted in a real browser.
+ */
+
+const STORY_IFRAME_URL =
+  '/iframe.html?id=catalog-molecules-metrics-metricvisualizer--comment-vs-action-item&viewMode=story';
+const STORY_LOAD_TIMEOUT_MS = 20000;
+
+test.describe('UX-05: comment vs action item rendering', () => {
+  test('comments render as muted italic annotations, action items render as pill badges', async ({
+    page,
+  }) => {
+    await page.goto(STORY_IFRAME_URL, {
+      waitUntil: 'networkidle',
+      timeout: STORY_LOAD_TIMEOUT_MS,
+    });
+
+    // ── Comment node ─────────────────────────────────────────────────────
+    const commentNodes = page.locator('[data-metric-type="comment"]');
+    // The story renders the comment in three rows (comment / mixed contains
+    // it once more); at minimum the dedicated row must exist.
+    await expect(commentNodes.first()).toBeVisible();
+    await expect(commentNodes.first()).toHaveText('Warm up first');
+
+    // Comments must be styled as muted italic text — no emoji badge,
+    // no border, no interactive `cursor-help` affordance.
+    await expect(commentNodes.first()).toHaveClass(/italic/);
+    await expect(commentNodes.first()).toHaveClass(/text-muted-foreground/);
+    await expect(commentNodes.first()).not.toHaveClass(/border/);
+    await expect(commentNodes.first()).not.toHaveClass(/cursor-help/);
+
+    // The notepad emoji used for the generic `text` icon must not leak
+    // into the comment slot (UX-05 root cause).
+    const commentText = await commentNodes.first().textContent();
+    expect(commentText ?? '').not.toContain('📝');
+
+    // ── Action item node ─────────────────────────────────────────────────
+    // Action items keep the standard interactive pill badge: inline-flex
+    // with a border and the cursor-help affordance.
+    const actionPill = page
+      .locator('span.inline-flex.border', { hasText: 'Set up barbell' })
+      .first();
+    await expect(actionPill).toBeVisible();
+    await expect(actionPill).toHaveClass(/cursor-help/);
+
+    // The action pill is *not* the comment node — they use distinct
+    // rendering paths.
+    await expect(actionPill).not.toHaveAttribute('data-metric-type', 'comment');
+  });
+});

--- a/e2e/acceptance/crossfit-benchmarks.e2e.ts
+++ b/e2e/acceptance/crossfit-benchmarks.e2e.ts
@@ -21,11 +21,16 @@ function storyUrl(storyId: string): string {
   return `/iframe.html?id=${storyId}&viewMode=story`;
 }
 
+// Story IDs are derived from the story file's `meta.title`
+// ('acceptance/RuntimeCrossFit') by Storybook's CSF `sanitize`, which
+// lowercases and replaces separators but does NOT split camelCase tokens.
+// Therefore `RuntimeCrossFit` becomes `runtimecrossfit` (no hyphen between
+// `runtime` and `crossfit`).
 const STORIES = {
-  fran: 'acceptance-runtime-crossfit--fran',
-  annie: 'acceptance-runtime-crossfit--annie',
-  cindy: 'acceptance-runtime-crossfit--cindy',
-  barbara: 'acceptance-runtime-crossfit--barbara',
+  fran: 'acceptance-runtimecrossfit--fran',
+  annie: 'acceptance-runtimecrossfit--annie',
+  cindy: 'acceptance-runtimecrossfit--cindy',
+  barbara: 'acceptance-runtimecrossfit--barbara',
 };
 
 // ─ Shared setup ───────────────────────────────────────────────────────────────

--- a/e2e/acceptance/fullscreen-timer-close.e2e.ts
+++ b/e2e/acceptance/fullscreen-timer-close.e2e.ts
@@ -1,0 +1,44 @@
+/**
+ * UX-01 — Close button dismisses the runner from the Ready-to-Start state.
+ *
+ * Issue: The Close (X) button in the FullscreenTimer overlay was perceived
+ * as non-functional in the Ready-to-Start state because `handleClose`
+ * deferred `onClose` by 100ms for hypothetical animations. This test
+ * exercises the Storybook FullscreenTimer harness (autoStart=false → Ready
+ * state) and asserts that clicking the Close button dismisses the overlay
+ * promptly.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?id=catalog-organisms-fullscreentimer--simple-timer&viewMode=story';
+const STORY_LOAD_TIMEOUT_MS = 20000;
+
+test.describe('FullscreenTimer — Close button (Ready to Start)', () => {
+  test('dismisses the runner overlay when Close is clicked in the Ready state', async ({ page }) => {
+    await page.goto(STORY_URL, { waitUntil: 'networkidle', timeout: STORY_LOAD_TIMEOUT_MS });
+
+    // Launch the FullscreenTimer overlay from the harness.
+    const launchButton = page.getByRole('button', { name: /^Open\b/i });
+    await expect(launchButton).toBeVisible();
+    await launchButton.click();
+
+    // Overlay should be visible with the Ready-to-Start label.
+    await expect(page.getByText('Ready to Start')).toBeVisible();
+
+    // The Close (X) button is the floating button at the top-right of the
+    // FocusedDialog. Identify it by its `title="Close"` attribute.
+    const closeButton = page.locator('button[title="Close"]').first();
+    await expect(closeButton).toBeVisible();
+
+    await closeButton.click();
+
+    // The overlay should be dismissed promptly (within a single React tick).
+    // A previous bug made the dismiss feel unresponsive by deferring the
+    // close via a 100ms setTimeout. Use a short timeout to guard against
+    // reintroduction of any long synthetic delay between click and unmount.
+    await expect(page.getByText('Ready to Start')).toBeHidden({ timeout: 250 });
+    await expect(launchButton).toBeVisible();
+  });
+});

--- a/e2e/acceptance/home-feature-card-markdown.e2e.ts
+++ b/e2e/acceptance/home-feature-card-markdown.e2e.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+const HOME_VIEW_STORY_URL = '/iframe.html?id=catalog-pages-homeview--default&viewMode=story';
+
+test.describe('Home page feature cards', () => {
+  test('renders analytics feature markdown as formatted list content', async ({ page }) => {
+    await page.goto(HOME_VIEW_STORY_URL, { waitUntil: 'networkidle', timeout: 20000 });
+
+    const analyticsSection = page.locator('#pre-post-analytics');
+
+    await analyticsSection.scrollIntoViewIfNeeded();
+    await expect(page.getByRole('heading', { name: /pre\s*&\s*post analytics/i })).toBeVisible();
+
+    const listItems = analyticsSection.getByRole('listitem');
+    await expect(listItems).toHaveCount(2);
+    await expect(listItems.nth(0).locator('strong')).toHaveText('Pre-run');
+    await expect(listItems.nth(1).locator('strong')).toHaveText('Post-run');
+
+    await expect(analyticsSection).not.toContainText('**Pre-run**');
+    await expect(analyticsSection).not.toContainText('- **Post-run**');
+  });
+});

--- a/e2e/acceptance/home-feature-card-markdown.e2e.ts
+++ b/e2e/acceptance/home-feature-card-markdown.e2e.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-const HOME_VIEW_STORY_URL = '/iframe.html?id=catalog-pages-homeview--default&viewMode=story';
+const HOMEVIEW_STORY_IFRAME_URL = '/iframe.html?id=catalog-pages-homeview--default&viewMode=story';
+const STORY_LOAD_TIMEOUT_MS = 20000;
 
 test.describe('Home page feature cards', () => {
   test('renders analytics feature markdown as formatted list content', async ({ page }) => {
-    await page.goto(HOME_VIEW_STORY_URL, { waitUntil: 'networkidle', timeout: 20000 });
+    await page.goto(HOMEVIEW_STORY_IFRAME_URL, { waitUntil: 'networkidle', timeout: STORY_LOAD_TIMEOUT_MS });
 
     const analyticsSection = page.locator('#pre-post-analytics');
 

--- a/e2e/live-app/canvas-editor-frontmatter.e2e.ts
+++ b/e2e/live-app/canvas-editor-frontmatter.e2e.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Canvas editor source content', () => {
+  test('does not show YAML frontmatter on syntax pages', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    await page.goto('/syntax/basics', { waitUntil: 'domcontentloaded', timeout: 20_000 });
+
+    const editors = page.locator('.cm-content[contenteditable="true"]');
+    await expect(editors.first()).toBeAttached({ timeout: 15_000 });
+
+    await expect
+      .poll(async () => (await editors.allInnerTexts()).join('\n'), { timeout: 15_000 })
+      .toContain('Pushups');
+    const allEditorText = await editors.allInnerTexts();
+    const joinedEditorText = allEditorText.join('\n');
+    expect(joinedEditorText.trimStart().startsWith('---')).toBe(false);
+    expect(joinedEditorText).not.toContain('search: hidden');
+    expect(joinedEditorText).not.toContain('title: Just a Movement');
+
+    expect(errors).toHaveLength(0);
+    await page.screenshot({ path: 'e2e/screenshots/canvas-editor-frontmatter.png', fullPage: true });
+  });
+});

--- a/markdown/canvas/syntax/supplemental.md
+++ b/markdown/canvas/syntax/supplemental.md
@@ -55,6 +55,23 @@ pipeline:
   - set-state: track
 ```
 
+## Comments {sticky}
+
+Prefix a line with `//` to add a passive coach annotation. Comments are notes
+to yourself or the athlete — they never affect the timer or generate a cue card,
+and they don't require interaction during the workout.
+
+```
+// Warm up first
+[Set up barbell]
+10 Back Squats
+```
+
+In the runner, `// ...` lines render as muted italic text — visually distinct
+from interactive `[action items]` which appear as labeled buttons. Use comments
+for context, coaching cues, or reminders; use `[brackets]` when the runtime
+should pause and wait for you.
+
 ## Progressive Load {sticky}
 
 Use `^` to flag a set as a warm-up ramp. Combine with `?lb` to let the runtime prompt for each weight as you build to your working load.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "build-storybook": "NODE_OPTIONS=--max-old-space-size=4096 storybook build",
     "postbuild-storybook": "bun x vite build --config vite.receiver.config.ts",
     "docs:check": "bun scripts/check-docs-links.cjs",
+    "docs:sync-vault": "node scripts/sync-storybook-to-vault.mjs --write",
+    "docs:sync-vault:check": "node scripts/sync-storybook-to-vault.mjs",
     "dev": "bun scripts/dev-start.cjs",
     "dev:web": "bun scripts/dev-start.cjs --web-only --no-emulator",
     "dev:all": "bun scripts/dev-start.cjs",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -45,6 +45,7 @@ import { Toaster } from '@/components/ui/toaster'
 // ── Shared page utilities ────────────────────────────────────────────────────
 import { NewEntryButton, ThemeSwitcher, ActionsMenu } from './pages/shared/PageToolbar'
 import { mapIndexToL3, applyTemplate } from './pages/shared/pageUtils'
+import { formatPlaygroundTimestampId } from '@/lib/playgroundDisplay'
 
 // ── Constants for Sidebar Navigation ────────────────────────────────
 
@@ -84,16 +85,19 @@ export interface WorkoutItem {
 }
 
 
-/** Generate a date-based name: YYYY-MM-DD HH-MM, with -SS.mmm if collision */
+const MAX_TIMESTAMP_ID_RETRIES = 10
+
+/** Generate a date-based name: YYYY-MM-DD-HH-MM-SS-MMM. */
 async function generatePlaygroundName(): Promise<string> {
-  const now = new Date()
-  const pad = (n: number) => String(n).padStart(2, '0')
-  const base = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}-${pad(now.getMinutes())}`
-  const basePageId = PlaygroundDBService.pageId('playground', base)
-  const existing = await playgroundDB.getPage(basePageId)
-  if (!existing) return base
-  const precise = `${base}-${pad(now.getSeconds())}.${String(now.getMilliseconds()).padStart(3, '0')}`
-  return precise
+  let name = formatPlaygroundTimestampId(Date.now())
+  let existing = await playgroundDB.getPage(PlaygroundDBService.pageId('playground', name))
+  for (let attempt = 0; existing && attempt < MAX_TIMESTAMP_ID_RETRIES; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 1))
+    name = formatPlaygroundTimestampId(Date.now())
+    existing = await playgroundDB.getPage(PlaygroundDBService.pageId('playground', name))
+  }
+  if (existing) throw new Error('Unable to allocate unique playground timestamp ID')
+  return name
 }
 
 function PlaygroundRedirect() {

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -744,11 +744,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
                           )
                         }
                         
-                        return viewDef
-                          ? <p className="text-sm lg:text-[15px] font-medium text-muted-foreground leading-relaxed mb-6">
-                              {section.prose}
-                            </p>
-                          : <CanvasProse prose={section.prose} className="mb-6" />
+                        return <CanvasProse prose={section.prose} className="mb-6" />
                       })()
                     )}
 

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -26,6 +26,7 @@ import type { WorkoutResults } from '@/components/Editor/types'
 import { MacOSChrome } from '../components/MacOSChrome'
 import { ButtonGroup } from '@/components/ui/ButtonGroup'
 import { cn } from '@/lib/utils'
+import { stripFrontmatter } from '@/utils/frontmatter'
 import { CanvasProse } from './CanvasProse'
 import { executeNavAction } from '../nav/navTypes'
 import type { INavActivation, NavActionDeps, INavAction } from '../nav/navTypes'
@@ -46,7 +47,7 @@ function resolveSource(dslPath: string, wodFiles: Record<string, string>): strin
   // Explicit markdown/canvas/ path
   if (dslPath.startsWith('markdown/')) {
     const key = '../../' + dslPath
-    if (wodFiles[key]) return wodFiles[key]
+    if (key in wodFiles) return stripFrontmatter(wodFiles[key])
   }
 
   // Legacy wods/ or collections/ prefixes
@@ -62,14 +63,14 @@ function resolveSource(dslPath: string, wodFiles: Record<string, string>): strin
   } else {
     // Check both canvas and collections as fallback
     const canvasKey = '../../markdown/canvas/' + dslPath
-    if (wodFiles[canvasKey]) return wodFiles[canvasKey]
+    if (canvasKey in wodFiles) return stripFrontmatter(wodFiles[canvasKey])
     
     const collectionsKey = '../../markdown/collections/' + dslPath
-    if (wodFiles[collectionsKey]) return wodFiles[collectionsKey]
+    if (collectionsKey in wodFiles) return stripFrontmatter(wodFiles[collectionsKey])
     
     key = '../../markdown/' + dslPath
   }
-  return wodFiles[key] ?? `# Source not found\n\nPath: \`${dslPath}\`\nResolved: \`${key}\``
+  return key in wodFiles ? stripFrontmatter(wodFiles[key]) : `# Source not found\n\nPath: \`${dslPath}\`\nResolved: \`${key}\``
 }
 
 // ── Section attribute helpers ─────────────────────────────────────────────────

--- a/playground/src/canvas/parseCanvasMarkdown.ts
+++ b/playground/src/canvas/parseCanvasMarkdown.ts
@@ -1,3 +1,5 @@
+import { parseFrontmatter } from '@/utils/frontmatter'
+
 /**
  * Canvas Markdown Parser
  *
@@ -72,20 +74,6 @@ function slugify(text: string): string {
     .replace(/[^\w\s-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/^-+|-+$/g, '')
-}
-
-function parseFrontmatter(raw: string): { meta: Record<string, string>; body: string } {
-  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/)
-  if (!match) return { meta: {}, body: raw }
-  const meta: Record<string, string> = {}
-  for (const line of match[1].split('\n')) {
-    const colonIdx = line.indexOf(':')
-    if (colonIdx === -1) continue
-    const key = line.slice(0, colonIdx).trim()
-    const val = line.slice(colonIdx + 1).trim()
-    if (key) meta[key] = val
-  }
-  return { meta, body: match[2] }
 }
 
 function parseHeadingLine(line: string): { level: number; text: string; attrs: string[] } | null {
@@ -245,9 +233,9 @@ function extractBlocks(text: string): {
 
 export function parseCanvasMarkdown(raw: string, defaultRoute: string = '/'): ParsedCanvasPage | null {
   const { meta, body } = parseFrontmatter(raw)
-  if (meta['template'] !== 'canvas') return null
+  if (String(meta['template'] ?? '') !== 'canvas') return null
 
-  const route = meta['route'] ?? defaultRoute
+  const route = String(meta['route'] ?? defaultRoute)
   const sections: CanvasSection[] = []
 
   type Acc = { heading: string; level: number; attrs: string[]; lines: string[] }

--- a/playground/src/hooks/useZipProcessor.ts
+++ b/playground/src/hooks/useZipProcessor.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryState } from 'nuqs';
-import { v4 as uuidv4 } from 'uuid';
 import { decodeZip } from '../services/decodeZip';
 import { playgroundDB, PlaygroundDBService } from '../services/playgroundDB';
+import { formatPlaygroundTimestampId } from '@/lib/playgroundDisplay';
 
 export function useZipProcessor() {
   const navigate = useNavigate();
@@ -19,8 +19,8 @@ export function useZipProcessor() {
       try {
         const content = await decodeZip(zip);
         if (cancelled) return;
-        const id = uuidv4();
         const now = Date.now();
+        const id = formatPlaygroundTimestampId(now);
         const pageId = PlaygroundDBService.pageId('playground', id);
         await playgroundDB.savePage({
           id: pageId,

--- a/playground/src/pages/PlaygroundNotePage.tsx
+++ b/playground/src/pages/PlaygroundNotePage.tsx
@@ -25,6 +25,7 @@ import { NewEntryButton, ThemeSwitcher, ActionsMenu } from './shared/PageToolbar
 import { extractPageIndex, mapIndexToL3 } from './shared/pageUtils'
 import newPlaygroundTemplate from '../templates/new-playground.md?raw'
 import { applyTemplate } from './shared/pageUtils'
+import { formatPlaygroundPageTitle } from '@/lib/playgroundDisplay'
 
 const PLAYGROUND_TEMPLATE = applyTemplate(newPlaygroundTemplate)
 
@@ -40,12 +41,14 @@ export function PlaygroundNotePage({
   onScrollToSection,
 }: PlaygroundNotePageProps) {
   const { id } = useParams<{ id: string }>()
-  // noteId is the full 'playground/uuid' so results can be grouped correctly in the journal
-  const noteId = PlaygroundDBService.pageId('playground', id!)
+  const pageName = id ?? 'playground'
+  // noteId is the full playground page identifier (for example, 'playground/<pageName>') so results can be grouped correctly in the journal
+  const noteId = PlaygroundDBService.pageId('playground', pageName)
+  const pageTitle = useMemo(() => (id ? formatPlaygroundPageTitle(id) : 'Playground'), [id])
   const navigate = useNavigate()
   const { content, loading, onChange } = usePlaygroundContent({
     category: 'playground',
-    name: id!,
+    name: pageName,
     mdContent: PLAYGROUND_TEMPLATE.content,
   })
 
@@ -104,6 +107,10 @@ export function PlaygroundNotePage({
     return () => setL3Items([])
   }, [index, setL3Items])
 
+  useEffect(() => {
+    document.title = `Wod.Wiki - ${pageTitle}`
+  }, [pageTitle])
+
   if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center text-zinc-400">
@@ -114,7 +121,7 @@ export function PlaygroundNotePage({
 
   return (
     <JournalPageShell
-      title={noteId}
+      title={pageTitle}
       index={index}
       onScrollToSection={onScrollToSection}
       actions={
@@ -123,7 +130,7 @@ export function PlaygroundNotePage({
           <CastButtonRpc />
           <AudioToggle />
           <ThemeSwitcher />
-          <ActionsMenu currentWorkout={{ name: noteId, content }} items={mapIndexToL3(index)} />
+          <ActionsMenu currentWorkout={{ name: pageTitle, content }} items={mapIndexToL3(index)} />
         </div>
       }
       editor={

--- a/scripts/sync-storybook-to-vault.mjs
+++ b/scripts/sync-storybook-to-vault.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/**
+ * sync-storybook-to-vault.mjs
+ *
+ * Strips Storybook boilerplate from stories/catalog/ and writes
+ * pure .md files into the Obsidian vault for design-system documentation.
+ *
+ * The Storybook MDX header (4 lines) is:
+ *   import { Meta } from '@storybook/addon-docs/blocks';
+ *   import * as stories from './Component.stories';
+ *   <blank>
+ *   <Meta of={stories} />
+ *
+ * Everything after that is pure markdown that Obsidian can render.
+ *
+ * Usage:
+ *   node scripts/sync-storybook-to-vault.mjs          # dry run (shows what would change)
+ *   node scripts/sync-storybook-to-vault.mjs --write   # actually writes files
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// ── Config ────────────────────────────────────────────────────────────────
+const VAULT_PATH = process.env.OBSIDIAN_VAULT_PATH
+  || path.join(process.env.HOME, 'Documents/captains-log/captains-log');
+
+const STORIES_DIR = path.resolve(process.cwd(), 'stories/catalog');
+const VAULT_TARGET = path.join(VAULT_PATH, 'projects', 'wod-wiki', 'docs', 'design-system');
+
+// Storybook boilerplate lines to strip (after removing, skip leading blanks)
+const BOILERPLATE_RE = /^import\s+\{[^}]+\}\s+from\s+'[^']+';\s*\n/m;
+const IMPORT_STORIES_RE = /^import\s+\*\s+as\s+stories\s+from\s+'[^']+';\s*\n/m;
+const META_TAG_RE = /^<Meta\s+[^/]*\/>\s*\n/m;
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function stripBoilerplate(content) {
+  let stripped = content;
+  stripped = stripped.replace(BOILERPLATE_RE, '');
+  stripped = stripped.replace(IMPORT_STORIES_RE, '');
+  stripped = stripped.replace(META_TAG_RE, '');
+  // Remove leading blank lines
+  stripped = stripped.replace(/^\n+/, '');
+  return stripped;
+}
+
+function getComponentName(filePath) {
+  // Extract the component name from the MDX filename
+  // e.g. MetricPill.mdx → MetricPill, Web.mdx → Web
+  return path.basename(filePath, '.mdx');
+}
+
+function getVaultRelativePath(mdxPath, storiesDir) {
+  // Map stories/catalog/atoms/MetricPill.mdx → atoms/MetricPill.md
+  const rel = path.relative(storiesDir, mdxPath);
+  return rel.replace(/\.mdx$/, '.md');
+}
+
+function getAtomicTier(relPath) {
+  // Extract tier from path: atoms, molecules, organisms, templates, pages
+  const tier = relPath.split(path.sep)[0];
+  const validTiers = ['atoms', 'molecules', 'organisms', 'templates', 'pages'];
+  return validTiers.includes(tier) ? tier : null;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+function collectMdxFiles(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMdxFiles(full));
+    } else if (entry.name.endsWith('.mdx')) {
+      results.push(full);
+    }
+  }
+  return results.sort();
+}
+
+function main() {
+  const write = process.argv.includes('--write');
+
+  if (!fs.existsSync(STORIES_DIR)) {
+    console.error(`❌ Stories directory not found: ${STORIES_DIR}`);
+    process.exit(1);
+  }
+
+  const mdxFiles = collectMdxFiles(STORIES_DIR);
+
+  if (mdxFiles.length === 0) {
+    console.log('No MDX files found in', STORIES_DIR);
+    return;
+  }
+
+  console.log(`📂 Found ${mdxFiles.length} MDX files in ${STORIES_DIR}`);
+  console.log(`📁 Vault target:      ${VAULT_TARGET}`);
+  console.log(`📝 Mode:              ${write ? 'WRITE' : 'DRY RUN'}\n`);
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const mdxPath of mdxFiles) {
+    const relPath = getVaultRelativePath(mdxPath, STORIES_DIR);
+    const vaultPath = path.join(VAULT_TARGET, relPath);
+    const tier = getAtomicTier(relPath);
+    const componentName = getComponentName(mdxPath);
+
+    const raw = fs.readFileSync(mdxPath, 'utf-8');
+    const markdown = stripBoilerplate(raw);
+
+    // Add a frontmatter section with metadata for Obsidian
+    const frontmatter = [
+      '---',
+      `source: wod-wiki/storybook`,
+      `component: ${componentName}`,
+      ...(tier ? [`tier: ${tier}`] : []),
+      `storybook: ${path.relative(process.cwd(), mdxPath)}`,
+      '---',
+      '',
+    ].join('\n');
+
+    const output = frontmatter + markdown;
+
+    // Check if file exists and compare
+    if (fs.existsSync(vaultPath)) {
+      const existing = fs.readFileSync(vaultPath, 'utf-8');
+      if (existing === output) {
+        skipped++;
+        continue;
+      }
+      if (write) {
+        fs.writeFileSync(vaultPath, output, 'utf-8');
+        updated++;
+        console.log(`  ✏️  Updated: ${relPath}`);
+      } else {
+        updated++;
+        console.log(`  ✏️  Would update: ${relPath}`);
+      }
+    } else {
+      if (write) {
+        fs.mkdirSync(path.dirname(vaultPath), { recursive: true });
+        fs.writeFileSync(vaultPath, output, 'utf-8');
+        created++;
+        console.log(`  ✨ Created: ${relPath}`);
+      } else {
+        created++;
+        console.log(`  ✨ Would create: ${relPath}`);
+      }
+    }
+  }
+
+  console.log(`\n${'─'.repeat(50)}`);
+  console.log(`  Created: ${created}`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped: ${skipped} (unchanged)`);
+  console.log(`  Total:   ${mdxFiles.length}`);
+
+  if (!write) {
+    console.log(`\n💡 Run with --write to apply changes.`);
+  }
+}
+
+main();

--- a/src/components/Editor/overlays/FullscreenTimer.tsx
+++ b/src/components/Editor/overlays/FullscreenTimer.tsx
@@ -29,8 +29,14 @@ export const FullscreenTimer: React.FC<FullscreenTimerProps> = ({
   const [selectedSegmentIds, setSelectedSegmentIds] = useState<Set<number>>(new Set());
 
   const handleClose = () => {
-    // Brief delay for any closing animations if we add them later
-    setTimeout(onClose, 100);
+    // Dismiss immediately so the runner closes on the same tick the user
+    // clicks the Close (X) button. A previous implementation deferred this
+    // by 100ms for hypothetical closing animations, but no animations are
+    // wired and the delay made the click feel unresponsive — particularly
+    // in the Ready-to-Start state where the timer hasn't started yet, so
+    // the user sees no other state change to acknowledge their input.
+    // See issue UX-01.
+    onClose();
   };
 
   // Called by RuntimeTimerPanel when the workout finishes (either naturally or

--- a/src/components/layout/Workbench.tsx
+++ b/src/components/layout/Workbench.tsx
@@ -47,6 +47,7 @@ import { WorkbenchSyncBridge } from './WorkbenchSyncBridge';
 import { DisplaySyncBridge } from './DisplaySyncBridge';
 import { useWorkbenchSync } from './useWorkbenchSync';
 import { DebugButton, useDebugMode } from '@/components/layout/DebugModeContext';
+import { formatPlaygroundTimestampLabel } from '@/lib/playgroundDisplay';
 import { RuntimeFactory } from '../../runtime/compiler/RuntimeFactory';
 import { globalCompiler } from '../../runtime-test-bench/services/testbench-services';
 import { ContentProviderMode, IContentProvider } from '../../types/content-provider';
@@ -289,12 +290,14 @@ const WorkbenchContent: React.FC<WorkbenchProps> = ({
   useEffect(() => {
     if (currentEntry?.title) {
       document.title = `Wod.Wiki - ${currentEntry.title}`;
+    } else if (currentEntry?.type === 'playground') {
+      document.title = `Wod.Wiki - ${formatPlaygroundTimestampLabel(currentEntry.createdAt)}`;
     } else if (routeId) {
-      document.title = `Wod.Wiki - ${routeId}`;
+      document.title = 'Wod.Wiki - Untitled note';
     } else {
       document.title = 'Wod.Wiki';
     }
-  }, [currentEntry?.title, routeId]);
+  }, [currentEntry?.createdAt, currentEntry?.title, currentEntry?.type, routeId]);
 
   // Consume synced state from Zustand store (via WorkbenchSyncBridge)
   const {

--- a/src/components/list/CommandListView.tsx
+++ b/src/components/list/CommandListView.tsx
@@ -133,7 +133,18 @@ export function CommandListView<TPayload>({
         {/* Group headers */}
         {state.visibleItems.length === 0
           ? (emptyState ?? (
-              <div className="py-8 text-center text-sm text-zinc-400">No results</div>
+              query
+                ? (
+                    <div className="py-8 text-center text-sm text-zinc-400">
+                      No results found for{' '}
+                      <span className="font-medium text-zinc-600 dark:text-zinc-300">
+                        &ldquo;{query}&rdquo;
+                      </span>
+                    </div>
+                  )
+                : (
+                    <div className="py-8 text-center text-sm text-zinc-400">No results</div>
+                  )
             ))
           : Array.from(state.groups.entries()).map(([group, groupItems]) => (
               <div key={group} className="mb-1">

--- a/src/components/list/adapters/historyAdapter.test.ts
+++ b/src/components/list/adapters/historyAdapter.test.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+import { describe, expect, it } from 'bun:test';
+import {
+  BeakerIcon,
+  BookOpenIcon,
+  DocumentDuplicateIcon,
+} from '@heroicons/react/24/outline';
+import { historyEntryToListItem } from './historyAdapter';
+import type { HistoryEntry } from '@/types/history';
+
+const baseEntry: HistoryEntry = {
+  id: 'entry-1',
+  title: '',
+  createdAt: new Date('2026-04-27T14:30:22.481Z').getTime(),
+  updatedAt: new Date('2026-04-27T14:30:22.481Z').getTime(),
+  targetDate: new Date('2026-04-27T14:30:22.481Z').getTime(),
+  rawContent: '',
+  tags: [],
+  schemaVersion: 1,
+};
+
+function iconType(item: ReturnType<typeof historyEntryToListItem>) {
+  return (item.icon as React.ReactElement).type;
+}
+
+describe('historyEntryToListItem', () => {
+  it('uses a formatted timestamp label and playground icon for untitled playground entries', () => {
+    const item = historyEntryToListItem({
+      ...baseEntry,
+      type: 'playground',
+    });
+
+    expect(item.label).toBe('Playground – Apr 27, 2026 2:30 PM');
+    expect(iconType(item)).toBe(BeakerIcon);
+  });
+
+  it('keeps the existing untitled workout fallback and note icon for notes', () => {
+    const item = historyEntryToListItem({
+      ...baseEntry,
+      type: 'note',
+    });
+
+    expect(item.label).toBe('Untitled workout');
+    expect(iconType(item)).toBe(BookOpenIcon);
+  });
+
+  it('uses a template icon for template entries', () => {
+    const item = historyEntryToListItem({
+      ...baseEntry,
+      type: 'template',
+    });
+
+    expect(iconType(item)).toBe(DocumentDuplicateIcon);
+  });
+});

--- a/src/components/list/adapters/historyAdapter.ts
+++ b/src/components/list/adapters/historyAdapter.ts
@@ -1,5 +1,10 @@
 import React from 'react';
-import { Calendar } from 'lucide-react';
+import {
+  BeakerIcon,
+  BookOpenIcon,
+  DocumentDuplicateIcon,
+} from '@heroicons/react/24/outline';
+import { formatPlaygroundTimestampLabel } from '@/lib/playgroundDisplay';
 import type { HistoryEntry } from '@/types/history';
 import type { IListItem } from '../types';
 
@@ -18,6 +23,22 @@ function formatDuration(ms: number): string {
   return secs > 0 ? `${mins}:${String(secs).padStart(2, '0')}` : `${mins}:00`;
 }
 
+function getLabel(entry: HistoryEntry): string {
+  if (entry.title) return entry.title;
+  if (entry.type === 'playground') return formatPlaygroundTimestampLabel(entry.createdAt);
+  return 'Untitled workout';
+}
+
+function getIcon(entry: HistoryEntry): React.ReactNode {
+  if (entry.type === 'playground') {
+    return React.createElement(BeakerIcon, { className: 'w-4 h-4' });
+  }
+  if (entry.type === 'template') {
+    return React.createElement(DocumentDuplicateIcon, { className: 'w-4 h-4' });
+  }
+  return React.createElement(BookOpenIcon, { className: 'w-4 h-4' });
+}
+
 export function historyEntryToListItem(entry: HistoryEntry): IListItem<HistoryEntry> {
   const duration = entry.results?.duration;
   const durationStr = duration ? formatDuration(duration) : undefined;
@@ -25,9 +46,9 @@ export function historyEntryToListItem(entry: HistoryEntry): IListItem<HistoryEn
 
   return {
     id: entry.id,
-    label: entry.title || 'Untitled workout',
+    label: getLabel(entry),
     subtitle: durationStr ? `${dateStr} · ${durationStr}` : dateStr,
-    icon: React.createElement(Calendar, { className: 'w-4 h-4' }),
+    icon: getIcon(entry),
     group: new Date(entry.targetDate).toLocaleDateString('en-US', {
       month: 'long',
       year: 'numeric',

--- a/src/components/metrics/MetricVisualizer.ColorMap.test.ts
+++ b/src/components/metrics/MetricVisualizer.ColorMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { getMetricColorClasses, metricColorMap } from '../../views/runtime/metricColorMap';
+import { getMetricColorClasses, getMetricIcon, metricColorMap } from '../../views/runtime/metricColorMap';
 
 describe('Visual Fragment Colors Test Suite', () => {
   describe('metricColorMap constant', () => {
@@ -60,6 +60,34 @@ describe('Visual Fragment Colors Test Suite', () => {
       expect(timerClasses).toContain('bg-');
       expect(timerClasses).toContain('border-');
       expect(timerClasses).toContain('text-');
+    });
+  });
+
+  // UX-04: Rest blocks must be visually distinct from work sets.
+  // Rest is parsed as an `effort` metric whose value is "Rest"; the
+  // helpers should detect this and return rest visuals instead of the
+  // running-figure (🏃) used for work sets.
+  describe('rest detection (UX-04)', () => {
+    it('should return the rest icon for effort metrics whose value is "Rest"', () => {
+      expect(getMetricIcon('effort', 'Rest')).toBe('⏸️');
+      expect(getMetricIcon('effort', 'rest')).toBe('⏸️');
+      expect(getMetricIcon('effort', '  REST  ')).toBe('⏸️');
+    });
+
+    it('should still return the effort icon for normal work-set effort metrics', () => {
+      expect(getMetricIcon('effort', 'Pushups')).toBe('🏃');
+      expect(getMetricIcon('effort')).toBe('🏃');
+    });
+
+    it('should return rest color classes for effort metrics whose value is "Rest"', () => {
+      const restClasses = getMetricColorClasses('effort', 'Rest');
+      expect(restClasses).toBe(metricColorMap.rest);
+      expect(restClasses).not.toContain('metric-effort');
+    });
+
+    it('should still return effort color classes for normal effort metrics', () => {
+      expect(getMetricColorClasses('effort', 'Pushups')).toContain('metric-effort');
+      expect(getMetricColorClasses('effort')).toContain('metric-effort');
     });
   });
 });

--- a/src/components/playground/CommandPalette.tsx
+++ b/src/components/playground/CommandPalette.tsx
@@ -16,26 +16,40 @@ interface CommandPaletteProps {
 export function CommandPalette({ isOpen, onClose, items, onSelect, initialCategory }: CommandPaletteProps) {
   const { search: query, setSearch: setQuery, activeStrategy } = useCommandPalette()
   const [strategyResults, setStrategyResults] = useState<CommandPaletteResult[]>([])
+  const [isLoading, setIsLoading] = useState(false)
 
   // Fetch results from active strategy
   useEffect(() => {
     if (!activeStrategy) {
       setStrategyResults([])
+      setIsLoading(false)
       return
     }
     let cancelled = false
+    setIsLoading(true)
     const fetchResults = async () => {
-      const results = await Promise.resolve(activeStrategy.getResults(query))
-      if (!cancelled) setStrategyResults(results)
+      try {
+        const results = await Promise.resolve(activeStrategy.getResults(query))
+        if (!cancelled) {
+          setStrategyResults(results)
+        }
+      } catch (e) {
+        console.error('Failed to fetch command palette results', e)
+        if (!cancelled) {
+          setStrategyResults([])
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
     }
     fetchResults()
-    return () => { cancelled = true }
+    return () => { cancelled = true; setIsLoading(false) }
   }, [query, activeStrategy])
 
   // Reset query when dialog closes
   useEffect(() => {
     if (!isOpen) {
-      const timer = setTimeout(() => { setQuery(''); setStrategyResults([]) }, 300)
+      const timer = setTimeout(() => { setQuery(''); setStrategyResults([]); setIsLoading(false) }, 300)
       return () => clearTimeout(timer)
     }
   }, [isOpen, setQuery])
@@ -60,6 +74,21 @@ export function CommandPalette({ isOpen, onClose, items, onSelect, initialCatego
     onClose()
   }
 
+  const emptyState = isLoading
+    ? (
+        <div className="py-8 text-center text-sm text-zinc-400">Searching…</div>
+      )
+    : query
+      ? (
+          <div className="py-8 text-center text-sm text-zinc-400">
+            No results found for{' '}
+            <span className="font-medium text-zinc-600 dark:text-zinc-300">
+              &ldquo;{query}&rdquo;
+            </span>
+          </div>
+        )
+      : undefined
+
   return (
     <Dialog
       as="div"
@@ -80,6 +109,7 @@ export function CommandPalette({ isOpen, onClose, items, onSelect, initialCatego
             onClose={onClose}
             placeholder={activeStrategy?.placeholder ?? (initialCategory ? `Search in ${initialCategory}…` : 'Search workouts…')}
             header={activeStrategy?.renderHeader ? activeStrategy.renderHeader() : undefined}
+            emptyState={emptyState}
           />
         </DialogPanel>
       </div>

--- a/src/components/review-grid/MetricPill.tsx
+++ b/src/components/review-grid/MetricPill.tsx
@@ -61,7 +61,16 @@ function metricDisplayText(frag: IMetric): string {
     return formatDurationSmart(frag.value);
   }
 
-  if (frag.image) return frag.image;
+  if (frag.image) {
+    // Round-group metrics (parser sets image = count) render as a bare number
+    // and are indistinguishable from rep badges. Append the "Round"/"Rounds"
+    // label so the pill reads e.g. "3 Rounds" (issue UX-03).
+    if (frag.type === MetricType.Rounds && /^\d+$/.test(frag.image.trim())) {
+      const n = Number(frag.image);
+      return `${frag.image} ${n === 1 ? 'Round' : 'Rounds'}`;
+    }
+    return frag.image;
+  }
   if (frag.value !== undefined && frag.value !== null) {
     if (typeof frag.value === 'object') {
       const val = frag.value as any;

--- a/src/lib/playgroundDisplay.test.ts
+++ b/src/lib/playgroundDisplay.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  formatPlaygroundPageTitle,
+  formatPlaygroundTimestampId,
+  formatPlaygroundTimestampLabel,
+} from './playgroundDisplay';
+
+describe('playgroundDisplay', () => {
+  const timestamp = Date.UTC(2026, 3, 27, 14, 30, 22, 481);
+
+  it('formats timestamp IDs for playground URLs', () => {
+    expect(formatPlaygroundTimestampId(timestamp)).toBe('2026-04-27-14-30-22-481');
+  });
+
+  it('formats playground timestamp labels', () => {
+    expect(formatPlaygroundTimestampLabel(timestamp)).toBe('Playground – Apr 27, 2026 2:30 PM');
+  });
+
+  it('formats timestamp route IDs as readable playground titles', () => {
+    expect(formatPlaygroundPageTitle('2026-04-27-14-30-22-481'))
+      .toBe('Playground – Apr 27, 2026 2:30 PM');
+  });
+
+  it('hides legacy UUID playground IDs behind a generic title', () => {
+    expect(formatPlaygroundPageTitle('123e4567-e89b-12d3-a456-426614174000')).toBe('Playground');
+  });
+
+  it('falls back to raw names when route decoding fails', () => {
+    expect(formatPlaygroundPageTitle('%E0%A4%A')).toBe('%E0%A4%A');
+  });
+
+  it('formats timestamp route IDs with collision suffixes as readable titles', () => {
+    expect(formatPlaygroundPageTitle('2026-04-27-14-30-22-481-1'))
+      .toBe('Playground – Apr 27, 2026 2:30 PM');
+  });
+});

--- a/src/lib/playgroundDisplay.ts
+++ b/src/lib/playgroundDisplay.ts
@@ -1,0 +1,60 @@
+const TIMESTAMP_ID_REGEX = /^(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})(?:-(\d{2})(?:-(\d{3}))?)?(?:-\d+)?$/;
+const LEGACY_TIMESTAMP_ID_REGEX = /^(\d{4})-(\d{2})-(\d{2}) (\d{2})-(\d{2})(?:-(\d{2})\.(\d{3}))?$/;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function formatPlaygroundTimestampId(timestamp: number): string {
+  const date = new Date(timestamp);
+  const pad = (value: number, length = 2) => String(value).padStart(length, '0');
+
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+    pad(date.getUTCMilliseconds(), 3),
+  ].join('-');
+}
+
+export function formatPlaygroundTimestampLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const dateStr = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+  const timeStr = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  });
+
+  return `Playground – ${dateStr} ${timeStr}`;
+}
+
+function timestampFromMatch(match: RegExpMatchArray): number {
+  return Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5]),
+    Number(match[6] ?? 0),
+    Number(match[7] ?? 0),
+  );
+}
+
+export function formatPlaygroundPageTitle(name: string): string {
+  let decodedName = name;
+  try {
+    decodedName = decodeURIComponent(name);
+  } catch {
+    decodedName = name;
+  }
+  const timestampMatch = decodedName.match(TIMESTAMP_ID_REGEX) ?? decodedName.match(LEGACY_TIMESTAMP_ID_REGEX);
+  if (timestampMatch) return formatPlaygroundTimestampLabel(timestampFromMatch(timestampMatch));
+  if (UUID_REGEX.test(decodedName)) return 'Playground';
+  return decodedName || 'Playground';
+}

--- a/src/panels/timer-panel.tsx
+++ b/src/panels/timer-panel.tsx
@@ -79,6 +79,12 @@ export interface TimerDisplayProps {
 const StackIntegratedTimer: React.FC<TimerDisplayProps> = (props) => {
   const runtime = useScriptRuntime();
   const viewMode = useWorkbenchSyncStore(s => s.viewMode);
+  // Subscribe to runtime execution status so the Play/Pause toggle reflects
+  // the runtime state, not just whether a timer span is currently open.
+  // This prevents the "Run while running silently does nothing" UX bug ([UX-02]):
+  // even between segments where no timer span is open, the runtime is still
+  // active and the button must show Pause (not Play).
+  const executionStatus = useWorkbenchSyncStore(s => s.execution.status);
 
   // Flash message state for required-timer skip attempts
   // skipFlashKey increments on each skip, giving the flash element a unique key
@@ -361,8 +367,12 @@ const StackIntegratedTimer: React.FC<TimerDisplayProps> = (props) => {
               break;
           }
         }}
-        // If any timer is running, the display should look alive
-        isRunning={isAnyTimerRunning}
+        // If any timer span is open OR the runtime is actively executing,
+        // the display should treat the workout as running. Including the
+        // execution status ensures the central control button shows Pause
+        // (and never the silently-failing Play) whenever the runtime is
+        // active, even between blocks where no timer span is open.
+        isRunning={isAnyTimerRunning || executionStatus === 'running'}
 
         primaryTimer={displayTimerEntry}
         subLabel={subLabel}

--- a/src/repositories/page-examples.ts
+++ b/src/repositories/page-examples.ts
@@ -14,6 +14,8 @@
  * Uses Vite's import.meta.glob — resolved at build time.
  */
 
+import { parseFrontmatter } from '@/utils/frontmatter';
+
 const exampleModules = import.meta.glob('../../markdown/canvas/**/*.md', {
     query: '?raw',
     eager: true,
@@ -26,26 +28,6 @@ export interface PageTabExample {
     section: string;
     order: number;
     content: string;
-}
-
-/**
- * Parse simple YAML frontmatter (flat key: value only, no nesting).
- * Returns parsed metadata and the body after the closing `---`.
- */
-function parseFrontmatter(raw: string): { meta: Record<string, string | number>; body: string } {
-    const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
-    if (!match) return { meta: {}, body: raw };
-
-    const meta: Record<string, string | number> = {};
-    for (const line of match[1].split('\n')) {
-        const colonIdx = line.indexOf(':');
-        if (colonIdx === -1) continue;
-        const key = line.slice(0, colonIdx).trim();
-        const rawVal = line.slice(colonIdx + 1).trim().replace(/^["']|["']$/g, '');
-        const num = Number(rawVal);
-        meta[key] = rawVal !== '' && !isNaN(num) ? num : rawVal;
-    }
-    return { meta, body: match[2].trim() };
 }
 
 /**
@@ -70,7 +52,7 @@ export function getTabExamples(page: string, section: string): PageTabExample[] 
             subtitle: String(meta.subtitle ?? ''),
             section: String(meta.section ?? ''),
             order: Number(meta.order ?? 0),
-            content: body,
+            content: body.trim(),
         });
     }
 
@@ -87,5 +69,5 @@ export function getHomeExample(name: string): string {
     );
     if (!key) return '';
     const { body } = parseFrontmatter(exampleModules[key] as string);
-    return body;
+    return body.trim();
 }

--- a/src/runtime-test-bench/hooks/__tests__/useRuntimeExecution.test.ts
+++ b/src/runtime-test-bench/hooks/__tests__/useRuntimeExecution.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for useRuntimeExecution hook
+ *
+ * Specifically guards the [UX-02] regression: starting an already-running
+ * execution must surface developer feedback instead of silently no-op'ing.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useRuntimeExecution } from '../useRuntimeExecution';
+import type { ScriptRuntime } from '../../../runtime/ScriptRuntime';
+
+function createMockRuntime(): ScriptRuntime {
+  // Minimal stub — only the surface used by useRuntimeExecution is implemented:
+  //  - `handle` (called for tick/resume/pause events)
+  //  - `subscribeToStack` (used to detect completion)
+  // Other ScriptRuntime methods are intentionally not stubbed; tests should
+  // not exercise code paths that depend on them.
+  return {
+    handle: () => { },
+    subscribeToStack: () => () => { },
+  } as unknown as ScriptRuntime;
+}
+
+describe('useRuntimeExecution', () => {
+  let originalWarn: typeof console.warn;
+  let warnSpy: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    warnSpy = mock(() => { });
+    console.warn = warnSpy as any;
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it('starts execution and reports running status', () => {
+    const runtime = createMockRuntime();
+    const { result } = renderHook(() => useRuntimeExecution(runtime));
+
+    expect(result.current.status).toBe('idle');
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.status).toBe('running');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('[UX-02] warns instead of silently failing when start() is called while running', () => {
+    const runtime = createMockRuntime();
+    const { result } = renderHook(() => useRuntimeExecution(runtime));
+
+    act(() => {
+      result.current.start();
+    });
+    expect(result.current.status).toBe('running');
+
+    // Second start while already running should surface a warning,
+    // not silently no-op (the original [UX-02] regression).
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.status).toBe('running');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String((warnSpy.mock.calls[0] as unknown as unknown[])[0] ?? '');
+    expect(message.toLowerCase()).toContain('already running');
+  });
+
+  it('warns when start() is called without a runtime', () => {
+    const { result } = renderHook(() => useRuntimeExecution(null));
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/runtime-test-bench/hooks/useRuntimeExecution.ts
+++ b/src/runtime-test-bench/hooks/useRuntimeExecution.ts
@@ -126,7 +126,13 @@ export const useRuntimeExecution = (
       return;
     }
 
-    if (status === 'running') return;
+    if (status === 'running') {
+      // Surface feedback instead of silently no-op'ing — see [UX-02].
+      // Callers should bind their Run button's `disabled` (or visibility)
+      // to `status === 'running'` so this branch is unreachable in normal UX.
+      console.warn('Cannot start execution: already running');
+      return;
+    }
 
     // Emit timer:resume event when resuming from paused state
     if (status === 'paused') {

--- a/src/services/content/IndexedDBContentProvider.ts
+++ b/src/services/content/IndexedDBContentProvider.ts
@@ -6,6 +6,7 @@
  */
 
 import { v4 as uuidv4 } from 'uuid';
+import { formatPlaygroundTimestampId } from '../../lib/playgroundDisplay';
 import { toShortId } from '../../lib/idUtils';
 import type { IContentProvider, ContentProviderMode } from '../../types/content-provider';
 import type { HistoryEntry, EntryQuery, ProviderCapabilities } from '../../types/history';
@@ -13,6 +14,8 @@ import { indexedDBService } from '../db/IndexedDBService';
 import { Note, NoteSegment, WorkoutResult, SegmentDataType, Attachment } from '../../types/storage';
 import { parseDocumentSections } from '../../components/Editor/utils/sectionParser';
 import { Section, SectionType } from '../../components/Editor/types/section';
+
+const MAX_TIMESTAMP_ID_SUFFIX_ATTEMPTS = 100;
 
 /**
  * Map legacy SectionType values stored in older DBs to current types.
@@ -75,6 +78,9 @@ export class IndexedDBContentProvider implements IContentProvider {
                 targetDate: note.targetDate || note.createdAt,
                 rawContent,
                 tags: note.tags,
+                type: note.type || 'note',
+                templateId: note.templateId,
+                clonedIds: note.clonedIds,
                 schemaVersion: 1,
             } as HistoryEntry;
         });
@@ -209,8 +215,19 @@ export class IndexedDBContentProvider implements IContentProvider {
     }
 
     async saveEntry(entry: Omit<HistoryEntry, 'id' | 'createdAt' | 'updatedAt' | 'schemaVersion'>): Promise<HistoryEntry> {
-        const noteId = uuidv4();
         const now = Date.now();
+        let noteId = entry.type === 'playground' ? formatPlaygroundTimestampId(now) : uuidv4();
+        if (entry.type === 'playground') {
+            const baseNoteId = noteId;
+            let attempt = 0;
+            while (await indexedDBService.getNote(noteId)) {
+                attempt += 1;
+                if (attempt > MAX_TIMESTAMP_ID_SUFFIX_ATTEMPTS) {
+                    throw new Error('Unable to allocate unique playground timestamp ID');
+                }
+                noteId = `${baseNoteId}-${attempt}`;
+            }
+        }
 
         // TRANSITION TO SEGMENTS
         const sections = parseDocumentSections(entry.rawContent);

--- a/src/services/content/__tests__/IndexedDBContentProvider.test.ts
+++ b/src/services/content/__tests__/IndexedDBContentProvider.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import type { Note, NoteSegment } from '../../../types/storage';
+
+const savedNotes: Note[] = [];
+const savedSegments: NoteSegment[] = [];
+const notes: Note[] = [];
+
+mock.module('../../db/IndexedDBService', () => ({
+  indexedDBService: {
+    getNote: async (id: string) => notes.find(note => note.id === id),
+    getAllNotes: async () => notes,
+    saveNote: async (note: Note) => {
+      savedNotes.push(note);
+      return note.id;
+    },
+    saveSegment: async (segment: NoteSegment) => {
+      savedSegments.push(segment);
+      return segment.id;
+    },
+  },
+}));
+
+const providerModule = import('../IndexedDBContentProvider');
+const originalDateNow = Date.now;
+
+afterEach(() => {
+  Date.now = originalDateNow;
+  notes.length = 0;
+  savedNotes.length = 0;
+  savedSegments.length = 0;
+});
+
+describe('IndexedDBContentProvider', () => {
+  it('uses timestamp IDs for new playground entries', async () => {
+    Date.now = () => Date.UTC(2026, 3, 27, 14, 30, 22, 481);
+    const { IndexedDBContentProvider } = await providerModule;
+    const provider = new IndexedDBContentProvider();
+
+    const entry = await provider.saveEntry({
+      title: '',
+      rawContent: '',
+      tags: [],
+      targetDate: Date.now(),
+      type: 'playground',
+    });
+
+    expect(entry.id).toBe('2026-04-27-14-30-22-481');
+    expect(savedNotes[0].id).toBe('2026-04-27-14-30-22-481');
+    expect(savedNotes[0].type).toBe('playground');
+  });
+
+  it('preserves playground type when listing entries', async () => {
+    notes.push({
+      id: '2026-04-27-14-30-22-481',
+      title: '',
+      rawContent: '',
+      tags: [],
+      createdAt: Date.UTC(2026, 3, 27, 14, 30, 22, 481),
+      updatedAt: Date.UTC(2026, 3, 27, 14, 30, 22, 481),
+      targetDate: Date.UTC(2026, 3, 27, 14, 30, 22, 481),
+      segmentIds: [],
+      type: 'playground',
+    });
+    const { IndexedDBContentProvider } = await providerModule;
+    const provider = new IndexedDBContentProvider();
+
+    const entries = await provider.getEntries();
+
+    expect(entries[0].type).toBe('playground');
+  });
+
+  it('adds a suffix when a playground timestamp ID already exists', async () => {
+    Date.now = () => Date.UTC(2026, 3, 27, 14, 30, 22, 481);
+    notes.push({
+      id: '2026-04-27-14-30-22-481',
+      title: 'Existing playground',
+      rawContent: '',
+      tags: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      targetDate: Date.now(),
+      segmentIds: [],
+      type: 'playground',
+    });
+    const { IndexedDBContentProvider } = await providerModule;
+    const provider = new IndexedDBContentProvider();
+
+    const entry = await provider.saveEntry({
+      title: '',
+      rawContent: '',
+      tags: [],
+      targetDate: Date.now(),
+      type: 'playground',
+    });
+
+    expect(entry.id).toBe('2026-04-27-14-30-22-481-1');
+    expect(savedNotes[0].id).toBe('2026-04-27-14-30-22-481-1');
+  });
+
+  it('keeps UUID IDs for non-playground entries', async () => {
+    Date.now = () => Date.UTC(2026, 3, 27, 14, 30, 22, 481);
+    const { IndexedDBContentProvider } = await providerModule;
+    const provider = new IndexedDBContentProvider();
+
+    const entry = await provider.saveEntry({
+      title: 'Fran',
+      rawContent: '',
+      tags: [],
+      targetDate: Date.now(),
+      type: 'note',
+    });
+
+    expect(entry.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  });
+});

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -44,7 +44,7 @@ export interface HistoryEntry {
   schemaVersion: number;               // For future migration
 
   // Note Management
-  type?: 'note' | 'template';          // Default to 'note' if undefined
+  type?: 'note' | 'template' | 'playground'; // Default to 'note' if undefined
   templateId?: string;                 // ID of the template/note this was cloned from
   clonedIds?: string[];                // IDs of notes cloned FROM this entry (reverse links)
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -34,7 +34,7 @@ export interface Note {
     segmentIds: string[]; // Ordered list of segment UUIDs
 
     // Note Management
-    type?: 'note' | 'template';
+    type?: 'note' | 'template' | 'playground';
     templateId?: string;
     clonedIds?: string[];              // IDs of notes cloned FROM this note
 }

--- a/src/utils/frontmatter.test.ts
+++ b/src/utils/frontmatter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+
+import { parseFrontmatter, stripFrontmatter } from './frontmatter'
+
+describe('frontmatter utilities', () => {
+  it('strips leading YAML frontmatter from editor source content', () => {
+    const raw = `---
+search: hidden
+title: Just a Movement
+section: statement
+order: 1
+---
+\`\`\`wod
+Pushups
+\`\`\`
+`
+
+    expect(stripFrontmatter(raw)).toBe(`\`\`\`wod
+Pushups
+\`\`\`
+`)
+  })
+
+  it('parses flat metadata while preserving body content', () => {
+    const raw = [
+      '---',
+      'title: "Quoted Title"',
+      "subtitle: 'Quoted subtitle'",
+      'order: 1',
+      'empty:',
+      '---',
+      'Body',
+      '',
+    ].join('\r\n')
+    const { meta, body } = parseFrontmatter(raw)
+
+    expect(meta).toEqual({
+      title: 'Quoted Title',
+      subtitle: 'Quoted subtitle',
+      order: 1,
+      empty: '',
+    })
+    expect(body).toBe('Body\r\n')
+  })
+
+  it('leaves content without leading frontmatter unchanged', () => {
+    const raw = `\`\`\`wod
+---
+Pushups
+---
+\`\`\`
+`
+
+    expect(stripFrontmatter(raw)).toBe(raw)
+  })
+
+  it('only removes matching wrapping quotes from metadata values', () => {
+    const { meta } = parseFrontmatter(`---
+title: "Matched"
+subtitle: "Mismatched'
+---
+Body
+`)
+
+    expect(meta.title).toBe('Matched')
+    expect(meta.subtitle).toBe(`"Mismatched'`)
+  })
+})

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,31 @@
+export interface ParsedFrontmatter {
+  meta: Record<string, string | number>
+  body: string
+}
+
+/**
+ * Parse simple YAML frontmatter (flat key: value only, no nesting).
+ * Returns parsed metadata and the body after the closing `---`.
+ */
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/)
+  if (!match) return { meta: {}, body: raw }
+
+  const meta: Record<string, string | number> = {}
+  for (const line of match[1].split(/\r?\n/)) {
+    const colonIdx = line.indexOf(':')
+    if (colonIdx === -1) continue
+    const key = line.slice(0, colonIdx).trim()
+    if (!/^[A-Za-z][\w-]*$/.test(key)) continue
+    const rawVal = line.slice(colonIdx + 1).trim()
+    const unquotedVal = rawVal.replace(/^(['"])(.*)\1$/, '$2')
+    const num = Number(unquotedVal)
+    meta[key] = unquotedVal !== '' && !isNaN(num) ? num : unquotedVal
+  }
+
+  return { meta, body: match[2] }
+}
+
+export function stripFrontmatter(raw: string): string {
+  return parseFrontmatter(raw).body
+}

--- a/src/views/runtime/MetricVisualizer.RoundsBadge.test.tsx
+++ b/src/views/runtime/MetricVisualizer.RoundsBadge.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * UX-03 — Round group badge must include the "Rounds" label so it is not
+ * visually indistinguishable from a rep count badge.
+ *
+ * Regression test for: `(3 Rounds)` group rendering as `🔄 3` instead of
+ * `🔄 3 Rounds`.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { MetricVisualizer } from './MetricVisualizer';
+import type { IMetric, MetricType } from '../../core/models/Metric';
+
+function metric(type: string, value: unknown, image?: string): IMetric {
+  return { type, value, image: image ?? String(value), origin: 'parser' } as IMetric;
+}
+
+describe('MetricVisualizer — rounds badge label (UX-03)', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  it('appends "Rounds" to the badge for a (3 Rounds) group', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[metric('rounds', 3)]} />,
+    );
+    expect(container.textContent).toContain('3 Rounds');
+    expect(container.textContent).toContain('🔄');
+  });
+
+  it('uses singular "Round" when count is 1', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[metric('rounds', 1)]} />,
+    );
+    expect(container.textContent).toContain('1 Round');
+    expect(container.textContent).not.toContain('1 Rounds');
+  });
+
+  it('uses plural "Rounds" for counts greater than 1', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[metric('rounds', 5)]} />,
+    );
+    expect(container.textContent).toContain('5 Rounds');
+  });
+
+  it('does not append "Rounds" to a rep badge', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[metric('rep', 21)]} />,
+    );
+    expect(container.textContent).toContain('21');
+    expect(container.textContent).not.toContain('Rounds');
+    expect(container.textContent).not.toContain('Round');
+  });
+
+  it('does not append the label to non-numeric round images (e.g. labels)', () => {
+    // RoundsMetric supports a string label (parser path: an Identifier in a
+    // group). In that case we must preserve the label unchanged.
+    const m: IMetric = {
+      type: 'rounds' as MetricType,
+      value: 'AMRAP',
+      image: 'AMRAP',
+      origin: 'parser',
+    } as IMetric;
+    const { container } = render(<MetricVisualizer metrics={[m]} />);
+    expect(container.textContent).toContain('AMRAP');
+    expect(container.textContent).not.toContain('AMRAP Rounds');
+  });
+});

--- a/src/views/runtime/MetricVisualizer.test.tsx
+++ b/src/views/runtime/MetricVisualizer.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render } from '@testing-library/react';
+import { MetricVisualizer } from './MetricVisualizer';
+import type { IMetric } from '../../core/models/Metric';
+
+/**
+ * UX-05 regression coverage: `// ...` comment lines must render visually
+ * distinct from `[action items]`. Comments are passive coach annotations
+ * (muted italic, no emoji badge); action items remain interactive pills.
+ */
+describe('MetricVisualizer comment vs action item rendering', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = '';
+  });
+
+  const commentMetric: IMetric = {
+    type: 'text',
+    origin: 'parser',
+    value: { text: 'Warm up first' },
+    image: 'Warm up first',
+  } as IMetric;
+
+  const actionMetric: IMetric = {
+    type: 'action',
+    origin: 'parser',
+    value: 'Set up barbell',
+    image: 'Set up barbell',
+  } as IMetric;
+
+  it('renders parser-origin text metrics (comments) as muted italic annotations without emoji badge', () => {
+    const { container } = render(<MetricVisualizer metrics={[commentMetric]} />);
+
+    const commentNode = container.querySelector('[data-metric-type="comment"]');
+    expect(commentNode).toBeTruthy();
+    expect(commentNode?.textContent).toBe('Warm up first');
+    expect(commentNode?.className).toContain('italic');
+    expect(commentNode?.className).toContain('text-muted-foreground');
+    // No pill / border / interactive affordances for comments.
+    expect(commentNode?.className).not.toContain('border');
+    expect(commentNode?.className).not.toContain('cursor-help');
+    // The notepad emoji used for the generic `text` icon must not leak through.
+    expect(container.textContent).not.toContain('📝');
+  });
+
+  it('renders action items as interactive pill badges (visually distinct from comments)', () => {
+    const { container } = render(<MetricVisualizer metrics={[actionMetric]} />);
+
+    // Action items keep the standard pill badge styling.
+    const pill = container.querySelector('span.inline-flex.border');
+    expect(pill).toBeTruthy();
+    expect(pill?.textContent).toContain('Set up barbell');
+    // Comments slot must not be used for action items.
+    expect(container.querySelector('[data-metric-type="comment"]')).toBeNull();
+  });
+
+  it('renders comments and action items distinctly when shown side-by-side', () => {
+    const { container } = render(
+      <MetricVisualizer metrics={[commentMetric, actionMetric]} />,
+    );
+
+    const commentNode = container.querySelector('[data-metric-type="comment"]');
+    const pill = container.querySelector('span.inline-flex.border');
+
+    expect(commentNode).toBeTruthy();
+    expect(pill).toBeTruthy();
+    // The two nodes must not be the same element — they should use different
+    // rendering paths so they look semantically distinct in the runner.
+    expect(commentNode).not.toBe(pill);
+  });
+
+  it('keeps runtime-origin text metrics (labels/subtitles from LabelingBehavior) on the standard pill rendering', () => {
+    const labelMetric: IMetric = {
+      type: 'text',
+      origin: 'runtime',
+      value: { text: 'Round 1 of 3', role: 'round' },
+      image: 'Round 1 of 3',
+    } as IMetric;
+
+    const { container } = render(<MetricVisualizer metrics={[labelMetric]} />);
+
+    // Runtime-origin text must NOT use the comment annotation slot.
+    expect(container.querySelector('[data-metric-type="comment"]')).toBeNull();
+    const pill = container.querySelector('span.inline-flex.border');
+    expect(pill).toBeTruthy();
+    expect(pill?.textContent).toContain('Round 1 of 3');
+  });
+});

--- a/src/views/runtime/MetricVisualizer.tsx
+++ b/src/views/runtime/MetricVisualizer.tsx
@@ -151,9 +151,32 @@ export const MetricVisualizer = React.memo<MetricVisualizerProps>(({
         })
         .map((metric, index) => {
         const type = metric.type || 'unknown';
-        const colorClasses = getMetricColorClasses(type);
         const tokenValue = formatTokenValue(metric, type);
-        const icon = getMetricIcon(type);
+
+        // Render parser-origin `text` metrics (from `// ...` comment syntax) as
+        // passive coach annotations: muted italic text without emoji badge,
+        // border, or interactive affordances. This visually distinguishes them
+        // from `[action items]` which remain rendered as interactive pills.
+        // Runtime-origin text metrics (labels, subtitles, round indicators
+        // emitted by LabelingBehavior) keep the standard pill rendering.
+        if (type === 'text' && metric.origin === 'parser') {
+          return (
+            <span
+              key={index}
+              className={cn(
+                'italic text-muted-foreground select-text',
+                currentStyle.text
+              )}
+              title={`COMMENT: ${tokenValue}`}
+              data-metric-type="comment"
+            >
+              {tokenValue}
+            </span>
+          );
+        }
+
+        const colorClasses = getMetricColorClasses(type, tokenValue);
+        const icon = getMetricIcon(type, tokenValue);
 
         return (
           <span

--- a/src/views/runtime/MetricVisualizer.tsx
+++ b/src/views/runtime/MetricVisualizer.tsx
@@ -152,7 +152,7 @@ export const MetricVisualizer = React.memo<MetricVisualizerProps>(({
         .map((metric, index) => {
         const type = metric.type || 'unknown';
         const colorClasses = getMetricColorClasses(type);
-        const tokenValue = metric.image || (typeof metric.value === 'object' ? JSON.stringify(metric.value) : String(metric.value));
+        const tokenValue = formatTokenValue(metric, type);
         const icon = getMetricIcon(type);
 
         return (
@@ -175,3 +175,29 @@ export const MetricVisualizer = React.memo<MetricVisualizerProps>(({
 });
 
 MetricVisualizer.displayName = 'MetricVisualizer';
+
+/**
+ * Compute the badge token text for a metric.
+ *
+ * For round-group metrics (`type: 'rounds'`), the parser-built image is just
+ * the count (e.g. "3"), which renders as a bare number ("🔄 3") and is
+ * visually indistinguishable from a rep badge. Append the "Round"/"Rounds"
+ * label so the badge reads "🔄 3 Rounds" (issue UX-03).
+ */
+function formatTokenValue(metric: IMetric, type: string): string {
+  const base = metric.image || (typeof metric.value === 'object'
+    ? JSON.stringify(metric.value)
+    : String(metric.value));
+
+  if (type.toLowerCase() === 'rounds') {
+    // Only append the label when the base is a numeric count; preserve
+    // string labels (e.g. AMRAP-style identifiers) untouched.
+    const trimmed = base.trim();
+    if (/^\d+$/.test(trimmed)) {
+      const numeric = Number(trimmed);
+      return `${base} ${numeric === 1 ? 'Round' : 'Rounds'}`;
+    }
+  }
+
+  return base;
+}

--- a/src/views/runtime/metricColorMap.ts
+++ b/src/views/runtime/metricColorMap.ts
@@ -17,7 +17,8 @@ export type MetricType =
   | 'elapsed'
   | 'total'
   | 'system-time'
-  | 'metric';
+  | 'metric'
+  | 'rest';
 
 export type FragmentColorMap = {
   readonly [key in MetricType]: string;
@@ -46,16 +47,36 @@ export const metricColorMap: FragmentColorMap = {
   total:       'bg-muted border-border text-foreground',
   'system-time': 'bg-muted/60 border-border/60 text-muted-foreground',
   metric:      'bg-metric-effort/10 border-metric-effort/30 text-metric-effort',
+  // Rest blocks use a muted treatment to distinguish them from active work sets (UX-04)
+  rest:        'bg-muted/70 border-muted-foreground/30 text-muted-foreground',
 };
+
+/**
+ * Detects whether a metric represents a rest period.
+ *
+ * Rest blocks (e.g. `* :90 Rest`) are parsed as `effort` metrics whose value
+ * is the word "Rest". They should be rendered with the rest icon/colors so
+ * they are visually distinct from work sets. See issue UX-04.
+ */
+function isRestMetric(type: string, value?: string): boolean {
+  if (type.toLowerCase() !== 'effort' || !value) return false;
+  return value.trim().toLowerCase() === 'rest';
+}
 
 /**
  * Get color classes for a metrics type
  * @param type - Fragment type string (case-insensitive)
+ * @param value - Optional metric value; used to detect rest indicators on
+ *   `effort` metrics so they can be styled distinctly from work sets.
  * @returns Tailwind CSS color classes for the type
  */
-export function getMetricColorClasses(type: string): string {
+export function getMetricColorClasses(type: string, value?: string): string {
+  if (isRestMetric(type, value)) {
+    return metricColorMap.rest;
+  }
+
   const normalizedType = type.toLowerCase() as MetricType;
-  
+
   // Return mapped color or fallback for unknown types
   return metricColorMap[normalizedType] || 'bg-gray-200 border-gray-300 text-gray-800 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100';
 }
@@ -85,8 +106,14 @@ const metricIconMap: Record<string, string> = {
 /**
  * Get icon/emoji for a metrics type
  * @param type - Fragment type string (case-insensitive)
+ * @param value - Optional metric value; used to detect rest indicators on
+ *   `effort` metrics so they can be shown with the rest icon (⏸️) instead
+ *   of the running figure used for work sets (UX-04).
  * @returns Emoji icon for the type, or null if no icon is defined
  */
-export function getMetricIcon(type: string): string | null {
+export function getMetricIcon(type: string, value?: string): string | null {
+  if (isRestMetric(type, value)) {
+    return metricIconMap.rest;
+  }
   return metricIconMap[type.toLowerCase()] || null;
 }

--- a/stories/acceptance/RuntimeCrossFit.stories.tsx
+++ b/stories/acceptance/RuntimeCrossFit.stories.tsx
@@ -9,10 +9,10 @@
  *   3. Assert round/rep/metric state from the UI
  *
  * Story IDs (used by e2e tests):
- *   acceptance-runtime-crossfit--fran
- *   acceptance-runtime-crossfit--annie
- *   acceptance-runtime-crossfit--cindy
- *   acceptance-runtime-crossfit--barbara
+ *   acceptance-runtimecrossfit--fran
+ *   acceptance-runtimecrossfit--annie
+ *   acceptance-runtimecrossfit--cindy
+ *   acceptance-runtimecrossfit--barbara
  *
  * All stories use the StorybookWorkbench so the full execution stack is live.
  * data-testid attributes are sourced from TestIdContract.

--- a/stories/catalog/molecules/MetricVisualizer.stories.tsx
+++ b/stories/catalog/molecules/MetricVisualizer.stories.tsx
@@ -111,6 +111,7 @@ export const ErrorState: Story = {
 };
 
 /**
+/**
  * UX-03 regression: the badge for a `(N Rounds)` group must include the
  * "Rounds" label so it is not confused with a rep count badge.
  *

--- a/stories/catalog/molecules/MetricVisualizer.stories.tsx
+++ b/stories/catalog/molecules/MetricVisualizer.stories.tsx
@@ -135,3 +135,68 @@ export const RoundsBadge: Story = {
     </div>
   ),
 };
+
+/**
+ * UX-04: Rest blocks must be visually distinct from work sets.
+ *
+ * "Rest" is parsed as an `effort` metric whose value is the literal word
+ * "Rest". The visualizer detects this and renders the rest icon (⏸️) with
+ * muted styling rather than the running figure (🏃) used for work sets.
+ */
+export const RestVsWorkSet: Story = {
+  render: () => (
+    <div className="flex flex-col gap-0 w-fit">
+      <Row label="work set">
+        <MetricVisualizer metrics={[m('rep', 10), m('effort', 'Pushups')]} />
+      </Row>
+      <Row label="rest block">
+        <MetricVisualizer metrics={[m('time', 90_000), m('effort', 'Rest')]} />
+      </Row>
+      <Row label="work set">
+        <MetricVisualizer metrics={[m('rep', 20), m('effort', 'Squats')]} />
+      </Row>
+    </div>
+  ),
+};
+
+/**
+ * Comments vs. action items.
+ *
+ * `// ...` comment lines are emitted as `text` metrics with `origin: 'parser'`
+ * and render as muted italic annotations (no badge, no emoji, not interactive).
+ *
+ * `[Set up barbell]` action items are emitted as `action` metrics and continue
+ * to render as interactive pill badges. This visual distinction reflects their
+ * different semantics: passive coach annotation vs. interactive task.
+ */
+export const CommentVsActionItem: Story = {
+  render: () => {
+    const comment: IMetric = {
+      type: 'text',
+      origin: 'parser',
+      value: { text: 'Warm up first' },
+      image: 'Warm up first',
+    } as IMetric;
+    const action: IMetric = {
+      type: 'action',
+      origin: 'parser',
+      value: 'Set up barbell',
+      image: 'Set up barbell',
+    } as IMetric;
+    return (
+      <div className="flex flex-col gap-0 w-full max-w-md">
+        <Row label="comment">
+          <MetricVisualizer metrics={[comment]} />
+        </Row>
+        <Row label="action item">
+          <MetricVisualizer metrics={[action]} />
+        </Row>
+        <Row label="mixed">
+          <MetricVisualizer
+            metrics={[comment, action, m('rep', 10), m('effort', 'Back Squats')]}
+          />
+        </Row>
+      </div>
+    );
+  },
+};

--- a/stories/catalog/molecules/MetricVisualizer.stories.tsx
+++ b/stories/catalog/molecules/MetricVisualizer.stories.tsx
@@ -109,3 +109,29 @@ export const ErrorState: Story = {
     error: { message: 'Failed to parse statement', line: 3, column: 7 },
   },
 };
+
+/**
+ * UX-03 regression: the badge for a `(N Rounds)` group must include the
+ * "Rounds" label so it is not confused with a rep count badge.
+ *
+ * Expected: `🔄 3 Rounds` (not `🔄 3`).
+ */
+export const RoundsBadge: Story = {
+  name: 'Rounds Badge (UX-03)',
+  render: () => (
+    <div className="flex flex-col gap-2 w-fit">
+      <Row label="(3 Rounds)">
+        <MetricVisualizer metrics={[m('rounds', 3)]} />
+      </Row>
+      <Row label="(1 Round)">
+        <MetricVisualizer metrics={[m('rounds', 1)]} />
+      </Row>
+      <Row label="(5 Rounds)">
+        <MetricVisualizer metrics={[m('rounds', 5)]} />
+      </Row>
+      <Row label="vs. 3 reps">
+        <MetricVisualizer metrics={[m('rep', 3)]} />
+      </Row>
+    </div>
+  ),
+};


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the end-to-end (E2E) test suite, markdown syntax documentation, and the playground app. The most significant changes include new E2E acceptance tests for UI/UX features, enhanced handling of markdown frontmatter to prevent YAML metadata from leaking into the canvas editor, and improved timestamp-based naming for playground pages. Additionally, several code refactors increase robustness and maintainability, and documentation has been updated to clarify markdown comment syntax.

**E2E Acceptance Tests and UX Validation:**

- Added new Playwright E2E tests for:
  - Distinguishing between comments (`// ...`) and action items (`[action items]`) in the metric visualizer, ensuring correct visual rendering and interaction states.
  - Verifying the FullscreenTimer close button promptly dismisses the overlay in the Ready-to-Start state, preventing regressions related to delayed dismissals.
  - Ensuring the Home page analytics feature card renders markdown as a formatted list, not as raw markdown.
  - Confirming the canvas editor does not display YAML frontmatter on syntax pages, and that no errors are thrown during rendering.

**Playground App Improvements:**

- Switched playground page naming and ID generation to use a robust timestamp-based format via `formatPlaygroundTimestampId`, with retry logic to guarantee uniqueness and avoid collisions. This change affects page creation, ZIP import, and related utilities. [[1]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R48) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L87-R100) [[3]](diffhunk://#diff-1b35914db2043091fa587e0bb1c6fa67f9ce2d53aee3c24121b3529ea8a0bc56L4-R6) [[4]](diffhunk://#diff-1b35914db2043091fa587e0bb1c6fa67f9ce2d53aee3c24121b3529ea8a0bc56L22-R23)
- Updated the Playground note page to display a human-friendly title (using `formatPlaygroundPageTitle`) and set the browser document title accordingly, improving user navigation and clarity. [[1]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54R28) [[2]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54L43-R51) [[3]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54R110-R113) [[4]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54L117-R124) [[5]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54L126-R133)

**Markdown Frontmatter Handling:**

- Refactored frontmatter parsing by moving it to a shared utility (`@/utils/frontmatter`), and ensured that all canvas markdown sources are stripped of frontmatter before being rendered in the editor. This prevents YAML metadata from leaking into the user-facing content. [[1]](diffhunk://#diff-fd665d995becaf7e894a340dbe99091f57f5ca9d05978101f30d0783ab43f936R29) [[2]](diffhunk://#diff-fd665d995becaf7e894a340dbe99091f57f5ca9d05978101f30d0783ab43f936L49-R50) [[3]](diffhunk://#diff-fd665d995becaf7e894a340dbe99091f57f5ca9d05978101f30d0783ab43f936L65-R73) [[4]](diffhunk://#diff-b6f333860b03d9cbf8245c3eb334ffbe5dff5e43d0fecaed774daa4bedf99d81R1-R2) [[5]](diffhunk://#diff-b6f333860b03d9cbf8245c3eb334ffbe5dff5e43d0fecaed774daa4bedf99d81L77-L90) [[6]](diffhunk://#diff-b6f333860b03d9cbf8245c3eb334ffbe5dff5e43d0fecaed774daa4bedf99d81L248-R238)
- Updated markdown/canvas syntax documentation to clearly describe the use and rendering of `//` comments, distinguishing them from interactive action items.

**Other Notable Changes:**

- Fixed Storybook story ID references in E2E tests to match Storybook's CSF `sanitize` logic, preventing test failures due to incorrect story URLs.
- Added new documentation sync scripts to `package.json` for improved workflow automation.

These changes collectively improve test coverage, user experience, and code maintainability across the project.