### PR TITLE
fix: render ReviewGrid in canvas page review panel after workout completion

### DIFF
--- a/docs/deep-dives/unified-visualization-implementation-guide.md
+++ b/docs/deep-dives/unified-visualization-implementation-guide.md
@@ -1,0 +1,1126 @@
+# Unified Visualization Implementation Guide
+
+This guide provides step-by-step instructions for implementing the unified visualization system described in the [Unified Visualization System Deep Dive](./unified-visualization-system.md).
+
+## Overview
+
+The implementation is divided into 5 phases, designed to minimize risk and allow incremental migration.
+
+---
+
+## Phase 1: Create Unified Data Model
+
+### Step 1.1: Create DisplayItem Interface
+
+Create the file `src/core/models/DisplayItem.ts`:
+
+```typescript
+/**
+ * DisplayItem.ts - Unified display model for workout visualization
+ * 
+ * This interface represents any workout data (parsed statements, runtime blocks,
+ * execution history) in a format optimized for consistent UI rendering.
+ * 
+ * Key principle: All visual data is represented as ICodeFragment[] arrays,
+ * ensuring consistent color-coding and styling across all views.
+ */
+
+import { ICodeFragment } from './CodeFragment';
+
+/**
+ * Status of a display item in the execution lifecycle
+ */
+export type DisplayStatus = 'pending' | 'active' | 'completed' | 'failed' | 'skipped';
+
+/**
+ * Source type indicator for debugging and tooltips
+ */
+export type DisplaySourceType = 'statement' | 'block' | 'span' | 'record';
+
+/**
+ * Unified display item interface
+ * 
+ * Can represent:
+ * - Parsed code statements (from parser)
+ * - Active runtime blocks (from stack)
+ * - Execution spans (from history)
+ */
+export interface IDisplayItem {
+  // === Identity ===
+  /** Unique identifier */
+  id: string;
+  /** Parent item ID for hierarchy (null for root items) */
+  parentId: string | null;
+  
+  // === Visual Content ===
+  /** 
+   * Fragments to display - THE KEY FIELD
+   * All workout data (timers, reps, exercises, etc.) is converted to fragments
+   * for consistent color-coded rendering via FragmentVisualizer
+   */
+  fragments: ICodeFragment[];
+  
+  // === Layout ===
+  /** Nesting depth for indentation (0 = root level) */
+  depth: number;
+  /** Whether this item should render as a section header */
+  isHeader: boolean;
+  /** Whether this item is part of a linked group (+ statements) */
+  isLinked?: boolean;
+  
+  // === State ===
+  /** Current execution status */
+  status: DisplayStatus;
+  
+  // === Metadata ===
+  /** Original data source type */
+  sourceType: DisplaySourceType;
+  /** Original source ID for linking back to source data */
+  sourceId: string | number;
+  
+  // === Optional Timing ===
+  /** Start timestamp (ms) */
+  startTime?: number;
+  /** End timestamp (ms) */
+  endTime?: number;
+  /** Calculated duration (ms) */
+  duration?: number;
+  
+  // === Optional Label ===
+  /** Display label (fallback if fragments empty) */
+  label?: string;
+}
+
+/**
+ * Type guard to check if an item is active
+ */
+export function isActiveItem(item: IDisplayItem): boolean {
+  return item.status === 'active';
+}
+
+/**
+ * Type guard to check if an item is completed
+ */
+export function isCompletedItem(item: IDisplayItem): boolean {
+  return item.status === 'completed' || item.status === 'failed' || item.status === 'skipped';
+}
+
+/**
+ * Type guard to check if an item is a header
+ */
+export function isHeaderItem(item: IDisplayItem): boolean {
+  return item.isHeader;
+}
+```
+
+### Step 1.2: Export from Core Module
+
+Update `src/core/models/index.ts` (or create if doesn't exist):
+
+```typescript
+export * from './DisplayItem';
+// ... other exports
+```
+
+---
+
+## Phase 2: Create Adapter Functions
+
+### Step 2.1: Create Adapters File
+
+Create the file `src/core/utils/displayItemAdapters.ts`:
+
+```typescript
+/**
+ * displayItemAdapters.ts - Convert various data types to IDisplayItem
+ * 
+ * These adapters form the bridge between source data models and the unified
+ * display system. Each adapter handles the specific conversion logic for
+ * its data type, ultimately producing IDisplayItem with ICodeFragment arrays.
+ */
+
+import { ICodeStatement } from '../models/CodeStatement';
+import { ICodeFragment, FragmentType } from '../models/CodeFragment';
+import { IDisplayItem, DisplayStatus } from '../models/DisplayItem';
+import { ExecutionSpan, SpanMetrics } from '../../runtime/models/ExecutionSpan';
+import { IRuntimeBlock } from '../../runtime/IRuntimeBlock';
+import { spanMetricsToFragments, metricsToFragments, createLabelFragment } from '../../runtime/utils/metricsToFragments';
+
+// ============================================================================
+// Statement Adapter
+// ============================================================================
+
+/**
+ * Convert a parsed CodeStatement to IDisplayItem
+ * 
+ * @param statement The parsed statement
+ * @param allStatements Map of all statements for depth calculation
+ * @param status Optional status override (default: 'pending')
+ */
+export function statementToDisplayItem(
+  statement: ICodeStatement,
+  allStatements: Map<number, ICodeStatement>,
+  status: DisplayStatus = 'pending'
+): IDisplayItem {
+  // Calculate depth by traversing parent chain
+  let depth = 0;
+  let currentId = statement.parent;
+  const visited = new Set<number>();
+  
+  while (currentId !== undefined && !visited.has(currentId)) {
+    visited.add(currentId);
+    const parent = allStatements.get(currentId);
+    if (!parent) break;
+    depth++;
+    currentId = parent.parent;
+    if (depth > 10) break; // Safety limit
+  }
+  
+  // Check if this is a linked statement (has lap fragment with '+')
+  const isLinked = statement.fragments.some(
+    f => f.fragmentType === FragmentType.Lap && f.image === '+'
+  );
+  
+  // Determine if this is a header (has children and certain fragment types)
+  const hasChildren = statement.children && statement.children.length > 0;
+  const hasTimerOrRounds = statement.fragments.some(
+    f => f.fragmentType === FragmentType.Timer || f.fragmentType === FragmentType.Rounds
+  );
+  const isHeader = hasChildren && hasTimerOrRounds;
+  
+  return {
+    id: statement.id.toString(),
+    parentId: statement.parent?.toString() ?? null,
+    fragments: statement.fragments,
+    depth,
+    isHeader,
+    isLinked,
+    status,
+    sourceType: 'statement',
+    sourceId: statement.id,
+    label: statement.fragments.map(f => f.image || '').join(' ').trim() || undefined
+  };
+}
+
+/**
+ * Convert an array of CodeStatements to IDisplayItem array
+ */
+export function statementsToDisplayItems(
+  statements: ICodeStatement[],
+  activeIds?: Set<number>
+): IDisplayItem[] {
+  const statementMap = new Map(statements.map(s => [s.id, s]));
+  
+  return statements.map(statement => {
+    const status: DisplayStatus = activeIds?.has(statement.id) ? 'active' : 'pending';
+    return statementToDisplayItem(statement, statementMap, status);
+  });
+}
+
+// ============================================================================
+// ExecutionSpan Adapter
+// ============================================================================
+
+/**
+ * Header types that should render with header styling
+ */
+const HEADER_TYPES = new Set([
+  'root', 'round', 'interval', 'warmup', 'cooldown', 
+  'amrap', 'emom', 'tabata', 'group', 'start'
+]);
+
+/**
+ * Convert an ExecutionSpan to IDisplayItem
+ * 
+ * @param span The execution span
+ * @param allSpans Map of all spans for depth calculation
+ */
+export function spanToDisplayItem(
+  span: ExecutionSpan,
+  allSpans: Map<string, ExecutionSpan>
+): IDisplayItem {
+  // Calculate depth by traversing parent chain
+  let depth = 0;
+  let currentParentId = span.parentSpanId;
+  const visited = new Set<string>();
+  visited.add(span.id);
+  
+  while (currentParentId && !visited.has(currentParentId)) {
+    visited.add(currentParentId);
+    const parent = allSpans.get(currentParentId);
+    if (!parent) break;
+    depth++;
+    currentParentId = parent.parentSpanId;
+    if (depth > 20) break; // Safety limit
+  }
+  
+  // Convert span metrics to fragments
+  const fragments = spanMetricsToFragments(
+    span.metrics,
+    span.label,
+    span.type
+  );
+  
+  // Map span status to display status
+  const status: DisplayStatus = span.status as DisplayStatus;
+  
+  // Determine if header based on type
+  const isHeader = HEADER_TYPES.has(span.type.toLowerCase());
+  
+  return {
+    id: span.id,
+    parentId: span.parentSpanId,
+    fragments,
+    depth,
+    isHeader,
+    status,
+    sourceType: 'span',
+    sourceId: span.blockId,
+    startTime: span.startTime,
+    endTime: span.endTime,
+    duration: span.endTime ? span.endTime - span.startTime : undefined,
+    label: span.label
+  };
+}
+
+/**
+ * Convert an array of ExecutionSpans to IDisplayItem array
+ */
+export function spansToDisplayItems(spans: ExecutionSpan[]): IDisplayItem[] {
+  const spanMap = new Map(spans.map(s => [s.id, s]));
+  return spans.map(span => spanToDisplayItem(span, spanMap));
+}
+
+// ============================================================================
+// RuntimeBlock Adapter (for active stack)
+// ============================================================================
+
+/**
+ * Convert an IRuntimeBlock to IDisplayItem
+ * 
+ * @param block The runtime block
+ * @param stackIndex Index in the runtime stack (used for depth)
+ * @param startTime Block start time
+ */
+export function blockToDisplayItem(
+  block: IRuntimeBlock,
+  stackIndex: number,
+  startTime?: number
+): IDisplayItem {
+  // Extract fragments from compiled metrics if available
+  let fragments: ICodeFragment[] = [];
+  
+  if (block.compiledMetrics) {
+    fragments = metricsToFragments([block.compiledMetrics]);
+  }
+  
+  // Fallback to label fragment if no metrics
+  if (fragments.length === 0 && block.label) {
+    fragments = [createLabelFragment(block.label, block.blockType || 'group')];
+  }
+  
+  const isHeader = HEADER_TYPES.has((block.blockType || '').toLowerCase());
+  
+  return {
+    id: block.key.toString(),
+    parentId: stackIndex > 0 ? null : null, // Stack doesn't track parent directly
+    fragments,
+    depth: stackIndex,
+    isHeader,
+    status: 'active',
+    sourceType: 'block',
+    sourceId: block.key.toString(),
+    startTime,
+    label: block.label
+  };
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Sort display items by start time (oldest first)
+ */
+export function sortByStartTime(items: IDisplayItem[]): IDisplayItem[] {
+  return [...items].sort((a, b) => (a.startTime || 0) - (b.startTime || 0));
+}
+
+/**
+ * Sort display items by start time (newest first)
+ */
+export function sortByStartTimeDesc(items: IDisplayItem[]): IDisplayItem[] {
+  return [...items].sort((a, b) => (b.startTime || 0) - (a.startTime || 0));
+}
+
+/**
+ * Group linked items together
+ */
+export function groupLinkedItems(items: IDisplayItem[]): (IDisplayItem | IDisplayItem[])[] {
+  const result: (IDisplayItem | IDisplayItem[])[] = [];
+  let currentGroup: IDisplayItem[] = [];
+  
+  for (const item of items) {
+    if (currentGroup.length === 0) {
+      currentGroup.push(item);
+      continue;
+    }
+    
+    const previousItem = currentGroup[currentGroup.length - 1];
+    
+    // Only group if BOTH are linked
+    if (item.isLinked && previousItem.isLinked) {
+      currentGroup.push(item);
+    } else {
+      // Close previous group
+      if (currentGroup.length === 1) {
+        result.push(currentGroup[0]);
+      } else {
+        result.push([...currentGroup]);
+      }
+      currentGroup = [item];
+    }
+  }
+  
+  // Push remaining
+  if (currentGroup.length === 1) {
+    result.push(currentGroup[0]);
+  } else if (currentGroup.length > 1) {
+    result.push([...currentGroup]);
+  }
+  
+  return result;
+}
+```
+
+---
+
+## Phase 3: Create Unified Components
+
+### Step 3.1: Create UnifiedItemRow Component
+
+Create the file `src/components/unified/UnifiedItemRow.tsx`:
+
+```typescript
+/**
+ * UnifiedItemRow.tsx - Single item row for unified visualization
+ * 
+ * Renders any IDisplayItem consistently, using FragmentVisualizer for
+ * the core visual content. Supports both regular rows and header rows.
+ */
+
+import React from 'react';
+import { cn } from '@/lib/utils';
+import { FragmentVisualizer } from '@/views/runtime/FragmentVisualizer';
+import { IDisplayItem, isActiveItem, isCompletedItem } from '@/core/models/DisplayItem';
+
+export interface UnifiedItemRowProps {
+  /** The item to display */
+  item: IDisplayItem;
+  
+  /** Whether this item is currently selected */
+  isSelected?: boolean;
+  
+  /** Whether this item is highlighted (e.g., on hover) */
+  isHighlighted?: boolean;
+  
+  /** Compact mode for tighter displays */
+  compact?: boolean;
+  
+  /** Whether to show timestamp */
+  showTimestamp?: boolean;
+  
+  /** Whether to show duration */
+  showDuration?: boolean;
+  
+  /** Whether this is part of a grouped display (no outer border) */
+  isGrouped?: boolean;
+  
+  /** Whether this is the last item in a group */
+  isLastInGroup?: boolean;
+  
+  /** Additional actions to render on the right */
+  actions?: React.ReactNode;
+  
+  /** Click handler */
+  onClick?: () => void;
+  
+  /** Hover handlers */
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+  
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Format timestamp for display
+ */
+function formatTimestamp(timestamp: number): string {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString([], { 
+    hour: '2-digit', 
+    minute: '2-digit', 
+    second: '2-digit' 
+  });
+}
+
+/**
+ * Format duration for display
+ */
+function formatDuration(ms: number): string {
+  if (!ms) return '';
+  const seconds = Math.floor(ms / 1000);
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  if (mins > 0) return `${mins}m ${secs}s`;
+  return `${secs}s`;
+}
+
+/**
+ * Get status indicator color class
+ */
+function getStatusColor(item: IDisplayItem): string {
+  switch (item.status) {
+    case 'active':
+      return 'bg-primary animate-pulse';
+    case 'completed':
+      return 'bg-green-500';
+    case 'failed':
+      return 'bg-red-500';
+    case 'skipped':
+      return 'bg-yellow-500';
+    default:
+      return 'bg-gray-400';
+  }
+}
+
+export const UnifiedItemRow: React.FC<UnifiedItemRowProps> = ({
+  item,
+  isSelected = false,
+  isHighlighted = false,
+  compact = false,
+  showTimestamp = false,
+  showDuration = false,
+  isGrouped = false,
+  isLastInGroup = false,
+  actions,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+  className
+}) => {
+  const indentSize = 16;
+  const indentStyle = { paddingLeft: `${item.depth * indentSize}px` };
+  
+  // Header rendering
+  if (item.isHeader) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col py-2 mt-2 mb-1 border-b border-border/50 select-none transition-colors",
+          isActiveItem(item) && "bg-muted/30",
+          isSelected && "bg-primary/10",
+          isHighlighted && "bg-accent/10",
+          onClick && "cursor-pointer",
+          className
+        )}
+        style={indentStyle}
+        onClick={onClick}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+      >
+        {showTimestamp && item.startTime && (
+          <div className="flex items-center gap-2 text-muted-foreground mb-1">
+            <span className="text-xs font-mono opacity-70">
+              {formatTimestamp(item.startTime)}
+            </span>
+            <div className="h-px bg-border flex-1 opacity-50" />
+          </div>
+        )}
+        
+        <div className="flex items-center justify-between pl-2">
+          <div className="font-semibold text-sm text-foreground">
+            {item.label || 'Section'}
+          </div>
+          
+          {item.fragments.length > 0 && (
+            <div className="flex-1 ml-4 overflow-hidden">
+              <FragmentVisualizer 
+                fragments={item.fragments} 
+                compact={compact}
+                className="gap-1" 
+              />
+            </div>
+          )}
+          
+          {showDuration && item.duration !== undefined && (
+            <div className="text-xs font-mono text-muted-foreground ml-2">
+              {formatDuration(item.duration)}
+            </div>
+          )}
+          
+          {actions}
+        </div>
+      </div>
+    );
+  }
+  
+  // Regular row rendering
+  let containerClass = cn(
+    "flex items-center gap-2 transition-colors",
+    compact ? "py-1 px-1.5" : "p-2",
+    onClick && "cursor-pointer"
+  );
+  
+  if (isGrouped) {
+    containerClass = cn(
+      containerClass,
+      isActiveItem(item) ? 'bg-primary/10' : 'hover:bg-accent/5',
+      !isLastInGroup && "border-b border-border"
+    );
+  } else {
+    containerClass = cn(
+      containerClass,
+      "bg-card rounded border border-border hover:border-primary/50",
+      isActiveItem(item) && "bg-primary/10 border-primary",
+      isSelected && "ring-2 ring-primary",
+      isHighlighted && "bg-accent/10"
+    );
+  }
+  
+  return (
+    <div
+      className={cn(containerClass, className)}
+      style={!isGrouped ? indentStyle : undefined}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      {/* Status indicator */}
+      <div className={cn(
+        "w-2 h-2 rounded-full flex-shrink-0",
+        getStatusColor(item)
+      )} />
+      
+      {/* Timestamp */}
+      {showTimestamp && item.startTime && (
+        <span className="font-mono text-[10px] opacity-40 shrink-0 w-12 text-right">
+          {formatTimestamp(item.startTime)}
+        </span>
+      )}
+      
+      {/* Label (if present and no fragments) */}
+      {item.label && item.fragments.length === 0 && (
+        <span className={cn(
+          "truncate text-sm font-medium",
+          isCompletedItem(item) && "line-through opacity-60"
+        )}>
+          {item.label}
+        </span>
+      )}
+      
+      {/* Fragments */}
+      <div className="flex-1 min-w-0">
+        <FragmentVisualizer 
+          fragments={item.fragments} 
+          compact={compact}
+          className={compact ? "gap-0.5" : "gap-1"}
+        />
+      </div>
+      
+      {/* Duration */}
+      {showDuration && item.duration !== undefined && (
+        <div className="text-[10px] font-mono opacity-60 shrink-0 ml-2 w-10 text-right">
+          {formatDuration(item.duration)}
+        </div>
+      )}
+      
+      {/* Actions */}
+      {actions && (
+        <div className="flex gap-1 shrink-0">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UnifiedItemRow;
+```
+
+### Step 3.2: Create UnifiedItemList Component
+
+Create the file `src/components/unified/UnifiedItemList.tsx`:
+
+```typescript
+/**
+ * UnifiedItemList.tsx - List component for unified visualization
+ * 
+ * Renders a list of IDisplayItem objects with support for:
+ * - Hierarchical indentation
+ * - Linked item grouping
+ * - Active/selected highlighting
+ * - Auto-scroll to active items
+ */
+
+import React, { useRef, useEffect, useMemo } from 'react';
+import { cn } from '@/lib/utils';
+import { IDisplayItem } from '@/core/models/DisplayItem';
+import { UnifiedItemRow } from './UnifiedItemRow';
+import { groupLinkedItems } from '@/core/utils/displayItemAdapters';
+
+export interface UnifiedItemListProps {
+  /** Items to display */
+  items: IDisplayItem[];
+  
+  /** ID of currently active item */
+  activeItemId?: string | null;
+  
+  /** Set of selected item IDs */
+  selectedIds?: Set<string>;
+  
+  /** Whether to group linked items (+ statements) */
+  groupLinked?: boolean;
+  
+  /** Whether to auto-scroll to active item */
+  autoScroll?: boolean;
+  
+  /** Compact mode for tighter displays */
+  compact?: boolean;
+  
+  /** Whether to show timestamps */
+  showTimestamps?: boolean;
+  
+  /** Whether to show durations */
+  showDurations?: boolean;
+  
+  /** Callback when an item is clicked */
+  onSelect?: (id: string) => void;
+  
+  /** Callback when an item is hovered */
+  onHover?: (id: string | null) => void;
+  
+  /** Custom render function for actions */
+  renderActions?: (item: IDisplayItem) => React.ReactNode;
+  
+  /** Additional CSS classes */
+  className?: string;
+  
+  /** Empty state message */
+  emptyMessage?: string;
+}
+
+export const UnifiedItemList: React.FC<UnifiedItemListProps> = ({
+  items,
+  activeItemId,
+  selectedIds = new Set(),
+  groupLinked = false,
+  autoScroll = false,
+  compact = false,
+  showTimestamps = false,
+  showDurations = false,
+  onSelect,
+  onHover,
+  renderActions,
+  className,
+  emptyMessage = "No items to display"
+}) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  
+  // Group items if requested
+  const groupedItems = useMemo(() => {
+    if (!groupLinked) {
+      return items.map(item => item); // Return individual items
+    }
+    return groupLinkedItems(items);
+  }, [items, groupLinked]);
+  
+  // Auto-scroll to bottom when items change
+  useEffect(() => {
+    if (autoScroll && scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [items.length, autoScroll]);
+  
+  // Render a single item
+  const renderItem = (item: IDisplayItem, isGrouped = false, isLastInGroup = false) => {
+    const isActive = item.id === activeItemId;
+    const isSelected = selectedIds.has(item.id);
+    
+    return (
+      <UnifiedItemRow
+        key={item.id}
+        item={item}
+        isSelected={isSelected}
+        isHighlighted={isActive}
+        isGrouped={isGrouped}
+        isLastInGroup={isLastInGroup}
+        compact={compact}
+        showTimestamp={showTimestamps}
+        showDuration={showDurations}
+        onClick={() => onSelect?.(item.id)}
+        onMouseEnter={() => onHover?.(item.id)}
+        onMouseLeave={() => onHover?.(null)}
+        actions={renderActions?.(item)}
+      />
+    );
+  };
+  
+  // Empty state
+  if (items.length === 0) {
+    return (
+      <div className={cn("flex flex-col h-full bg-background", className)}>
+        <div className="p-4 text-sm text-muted-foreground italic text-center opacity-50">
+          {emptyMessage}
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className={cn("flex flex-col h-full bg-background", className)}>
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto custom-scrollbar px-2 py-2"
+      >
+        <div className="space-y-2">
+          {groupedItems.map((itemOrGroup, index) => {
+            // Handle grouped items
+            if (Array.isArray(itemOrGroup)) {
+              const group = itemOrGroup;
+              const firstItem = group[0];
+              const indentStyle = { marginLeft: `${firstItem.depth * 1.5}rem` };
+              
+              return (
+                <div 
+                  key={`group-${firstItem.id}`}
+                  style={indentStyle}
+                  className="bg-card rounded border border-border overflow-hidden hover:border-primary/50 transition-colors"
+                >
+                  {group.map((item, i) => 
+                    renderItem(item, true, i === group.length - 1)
+                  )}
+                </div>
+              );
+            }
+            
+            // Handle single item
+            const item = itemOrGroup;
+            const indentStyle = { marginLeft: `${item.depth * 1.5}rem` };
+            
+            return (
+              <div key={item.id} style={indentStyle}>
+                {renderItem(item)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UnifiedItemList;
+```
+
+### Step 3.3: Create Index Export
+
+Create the file `src/components/unified/index.ts`:
+
+```typescript
+/**
+ * Unified Visualization Components
+ * 
+ * These components provide consistent rendering for workout data
+ * across all contexts (parsing, execution, history).
+ */
+
+export { UnifiedItemRow, type UnifiedItemRowProps } from './UnifiedItemRow';
+export { UnifiedItemList, type UnifiedItemListProps } from './UnifiedItemList';
+```
+
+---
+
+## Phase 4: Testing & Stories
+
+### Step 4.1: Create Storybook Stories
+
+Create the file `stories/components/UnifiedVisualization.stories.tsx`:
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { UnifiedItemList, UnifiedItemRow } from '../../src/components/unified';
+import { IDisplayItem } from '../../src/core/models/DisplayItem';
+import { FragmentType } from '../../src/core/models/CodeFragment';
+
+const meta: Meta<typeof UnifiedItemList> = {
+  title: 'Components/Unified Visualization',
+  component: UnifiedItemList,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnifiedItemList>;
+
+// Sample items representing different states
+const sampleItems: IDisplayItem[] = [
+  {
+    id: '1',
+    parentId: null,
+    fragments: [
+      { type: 'timer', fragmentType: FragmentType.Timer, value: 300, image: '5:00' },
+      { type: 'action', fragmentType: FragmentType.Action, value: 'AMRAP', image: 'AMRAP' },
+    ],
+    depth: 0,
+    isHeader: true,
+    status: 'active',
+    sourceType: 'span',
+    sourceId: 'block-1',
+    startTime: Date.now() - 60000,
+    label: 'AMRAP 5:00',
+  },
+  {
+    id: '2',
+    parentId: '1',
+    fragments: [
+      { type: 'rep', fragmentType: FragmentType.Rep, value: 10, image: '10x' },
+      { type: 'effort', fragmentType: FragmentType.Effort, value: 'Pushups', image: 'Pushups' },
+    ],
+    depth: 1,
+    isHeader: false,
+    status: 'completed',
+    sourceType: 'span',
+    sourceId: 'block-2',
+    startTime: Date.now() - 50000,
+    duration: 15000,
+    label: '10 Pushups',
+  },
+  {
+    id: '3',
+    parentId: '1',
+    fragments: [
+      { type: 'rep', fragmentType: FragmentType.Rep, value: 15, image: '15x' },
+      { type: 'effort', fragmentType: FragmentType.Effort, value: 'Situps', image: 'Situps' },
+    ],
+    depth: 1,
+    isHeader: false,
+    status: 'active',
+    sourceType: 'span',
+    sourceId: 'block-3',
+    startTime: Date.now() - 35000,
+    label: '15 Situps',
+  },
+  {
+    id: '4',
+    parentId: '1',
+    fragments: [
+      { type: 'rep', fragmentType: FragmentType.Rep, value: 20, image: '20x' },
+      { type: 'effort', fragmentType: FragmentType.Effort, value: 'Squats', image: 'Squats' },
+    ],
+    depth: 1,
+    isHeader: false,
+    status: 'pending',
+    sourceType: 'span',
+    sourceId: 'block-4',
+    label: '20 Squats',
+  },
+];
+
+export const BasicList: Story = {
+  args: {
+    items: sampleItems,
+    activeItemId: '3',
+  },
+};
+
+export const WithTimestamps: Story = {
+  args: {
+    items: sampleItems,
+    activeItemId: '3',
+    showTimestamps: true,
+    showDurations: true,
+  },
+};
+
+export const CompactMode: Story = {
+  args: {
+    items: sampleItems,
+    activeItemId: '3',
+    compact: true,
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    items: [],
+    emptyMessage: 'Start a workout to see execution history',
+  },
+};
+```
+
+---
+
+## Phase 5: Migration Guide
+
+### Migrating RuntimeHistoryLog
+
+Replace the current implementation with the unified components:
+
+```typescript
+// src/components/history/RuntimeHistoryLog.tsx
+
+import React, { useMemo, useEffect, useState } from 'react';
+import { ScriptRuntime } from '@/runtime/ScriptRuntime';
+import { UnifiedItemList } from '@/components/unified';
+import { spansToDisplayItems } from '@/core/utils/displayItemAdapters';
+
+export interface RuntimeHistoryLogProps {
+  runtime: ScriptRuntime | null;
+  activeStatementIds?: Set<number>;
+  highlightedBlockKey?: string | null;
+  autoScroll?: boolean;
+  className?: string;
+}
+
+export const RuntimeHistoryLog: React.FC<RuntimeHistoryLogProps> = ({
+  runtime,
+  highlightedBlockKey,
+  autoScroll = true,
+  className
+}) => {
+  const [updateVersion, setUpdateVersion] = useState(0);
+
+  useEffect(() => {
+    if (!runtime) return;
+    const unsubscribe = runtime.memory.subscribe(() => setUpdateVersion(v => v + 1));
+    const intervalId = setInterval(() => setUpdateVersion(v => v + 1), 100);
+    return () => {
+      unsubscribe();
+      clearInterval(intervalId);
+    };
+  }, [runtime]);
+
+  const { items, activeItemId } = useMemo(() => {
+    if (!runtime) return { items: [], activeItemId: null };
+    void updateVersion;
+
+    // Combine completed and active spans
+    const allSpans = [
+      ...runtime.executionLog,
+      ...Array.from(runtime.activeSpans.values())
+    ].sort((a, b) => a.startTime - b.startTime);
+
+    // Convert to display items
+    const items = spansToDisplayItems(allSpans);
+
+    // Find active item
+    const activeItems = items.filter(i => i.status === 'active');
+    const activeItemId = activeItems.length > 0 
+      ? activeItems[activeItems.length - 1].id 
+      : null;
+
+    return { items, activeItemId };
+  }, [runtime, updateVersion]);
+
+  return (
+    <UnifiedItemList
+      items={items}
+      activeItemId={activeItemId || highlightedBlockKey}
+      autoScroll={autoScroll}
+      showTimestamps
+      showDurations
+      className={className}
+      emptyMessage="No events recorded"
+    />
+  );
+};
+```
+
+### Migrating WodScriptVisualizer
+
+Replace with unified components:
+
+```typescript
+// src/components/WodScriptVisualizer.tsx
+
+import React, { useMemo } from 'react';
+import { ICodeStatement } from '../core/models/CodeStatement';
+import { IDisplayItem } from '../core/models/DisplayItem';
+import { UnifiedItemList } from './unified';
+import { statementsToDisplayItems } from '@/core/utils/displayItemAdapters';
+
+export interface WodScriptVisualizerProps {
+  statements: ICodeStatement[];
+  activeStatementIds?: Set<number>;
+  selectedStatementId?: number | null;
+  onSelectionChange?: (id: number | null) => void;
+  onHover?: (id: number | null) => void;
+  /** Custom action renderer for each display item */
+  renderActions?: (item: IDisplayItem) => React.ReactNode;
+  className?: string;
+}
+
+export const WodScriptVisualizer: React.FC<WodScriptVisualizerProps> = ({
+  statements,
+  activeStatementIds = new Set(),
+  selectedStatementId,
+  onSelectionChange,
+  onHover,
+  renderActions,
+  className = ''
+}) => {
+  const items = useMemo(() => {
+    return statementsToDisplayItems(statements, activeStatementIds);
+  }, [statements, activeStatementIds]);
+
+  const selectedIds = useMemo(() => {
+    return selectedStatementId !== undefined && selectedStatementId !== null
+      ? new Set([selectedStatementId.toString()])
+      : new Set<string>();
+  }, [selectedStatementId]);
+
+  return (
+    <UnifiedItemList
+      items={items}
+      selectedIds={selectedIds}
+      groupLinked
+      onSelect={(id) => onSelectionChange?.(parseInt(id))}
+      onHover={(id) => onHover?.(id ? parseInt(id) : null)}
+      renderActions={renderActions}
+      className={className}
+    />
+  );
+};
+```
+
+---
+
+## Verification Checklist
+
+After implementation, verify:
+
+- [ ] FragmentVisualizer colors are consistent across all views
+- [ ] Parser view shows statements with proper indentation
+- [ ] Execution history shows spans with correct status indicators
+- [ ] Active items are highlighted correctly
+- [ ] Linked items group properly in parser view
+- [ ] Auto-scroll works in history view
+- [ ] Compact mode reduces spacing appropriately
+- [ ] Empty states display correctly
+- [ ] Timestamps and durations format correctly
+- [ ] Storybook stories render without errors
+
+---
+
+## Rollback Plan
+
+If issues arise:
+
+1. The original components remain in place until migration is complete
+2. New unified components are additive - they don't replace existing code initially
+3. Migration can be done one component at a time
+4. Adapter functions can be tested independently before component migration

--- a/docs/deep-dives/unified-visualization-system.md
+++ b/docs/deep-dives/unified-visualization-system.md
@@ -1,0 +1,634 @@
+# Unified Visualization System Deep Dive
+
+This document provides an in-depth analysis of how different data types (CodeStatements, RuntimeMetrics, ExecutionSpans, RuntimeBlocks) are currently bound to UI components in WOD Wiki, and presents a roadmap for creating a unified visualization component set that allows consistent display across all contexts.
+
+## Table of Contents
+
+1. [Problem Statement](#problem-statement)
+2. [Current Data Types Overview](#current-data-types-overview)
+3. [Current UI Components](#current-ui-components)
+4. [Data Flow Analysis](#data-flow-analysis)
+5. [Component Binding Patterns](#component-binding-patterns)
+6. [Unified Visualization Architecture](#unified-visualization-architecture)
+7. [Implementation Guide](#implementation-guide)
+
+---
+
+## Problem Statement
+
+The WOD Wiki application currently has three main contexts where workout data needs to be visualized:
+
+1. **Parser View (Edit Mode)**: Displays parsed `CodeStatement` objects with their fragments
+2. **Active Execution (Track Mode)**: Shows active runtime blocks and their metrics in real-time
+3. **History/Analytics (Analyze Mode)**: Displays completed execution records and metrics for comparison
+
+Each context currently uses different components with varying implementations, leading to:
+- Inconsistent visual presentation
+- Duplicated rendering logic
+- Difficulty in comparing data across contexts
+- Maintenance overhead when updating visualization styles
+
+**Goal**: Create a unified visualization component set that can represent:
+- Code statements (parsed workout definitions)
+- Runtime block metrics (active execution state)
+- Execution history records (completed blocks with collected metrics)
+
+All displayed in a visually consistent way regardless of the source data type.
+
+---
+
+## Current Data Types Overview
+
+### 1. ICodeStatement (Parser Output)
+
+```typescript
+// src/core/models/CodeStatement.ts
+interface ICodeStatement {
+  id: number;
+  parent?: number;
+  children: number[][];
+  fragments: ICodeFragment[];
+  isLeaf?: boolean;
+  meta: CodeMetadata;
+  hints?: Set<string>;
+}
+```
+
+**Source**: Chevrotain parser output from `src/parser/`
+**Usage**: Represents parsed workout script lines
+**Key Property**: `fragments: ICodeFragment[]` - contains the visual/semantic data
+
+### 2. ICodeFragment (Visual Unit)
+
+```typescript
+// src/core/models/CodeFragment.ts
+interface ICodeFragment {
+  readonly image?: string;       // Display text
+  readonly value?: any;          // Parsed value
+  readonly type: string;         // Fragment type string
+  readonly meta?: CodeMetadata;
+  readonly fragmentType: FragmentType;
+}
+
+enum FragmentType {
+  Timer = 'timer',
+  Rep = 'rep',
+  Effort = 'effort',
+  Distance = 'distance',
+  Rounds = 'rounds',
+  Action = 'action',
+  Increment = 'increment',
+  Lap = 'lap',
+  Text = 'text',
+  Resistance = 'resistance'
+}
+```
+
+**Purpose**: The fundamental visual unit - represents a single piece of workout information
+**Usage**: Used by `FragmentVisualizer` to render color-coded tags
+
+### 3. RuntimeMetric (Execution Metrics)
+
+```typescript
+// src/runtime/RuntimeMetric.ts
+interface RuntimeMetric {
+  exerciseId: string;
+  values: MetricValue[];
+  timeSpans: TimeSpan[];
+}
+
+type MetricValue = {
+  type: "repetitions" | "resistance" | "distance" | "timestamp" | "rounds" | "time" | "calories" | "action" | "effort" | "heart_rate" | "cadence" | "power";
+  value: number | undefined;
+  unit: string;
+};
+```
+
+**Source**: Generated during runtime execution
+**Usage**: Tracks performance data for blocks
+
+### 4. ExecutionSpan (Unified Execution Model)
+
+```typescript
+// src/runtime/models/ExecutionSpan.ts
+interface ExecutionSpan {
+  id: string;
+  blockId: string;
+  parentSpanId: string | null;
+  type: SpanType;  // 'timer' | 'rounds' | 'effort' | 'group' | 'interval' | 'emom' | 'amrap' | 'tabata'
+  label: string;
+  status: SpanStatus;  // 'active' | 'completed' | 'failed' | 'skipped'
+  startTime: number;
+  endTime?: number;
+  metrics: SpanMetrics;
+  segments: TimeSegment[];
+  sourceIds?: number[];
+  debugMetadata?: DebugMetadata;
+}
+
+interface SpanMetrics {
+  exerciseId?: string;
+  reps?: MetricValueWithTimestamp<number>;
+  weight?: MetricValueWithTimestamp<number>;
+  distance?: MetricValueWithTimestamp<number>;
+  duration?: MetricValueWithTimestamp<number>;
+  currentRound?: number;
+  totalRounds?: number;
+  repScheme?: number[];
+  // ... more metrics
+}
+```
+
+**Source**: Created when blocks execute
+**Usage**: Unified model for tracking execution history and current state
+
+### 5. IRuntimeBlock (Execution Unit)
+
+```typescript
+// src/runtime/IRuntimeBlock.ts
+interface IRuntimeBlock {
+  readonly key: BlockKey;
+  readonly sourceIds: number[];
+  readonly blockType?: string;
+  readonly label: string;
+  readonly compiledMetrics?: RuntimeMetric;
+  readonly context: IBlockContext;
+  // ... lifecycle methods
+}
+```
+
+**Source**: JIT compiled from statements
+**Usage**: Active execution unit on the runtime stack
+
+---
+
+## Current UI Components
+
+### 1. FragmentVisualizer (Core Visual Unit)
+
+**Location**: `src/views/runtime/FragmentVisualizer.tsx`
+
+**Purpose**: Renders an array of `ICodeFragment` objects as color-coded tags
+
+**Input**: `fragments: ICodeFragment[]`
+
+**Visual Output**: Horizontal row of colored tags with icons
+
+```tsx
+<FragmentVisualizer fragments={statement.fragments} />
+// Renders: [⏱️ 5:00] [×10] [🏃 Pushups] [💪 95lb]
+```
+
+**Color Map**: `src/views/runtime/fragmentColorMap.ts`
+- Timer: Blue
+- Rep: Green
+- Effort: Yellow
+- Distance: Teal
+- Rounds: Purple
+- Action: Pink
+- Increment: Indigo
+- Lap: Orange
+- Text: Gray
+- Resistance: Red
+
+### 2. WodScriptVisualizer (Statement List)
+
+**Location**: `src/components/WodScriptVisualizer.tsx`
+
+**Purpose**: Renders a list of `ICodeStatement` objects with hierarchy and grouping
+
+**Input**: 
+```typescript
+interface WodScriptVisualizerProps {
+  statements: ICodeStatement[];
+  activeStatementIds?: Set<number>;
+  selectedStatementId?: number | null;
+  onSelectionChange?: (id: number | null) => void;
+  onHover?: (id: number | null) => void;
+  onRenderActions?: (statement: ICodeStatement) => React.ReactNode;
+}
+```
+
+**Features**:
+- Groups linked statements (+ prefix)
+- Calculates and applies indentation
+- Highlights active/selected states
+- Uses `FragmentVisualizer` for each statement
+
+### 3. StatementDisplay & BlockDisplay
+
+**Location**: `src/components/fragments/StatementDisplay.tsx`
+
+**Purpose**: Unified wrapper components for statements and blocks
+
+```tsx
+// For code statements
+<StatementDisplay 
+  statement={stmt}
+  isActive={isActive}
+  isGrouped={isGrouped}
+  compact={compact}
+  actions={actions}
+/>
+
+// For runtime blocks
+<BlockDisplay
+  label={block.label}
+  blockType={block.blockType}
+  metrics={metrics}
+  status={status}
+  depth={depth}
+  isActive={isActive}
+/>
+```
+
+### 4. HistoryRow & HistoryList
+
+**Location**: `src/components/history/`
+
+**Purpose**: Renders execution history items
+
+**Input**:
+```typescript
+interface HistoryItem {
+  id: string;
+  label: string;
+  startTime: number;
+  endTime?: number;
+  type: string;
+  depth: number;
+  fragments: ICodeFragment[];
+  isHeader: boolean;
+  status: 'active' | 'completed' | 'failed' | 'skipped';
+}
+```
+
+**Note**: Converts `SpanMetrics` to `ICodeFragment[]` via `spanMetricsToFragments()`
+
+### 5. MetricsTreeView
+
+**Location**: `src/components/metrics/MetricsTreeView.tsx`
+
+**Purpose**: Tree visualization with connecting lines
+
+**Input**:
+```typescript
+interface MetricItem {
+  id: string;
+  parentId: string | null;
+  lane: number;
+  title: string;
+  icon?: React.ReactNode;
+  tags?: React.ReactNode;
+  footer?: React.ReactNode;
+  status?: 'active' | 'completed' | 'pending';
+  startTime?: number;
+  isHeading?: boolean;
+}
+```
+
+---
+
+## Data Flow Analysis
+
+### Parser View Flow
+
+```
+WodScript Text
+    ↓ (Lexer + Parser)
+ICodeStatement[]
+    ↓ (WodScriptVisualizer)
+For each statement:
+    ↓ (FragmentVisualizer)
+[Colored Fragment Tags]
+```
+
+### Runtime Execution Flow
+
+```
+ICodeStatement[]
+    ↓ (JitCompiler)
+IRuntimeBlock
+    ↓ (Push to Stack)
+Block.mount() → Creates ExecutionSpan
+    ↓ (Behaviors update SpanMetrics)
+SpanMetrics updated in memory
+    ↓ (RuntimeHistoryLog subscribes)
+spanMetricsToFragments(metrics)
+    ↓ (HistoryRow)
+[Colored Fragment Tags]
+```
+
+### History/Analytics Flow
+
+```
+ScriptRuntime.executionLog (ExecutionSpan[])
+    ↓ (RuntimeHistoryLog)
+Convert to HistoryItem[]
+    ↓ (HistoryList → HistoryRow)
+    ↓ (FragmentVisualizer)
+[Colored Fragment Tags]
+```
+
+---
+
+## Component Binding Patterns
+
+### Pattern 1: Direct Fragment Binding
+
+**Used by**: ParsedView, WodScriptVisualizer
+
+```typescript
+// Data already has fragments
+const statement: ICodeStatement = {
+  fragments: [...ICodeFragment[]]
+};
+
+<FragmentVisualizer fragments={statement.fragments} />
+```
+
+### Pattern 2: Metrics-to-Fragments Conversion
+
+**Used by**: RuntimeHistoryLog, HistoryRow
+
+```typescript
+// Convert metrics to fragments
+import { spanMetricsToFragments } from '@/runtime/utils/metricsToFragments';
+
+const fragments = spanMetricsToFragments(span.metrics, span.label, span.type);
+
+<FragmentVisualizer fragments={fragments} />
+```
+
+### Pattern 3: Custom Item Rendering
+
+**Used by**: MetricsTreeView, AnalyticsHistoryPanel
+
+```typescript
+// Custom rendering with renderItem callback
+const items: MetricItem[] = segments.map(seg => ({
+  id: seg.id.toString(),
+  title: seg.name,
+  tags: <CustomTagsComponent />,  // Manual fragment rendering
+  // ...
+}));
+
+<MetricsTreeView items={items} renderItem={customRenderer} />
+```
+
+---
+
+## Unified Visualization Architecture
+
+### Core Principle: Fragment-First Design
+
+All data types should ultimately be represented as `ICodeFragment[]` for visualization. This ensures:
+
+1. **Consistent Colors**: Same fragment type = same color everywhere
+2. **Consistent Icons**: Same fragment type = same icon everywhere
+3. **Single Point of Customization**: Update `fragmentColorMap.ts` to change all views
+
+### Proposed Unified Data Model
+
+```typescript
+// src/core/models/UnifiedDisplayItem.ts
+
+/**
+ * Unified display item that can represent any workout data
+ * regardless of its original source (parsed, active, historical)
+ */
+export interface IDisplayItem {
+  // Identity
+  id: string;
+  parentId: string | null;
+  
+  // Visual Content (THE KEY: everything becomes fragments)
+  fragments: ICodeFragment[];
+  
+  // Layout
+  depth: number;           // Nesting level for indentation
+  isHeader: boolean;       // Header vs content row styling
+  
+  // State
+  status: DisplayStatus;   // 'pending' | 'active' | 'completed' | 'failed'
+  
+  // Metadata (for tooltips, debugging)
+  sourceType: 'statement' | 'block' | 'span' | 'record';
+  sourceId: number | string;
+  
+  // Optional timing
+  timestamp?: number;
+  duration?: number;
+}
+
+export type DisplayStatus = 'pending' | 'active' | 'completed' | 'failed';
+```
+
+### Proposed Unified Components
+
+#### 1. `UnifiedItemRow` - Single Item Display
+
+```typescript
+interface UnifiedItemRowProps {
+  item: IDisplayItem;
+  isSelected?: boolean;
+  isHighlighted?: boolean;
+  compact?: boolean;
+  showTimestamp?: boolean;
+  showDuration?: boolean;
+  actions?: React.ReactNode;
+  onClick?: () => void;
+}
+```
+
+#### 2. `UnifiedItemList` - List of Items
+
+```typescript
+interface UnifiedItemListProps {
+  items: IDisplayItem[];
+  activeItemId?: string;
+  selectedIds?: Set<string>;
+  groupLinkedItems?: boolean;  // For parser view grouping
+  showConnectors?: boolean;    // For tree view lines
+  autoScroll?: boolean;
+  onSelect?: (id: string) => void;
+  onHover?: (id: string | null) => void;
+}
+```
+
+#### 3. Adapter Functions
+
+```typescript
+// Convert CodeStatement to IDisplayItem
+function statementToDisplayItem(
+  statement: ICodeStatement,
+  allStatements: Map<number, ICodeStatement>,
+  status?: DisplayStatus
+): IDisplayItem;
+
+// Convert ExecutionSpan to IDisplayItem
+function spanToDisplayItem(
+  span: ExecutionSpan,
+  allSpans: Map<string, ExecutionSpan>
+): IDisplayItem;
+
+// Convert IRuntimeBlock to IDisplayItem (for active stack)
+function blockToDisplayItem(
+  block: IRuntimeBlock,
+  stackIndex: number,
+  runtime: IScriptRuntime
+): IDisplayItem;
+```
+
+---
+
+## Implementation Guide
+
+### Phase 1: Create Unified Data Model (Low Risk)
+
+**Files to Create**:
+- `src/core/models/DisplayItem.ts` - Interface and type definitions
+
+**Steps**:
+1. Define `IDisplayItem` interface
+2. Add `DisplayStatus` type
+3. Export from core module index
+
+### Phase 2: Create Adapter Functions (Low Risk)
+
+**Files to Create**:
+- `src/core/adapters/displayItemAdapters.ts`
+
+**Steps**:
+1. Implement `statementToDisplayItem()` - wraps existing statement fragments
+2. Implement `spanToDisplayItem()` - uses existing `spanMetricsToFragments()`
+3. Implement `blockToDisplayItem()` - extracts fragments from block metrics
+4. Add tests for adapters
+
+### Phase 3: Create Unified Components (Medium Risk)
+
+**Files to Create**:
+- `src/components/unified/UnifiedItemRow.tsx`
+- `src/components/unified/UnifiedItemList.tsx`
+- `src/components/unified/index.ts`
+
+**Steps**:
+1. Create `UnifiedItemRow` based on existing `HistoryRow` patterns
+2. Create `UnifiedItemList` with support for:
+   - Grouping (from WodScriptVisualizer)
+   - Tree connectors (from MetricsTreeView)
+   - Auto-scroll (from HistoryList)
+3. Ensure existing `FragmentVisualizer` is reused
+4. Create Storybook stories for testing
+
+### Phase 4: Migrate Existing Views (Higher Risk)
+
+**Files to Update** (one at a time):
+1. `src/components/history/RuntimeHistoryLog.tsx` → Use UnifiedItemList
+2. `src/components/WodScriptVisualizer.tsx` → Use UnifiedItemList
+3. `src/components/workout/AnalyticsHistoryPanel.tsx` → Use UnifiedItemList
+
+**Migration Strategy**:
+1. Update one component at a time
+2. Run Storybook visual regression tests
+3. Ensure no breaking changes to existing props/API
+
+### Phase 5: Documentation and Cleanup
+
+**Files to Create/Update**:
+- `docs/unified-visualization-guide.md` - Usage guide for new components
+- Update component Storybook stories
+- Add migration notes for deprecated patterns
+
+---
+
+## Code Changes Summary
+
+### New Files Required
+
+```
+src/
+├── core/
+│   ├── models/
+│   │   └── DisplayItem.ts        # IDisplayItem interface
+│   └── adapters/
+│       └── displayItemAdapters.ts # Conversion functions
+└── components/
+    └── unified/
+        ├── index.ts
+        ├── UnifiedItemRow.tsx
+        └── UnifiedItemList.tsx
+```
+
+### Files to Modify (Eventually)
+
+```
+src/components/
+├── WodScriptVisualizer.tsx        # Migrate to UnifiedItemList
+├── history/
+│   └── RuntimeHistoryLog.tsx      # Migrate to UnifiedItemList
+└── workout/
+    └── AnalyticsHistoryPanel.tsx  # Migrate to UnifiedItemList
+```
+
+### Shared Dependencies (No Changes Needed)
+
+```
+src/views/runtime/
+├── FragmentVisualizer.tsx         # Reused as-is
+└── fragmentColorMap.ts            # Reused as-is
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Adapter Functions**: Test conversion of each data type to `IDisplayItem`
+2. **Fragment Generation**: Ensure fragments are correctly generated for all metric types
+
+### Visual Tests (Storybook)
+
+1. Create stories showing same workout in all three contexts
+2. Verify visual consistency between Parser, Track, and Analyze views
+
+### Integration Tests
+
+1. End-to-end test parsing → execution → history display
+2. Verify data flows correctly through all adapters
+
+---
+
+## Appendix: Existing Utility Functions
+
+### metricsToFragments.ts Functions
+
+```typescript
+// Convert RuntimeMetric[] to ICodeFragment[]
+export function metricsToFragments(metrics: RuntimeMetric[]): ICodeFragment[];
+
+// Convert SpanMetrics to ICodeFragment[]
+export function spanMetricsToFragments(
+  metrics: SpanMetrics,
+  label: string,
+  type: string
+): ICodeFragment[];
+
+// Create fallback fragment from label
+export function createLabelFragment(label: string, type: string): ICodeFragment;
+```
+
+These existing functions should be leveraged by the new adapter layer.
+
+### fragmentColorMap.ts
+
+```typescript
+// Get Tailwind classes for fragment type
+export function getFragmentColorClasses(type: string): string;
+
+// Fragment type definitions
+export const fragmentColorMap: FragmentColorMap;
+```
+
+This remains the single source of truth for fragment styling.

--- a/docs/plans/2026-04-28-collection-import-pull.md
+++ b/docs/plans/2026-04-28-collection-import-pull.md
@@ -1,0 +1,822 @@
+# Collection Import (Pull) Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a pull mechanism so users can import WOD blocks from any collection *or* any existing history entry into the current journal note via the command palette (Cmd+K), without leaving the editor.
+
+**Architecture:**
+- Three-level command palette flow using strategy-swapping: Collection/Source → Workout/Entry → WOD Block → import
+- New `extractWodBlocks()` utility parses raw markdown for ` ```wod ``` ` fences
+- New `CollectionImportStrategy` and `HistoryImportStrategy` classes implement `CommandStrategy`
+- `PlanPanel` (journal editor) registers a keyboard shortcut (`Cmd+Shift+I`) that opens the palette with the import strategy active
+- History entries are treated as first-class sources identical to collection items
+
+**Tech Stack:** TypeScript, React, `cmdk`, existing `CommandStrategy` interface, `getWodCollections()`, `IContentProvider`
+
+**Branch:** `feat/collection-import-pull` off `main`
+
+---
+
+## Setup
+
+### Task 0: Create the branch
+
+```bash
+cd /home/serge/projects/wod-wiki/wod-wiki
+git checkout main && git pull origin main
+git checkout -b feat/collection-import-pull
+```
+
+Verify: `git branch --show-current` → `feat/collection-import-pull`
+
+---
+
+## Phase 1 — WOD Block Extraction Utility
+
+### Task 1: Create `extractWodBlocks` utility
+
+**Objective:** Parse raw markdown and return each ` ```wod ``` ` fenced block as a structured object.
+
+**Files:**
+- Create: `wod-wiki-e2e/src/lib/wodBlockExtract.ts`
+- Create: `wod-wiki-e2e/src/lib/wodBlockExtract.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+// wod-wiki-e2e/src/lib/wodBlockExtract.test.ts
+import { extractWodBlocks } from './wodBlockExtract';
+
+const FRAN_MD = `
+# Fran
+
+Classic CrossFit benchmark.
+
+\`\`\`wod
+21-15-9
+Thrusters 95/65lb
+Pull-ups
+\`\`\`
+`;
+
+const MULTI_MD = `
+# Two WODs
+
+\`\`\`wod
+10 rounds
+10 push-ups
+\`\`\`
+
+Some text.
+
+\`\`\`crossfit
+3 rounds
+400m run
+\`\`\`
+`;
+
+describe('extractWodBlocks', () => {
+  it('extracts a single block', () => {
+    const blocks = extractWodBlocks(FRAN_MD);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].dialect).toBe('wod');
+    expect(blocks[0].content).toContain('Thrusters');
+  });
+
+  it('labels block from preceding heading', () => {
+    const blocks = extractWodBlocks(FRAN_MD);
+    expect(blocks[0].label).toBe('Fran');
+  });
+
+  it('extracts multiple blocks with different dialects', () => {
+    const blocks = extractWodBlocks(MULTI_MD);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1].dialect).toBe('crossfit');
+  });
+
+  it('returns empty array for markdown with no wod fences', () => {
+    expect(extractWodBlocks('# Just text\nNo blocks here.')).toHaveLength(0);
+  });
+});
+```
+
+**Step 2: Run to verify failure**
+
+```bash
+cd /home/serge/projects/wod-wiki/wod-wiki-e2e
+bun test src/lib/wodBlockExtract.test.ts
+```
+
+Expected: FAIL — module not found.
+
+**Step 3: Implement**
+
+```ts
+// wod-wiki-e2e/src/lib/wodBlockExtract.ts
+
+export interface WodBlockExtract {
+  /** Index-based ID, e.g. "block-0" */
+  id: string;
+  /** Nearest preceding heading, or "Block N" if none found */
+  label: string;
+  /** Fence dialect: "wod", "crossfit", etc. */
+  dialect: string;
+  /** Inner content of the fenced block (trimmed) */
+  content: string;
+}
+
+const WOD_DIALECTS = ['wod', 'crossfit', 'amrap', 'emom', 'tabata'];
+
+/**
+ * Parse raw markdown and extract all WOD fenced code blocks.
+ * Supports dialects: wod, crossfit, amrap, emom, tabata.
+ */
+export function extractWodBlocks(markdown: string): WodBlockExtract[] {
+  const lines = markdown.split('\n');
+  const blocks: WodBlockExtract[] = [];
+  let lastHeading = '';
+  let inFence = false;
+  let fenceDialect = '';
+  let fenceLines: string[] = [];
+  let blockIndex = 0;
+
+  for (const line of lines) {
+    if (!inFence) {
+      // Track the last heading we saw
+      const headingMatch = line.match(/^#{1,6}\s+(.+)/);
+      if (headingMatch) {
+        lastHeading = headingMatch[1].trim();
+        continue;
+      }
+
+      // Detect opening fence
+      const fenceOpen = line.match(/^```(\w+)\s*$/);
+      if (fenceOpen && WOD_DIALECTS.includes(fenceOpen[1].toLowerCase())) {
+        inFence = true;
+        fenceDialect = fenceOpen[1].toLowerCase();
+        fenceLines = [];
+        continue;
+      }
+    } else {
+      // Detect closing fence
+      if (line.trim() === '```') {
+        blocks.push({
+          id: `block-${blockIndex++}`,
+          label: lastHeading || `Block ${blockIndex}`,
+          dialect: fenceDialect,
+          content: fenceLines.join('\n').trim(),
+        });
+        inFence = false;
+        fenceDialect = '';
+        fenceLines = [];
+      } else {
+        fenceLines.push(line);
+      }
+    }
+  }
+
+  return blocks;
+}
+```
+
+**Step 4: Run to verify pass**
+
+```bash
+bun test src/lib/wodBlockExtract.test.ts
+```
+
+Expected: 4 tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add wod-wiki-e2e/src/lib/wodBlockExtract.ts wod-wiki-e2e/src/lib/wodBlockExtract.test.ts
+git commit -m "feat: add extractWodBlocks utility for parsing wod fence blocks from markdown"
+```
+
+---
+
+## Phase 2 — Collection Import Strategy
+
+### Task 2: Create `CollectionImportStrategy`
+
+**Objective:** Three-level command strategy — select collection → select workout → select WOD block → inserts block into current note.
+
+**Files:**
+- Create: `wod-wiki-e2e/src/components/command-palette/strategies/CollectionImportStrategy.ts`
+
+**Key design:** Uses `setStrategy` from `CommandContextType` to push the next level when the user selects an item. The `onInsert` callback is injected at construction time and called when a block is selected.
+
+```ts
+// wod-wiki-e2e/src/components/command-palette/strategies/CollectionImportStrategy.ts
+import type { Command, CommandStrategy } from '../types';
+import { getWodCollections, WodCollectionItem } from '@/repositories/wod-collections';
+import { extractWodBlocks, WodBlockExtract } from '@/lib/wodBlockExtract';
+
+type SetStrategy = (strategy: CommandStrategy | null) => void;
+type OnInsert = (blocks: WodBlockExtract[]) => void;
+
+// ─── Level 3: Block selection ─────────────────────────────────────────────────
+
+class WodBlockSelectStrategy implements CommandStrategy {
+  id = 'collection-import-block';
+  placeholder: string;
+
+  constructor(
+    private item: WodCollectionItem,
+    private collectionName: string,
+    private onInsert: OnInsert,
+    private setStrategy: SetStrategy,
+  ) {
+    this.placeholder = `Select block from "${item.name}"…`;
+  }
+
+  getCommands(): Command[] {
+    const blocks = extractWodBlocks(this.item.content);
+
+    if (blocks.length === 0) {
+      // Fallback: import the whole item as a plain block
+      return [{
+        id: 'import-whole',
+        label: `Import entire "${this.item.name}"`,
+        group: 'Import',
+        action: () => {
+          this.onInsert([{
+            id: 'block-0',
+            label: this.item.name,
+            dialect: 'wod',
+            content: this.item.content,
+          }]);
+          this.setStrategy(null);
+        },
+      }];
+    }
+
+    return blocks.map((block) => ({
+      id: block.id,
+      label: block.label,
+      group: `${this.collectionName} › ${this.item.name}`,
+      keywords: [block.dialect, block.content.slice(0, 60)],
+      action: () => {
+        this.onInsert([block]);
+        this.setStrategy(null);
+      },
+    }));
+  }
+}
+
+// ─── Level 2: Workout selection ───────────────────────────────────────────────
+
+class WodWorkoutSelectStrategy implements CommandStrategy {
+  id = 'collection-import-workout';
+  placeholder: string;
+
+  constructor(
+    private collectionId: string,
+    private collectionName: string,
+    private onInsert: OnInsert,
+    private setStrategy: SetStrategy,
+  ) {
+    this.placeholder = `Select workout from "${collectionName}"…`;
+  }
+
+  getCommands(): Command[] {
+    const collections = getWodCollections();
+    const col = collections.find(c => c.id === this.collectionId);
+    if (!col) return [];
+
+    return col.items.map(item => ({
+      id: item.id,
+      label: item.name,
+      group: col.name,
+      keywords: [item.id],
+      action: () => {
+        this.setStrategy(
+          new WodBlockSelectStrategy(item, col.name, this.onInsert, this.setStrategy)
+        );
+      },
+    }));
+  }
+}
+
+// ─── Level 1: Collection selection ───────────────────────────────────────────
+
+export class CollectionImportStrategy implements CommandStrategy {
+  id = 'collection-import';
+  placeholder = 'Import from collection… (type to filter)';
+
+  constructor(
+    private onInsert: OnInsert,
+    private setStrategy: SetStrategy,
+  ) {}
+
+  getCommands(): Command[] {
+    const collections = getWodCollections();
+
+    return collections.map(col => ({
+      id: col.id,
+      label: col.name,
+      group: 'Collections',
+      keywords: [col.id, ...col.categories],
+      action: () => {
+        this.setStrategy(
+          new WodWorkoutSelectStrategy(col.id, col.name, this.onInsert, this.setStrategy)
+        );
+      },
+    }));
+  }
+}
+```
+
+**Verify (manual):** TypeScript compile — no errors.
+
+```bash
+cd /home/serge/projects/wod-wiki/wod-wiki-e2e
+bun x tsc --noEmit 2>&1 | head -30
+```
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/components/command-palette/strategies/CollectionImportStrategy.ts
+git commit -m "feat: add CollectionImportStrategy — 3-level collection → workout → block selection"
+```
+
+---
+
+### Task 3: Create `HistoryImportStrategy`
+
+**Objective:** Same 3-level flow but sources from `provider.getEntries()` instead of static collections. Treats any journal note with WOD blocks as an importable source.
+
+**Files:**
+- Create: `wod-wiki-e2e/src/components/command-palette/strategies/HistoryImportStrategy.ts`
+
+```ts
+// wod-wiki-e2e/src/components/command-palette/strategies/HistoryImportStrategy.ts
+import type { Command, CommandStrategy } from '../types';
+import type { IContentProvider } from '@/types/content-provider';
+import type { HistoryEntry } from '@/types/history';
+import { extractWodBlocks, WodBlockExtract } from '@/lib/wodBlockExtract';
+
+type SetStrategy = (strategy: CommandStrategy | null) => void;
+type OnInsert = (blocks: WodBlockExtract[]) => void;
+
+// ─── Level 2: Block selection from a history entry ───────────────────────────
+
+class HistoryBlockSelectStrategy implements CommandStrategy {
+  id = 'history-import-block';
+  placeholder: string;
+
+  constructor(
+    private entry: HistoryEntry,
+    private onInsert: OnInsert,
+    private setStrategy: SetStrategy,
+  ) {
+    this.placeholder = `Select block from "${entry.title}"…`;
+  }
+
+  getCommands(): Command[] {
+    const blocks = extractWodBlocks(this.entry.rawContent ?? '');
+
+    if (blocks.length === 0) {
+      return [{
+        id: 'import-whole',
+        label: `Import entire note`,
+        group: this.entry.title,
+        action: () => {
+          this.onInsert([{
+            id: 'block-0',
+            label: this.entry.title,
+            dialect: 'wod',
+            content: this.entry.rawContent ?? '',
+          }]);
+          this.setStrategy(null);
+        },
+      }];
+    }
+
+    return blocks.map(block => ({
+      id: block.id,
+      label: block.label,
+      group: this.entry.title,
+      keywords: [block.dialect],
+      action: () => {
+        this.onInsert([block]);
+        this.setStrategy(null);
+      },
+    }));
+  }
+}
+
+// ─── Level 1: Entry selection ─────────────────────────────────────────────────
+
+export class HistoryImportStrategy implements CommandStrategy {
+  id = 'history-import';
+  placeholder = 'Import from workout history… (type to filter)';
+  private entries: HistoryEntry[] = [];
+
+  constructor(
+    private provider: IContentProvider,
+    private onInsert: OnInsert,
+    private setStrategy: SetStrategy,
+  ) {}
+
+  async init() {
+    // Pre-load entries; filter to only those with wod blocks
+    const all = await this.provider.getEntries();
+    this.entries = all.filter(e =>
+      e.type !== 'template' &&
+      e.rawContent &&
+      /```(wod|crossfit|amrap|emom|tabata)/.test(e.rawContent)
+    );
+  }
+
+  getCommands(): Command[] {
+    return this.entries.map(entry => {
+      const date = new Date(entry.targetDate).toLocaleDateString(undefined, {
+        month: 'short', day: 'numeric', year: 'numeric'
+      });
+      return {
+        id: entry.id,
+        label: entry.title,
+        group: 'Workout History',
+        keywords: [date, entry.id],
+        action: () => {
+          this.setStrategy(
+            new HistoryBlockSelectStrategy(entry, this.onInsert, this.setStrategy)
+          );
+        },
+      };
+    });
+  }
+}
+```
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/components/command-palette/strategies/HistoryImportStrategy.ts
+git commit -m "feat: add HistoryImportStrategy — import WOD blocks from any past journal entry"
+```
+
+---
+
+## Phase 3 — Wire Import Into the Editor
+
+### Task 4: Add `useCollectionImport` hook
+
+**Objective:** Encapsulate the logic for opening the import palette from within the journal editor. Returns an `openImport` function that the editor toolbar can call.
+
+**Files:**
+- Create: `wod-wiki-e2e/src/hooks/useCollectionImport.ts`
+
+```ts
+// wod-wiki-e2e/src/hooks/useCollectionImport.ts
+import { useCallback } from 'react';
+import { useCommandPalette } from '@/components/command-palette/CommandContext';
+import { CollectionImportStrategy } from '@/components/command-palette/strategies/CollectionImportStrategy';
+import { HistoryImportStrategy } from '@/components/command-palette/strategies/HistoryImportStrategy';
+import type { WodBlockExtract } from '@/lib/wodBlockExtract';
+import type { IContentProvider } from '@/types/content-provider';
+
+interface UseCollectionImportOptions {
+  onInsert: (blocks: WodBlockExtract[]) => void;
+  provider?: IContentProvider;
+}
+
+export function useCollectionImport({ onInsert, provider }: UseCollectionImportOptions) {
+  const { setIsOpen, setStrategy } = useCommandPalette();
+
+  const openCollectionImport = useCallback(() => {
+    const strategy = new CollectionImportStrategy(onInsert, setStrategy);
+    setStrategy(strategy);
+    setIsOpen(true);
+  }, [onInsert, setStrategy, setIsOpen]);
+
+  const openHistoryImport = useCallback(async () => {
+    if (!provider) return;
+    const strategy = new HistoryImportStrategy(provider, onInsert, setStrategy);
+    await strategy.init();
+    setStrategy(strategy);
+    setIsOpen(true);
+  }, [provider, onInsert, setStrategy, setIsOpen]);
+
+  return { openCollectionImport, openHistoryImport };
+}
+```
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/hooks/useCollectionImport.ts
+git commit -m "feat: add useCollectionImport hook for opening import palette from editor"
+```
+
+---
+
+### Task 5: Wire import into `PlanPanel`
+
+**Objective:** Add an "Import WOD" button to the plan panel toolbar and bind `Cmd+Shift+I` keyboard shortcut. When triggered, opens collection import palette. The `onInsert` callback appends the selected block as a ` ```wod``` ` fence to the current note content.
+
+**Files:**
+- Modify: `wod-wiki-e2e/src/panels/plan-panel.tsx`
+
+**Step 1: Read the current file fully**
+
+```bash
+cat /home/serge/projects/wod-wiki/wod-wiki-e2e/src/panels/plan-panel.tsx
+```
+
+**Step 2: Apply changes**
+
+Add imports at top:
+```ts
+import { useEffect, useCallback } from 'react';
+import { useCollectionImport } from '@/hooks/useCollectionImport';
+import type { WodBlockExtract } from '@/lib/wodBlockExtract';
+import type { IContentProvider } from '@/types/content-provider';
+import { Download } from 'lucide-react';
+```
+
+Add `provider` to `PlanPanelProps` (remove `@deprecated` — we're re-enabling it for import):
+```ts
+/** Content provider — used for history import */
+provider?: IContentProvider;
+```
+
+Inside `PlanPanel` component body, add:
+
+```ts
+// Build insert handler — appends block as wod fence to current content
+const handleInsert = useCallback((blocks: WodBlockExtract[]) => {
+  const appended = blocks
+    .map(b => `\n\n\`\`\`${b.dialect}\n${b.content.trim()}\n\`\`\``)
+    .join('');
+  setContent((prev: string) => prev.trimEnd() + appended);
+}, [setContent]);
+
+const { openCollectionImport, openHistoryImport } = useCollectionImport({
+  onInsert: handleInsert,
+  provider,
+});
+
+// Keyboard shortcut: Cmd+Shift+I → collection import, Cmd+Shift+H → history import
+useEffect(() => {
+  const handler = (e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'I') {
+      e.preventDefault();
+      openCollectionImport();
+    }
+    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === 'H') {
+      e.preventDefault();
+      openHistoryImport();
+    }
+  };
+  window.addEventListener('keydown', handler);
+  return () => window.removeEventListener('keydown', handler);
+}, [openCollectionImport, openHistoryImport]);
+```
+
+Add import toolbar above the `NoteEditor` in the JSX:
+```tsx
+{/* Import toolbar */}
+<div className="flex-shrink-0 flex items-center gap-1 px-2 py-1 border-b border-border/40 bg-muted/30">
+  <button
+    type="button"
+    onClick={openCollectionImport}
+    className="flex items-center gap-1.5 text-xs px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+    title="Import from collection (Cmd+Shift+I)"
+  >
+    <Download className="h-3 w-3" />
+    <span>From Collection</span>
+  </button>
+  {provider && (
+    <button
+      type="button"
+      onClick={openHistoryImport}
+      className="flex items-center gap-1.5 text-xs px-2 py-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+      title="Import from history (Cmd+Shift+H)"
+    >
+      <Download className="h-3 w-3" />
+      <span>From History</span>
+    </button>
+  )}
+</div>
+```
+
+**Step 3: Verify TypeScript**
+
+```bash
+cd /home/serge/projects/wod-wiki/wod-wiki-e2e
+bun x tsc --noEmit 2>&1 | head -30
+```
+
+Expected: No errors (or only pre-existing errors).
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/panels/plan-panel.tsx
+git commit -m "feat: add import toolbar and Cmd+Shift+I shortcut to PlanPanel for collection/history import"
+```
+
+---
+
+## Phase 4 — Fix CollectionsPage Preview
+
+### Task 6: Fix preview panel visibility in `CollectionsPage`
+
+**Objective:** Replace the dynamic `createHistoryView` panel layout with a stable two-column div so the preview panel appears when a workout is selected.
+
+**Files:**
+- Modify: `wod-wiki-e2e/src/app/pages/CollectionsPage.tsx`
+
+**Read the full file first:**
+
+```bash
+cat /home/serge/projects/wod-wiki/wod-wiki-e2e/src/app/pages/CollectionsPage.tsx
+```
+
+**Find this block** (around line 174–194):
+```tsx
+// Using createHistoryView with our constructed panels matches the layout system
+const historyView = createHistoryView(mainPanel, previewPanel);
+const layoutState = { ... };
+
+return (
+  <HistoryLayout>
+    <PanelGrid ... />
+  </HistoryLayout>
+);
+```
+
+**Replace with:**
+```tsx
+return (
+  <div className="flex h-full w-full overflow-hidden">
+    {/* Left: filter + list (full width when nothing selected, half when preview open) */}
+    <div className={cn(
+      "flex flex-col h-full transition-all duration-200",
+      entryToShow ? "w-1/2 border-r border-border" : "w-full"
+    )}>
+      {mainPanel}
+    </div>
+
+    {/* Right: preview panel (only rendered when an entry is selected) */}
+    {entryToShow && (
+      <div className="w-1/2 h-full overflow-hidden">
+        {previewPanel}
+      </div>
+    )}
+  </div>
+);
+```
+
+Remove the unused `createHistoryView`, `HistoryLayout`, `PanelGrid`, `PanelSpan`, `layoutState` imports/declarations if they are no longer used after this change.
+
+**Verify:**
+1. `bun x tsc --noEmit` — no errors
+2. Visit `https://playground.forest-adhara.ts.net/collections/crossfit-girls`
+3. Click FRAN → right panel appears with preview
+4. Click another workout → preview updates
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/app/pages/CollectionsPage.tsx
+git commit -m "fix: replace dynamic PanelGrid layout in CollectionsPage with stable two-column split"
+```
+
+---
+
+### Task 7: Fix "New" in collections context to seed from selected item
+
+**Objective:** When a collection workout is selected in `CollectionsPage`, the "New" / `onClone` action should seed the new entry from that item's content, not from a blank template.
+
+**File:** `wod-wiki-e2e/src/app/pages/CollectionsPage.tsx`
+
+The `onClone` handler in the `ListOfNotes` already uses `entry.rawContent`. The problem is the "New" toolbar button calls the page-level `useCreateWorkoutEntry` which ignores the selected entry.
+
+**Change:** In `CollectionsPage`, remove or hide the generic "New" toolbar button when a collection entry is selected. Let `onClone` / `onAddToPlan` on `NotePreview` be the action surface instead. Add a tooltip or instruction text in the empty state: "Select a workout to add it to your journal."
+
+This is a conservative fix — no new code, just a UX clarification.
+
+```tsx
+// In the empty state of listPanel (when no entry selected), add guidance:
+{!selectedId && (
+  <div className="px-4 py-2 text-xs text-muted-foreground italic">
+    Select a workout to preview and add it to your journal.
+  </div>
+)}
+```
+
+**Commit:**
+
+```bash
+git add wod-wiki-e2e/src/app/pages/CollectionsPage.tsx
+git commit -m "fix: add selection guidance to CollectionsPage empty state"
+```
+
+---
+
+## Phase 5 — Clean Up Dead UI
+
+### Task 8: Wire or remove `+ Plan a workout` stub
+
+**Objective:** Find the rendered "Plan a workout" button and either wire it to `openCollectionImport` or remove it.
+
+**Step 1: Find it**
+
+```bash
+grep -rn "Plan a workout\|plan.*workout\|planAWorkout" \
+  /home/serge/projects/wod-wiki/wod-wiki-e2e/src --include="*.tsx" --include="*.ts"
+```
+
+**Step 2:** If found, wire `onClick` to open the collection import palette using `useCollectionImport`.  
+If it's in a static string / HeroBanner widget with no live handler, remove it from the template.
+
+**Commit:**
+
+```bash
+git commit -m "fix: wire or remove dead 'Plan a workout' UI stub"
+```
+
+---
+
+## Phase 6 — Integration Smoke Test
+
+### Task 9: Manual end-to-end verification
+
+**Steps:**
+1. Navigate to `https://playground.forest-adhara.ts.net/`
+2. Open or create a journal entry for today
+3. Press `Cmd+Shift+I` → command palette opens with "Collections" group
+4. Type "cross" → CrossFit Girls appears
+5. Select it → level 2: list of workouts (FRAN, HELEN, etc.)
+6. Select FRAN → level 3: list of blocks ("Fran" block)
+7. Select block → palette closes, ` ```wod\n21-15-9\n...\n``` ` appended to editor
+8. Press `Cmd+Shift+H` → palette opens with "Workout History" group
+9. Select a past entry with a WOD block → block list shown → select → inserted
+10. Navigate to Collections → click CrossFit Girls → click FRAN → preview panel appears on the right
+
+**Commit (if any cleanup needed):**
+
+```bash
+git commit -m "fix: integration cleanup from smoke test"
+```
+
+---
+
+## Phase 7 — PR
+
+### Task 10: Open PR
+
+```bash
+cd /home/serge/projects/wod-wiki/wod-wiki
+git push -u origin feat/collection-import-pull
+
+gh pr create \
+  --title "feat: collection import pull — Cmd+Shift+I imports WOD blocks from collections and history" \
+  --body "## Summary
+
+Adds a pull mechanism for importing WOD blocks from any collection or past journal entry into the current note.
+
+## Changes
+
+- **\`extractWodBlocks\`** — new utility to parse \`\`\`wod\`\`\` fences from raw markdown
+- **\`CollectionImportStrategy\`** — 3-level command palette: collection → workout → WOD block
+- **\`HistoryImportStrategy\`** — same flow but sources from past journal entries with WOD blocks
+- **\`useCollectionImport\`** — hook wiring import strategies into the editor
+- **\`PlanPanel\`** — adds 'From Collection' / 'From History' toolbar buttons + Cmd+Shift+I / H shortcuts
+- **\`CollectionsPage\`** — fixes invisible preview panel (stable 2-column layout)
+- **\`CollectionsPage\`** — adds selection guidance in empty state
+
+## UX Flow
+
+\`Cmd+Shift+I\` → type collection name → select workout → select WOD block → block appended to current note as \`\`\`wod\`\`\` fence.
+
+Closes dogfood issues: #1 (no pull mechanism), #3 (command palette wrong source), #4 (preview invisible), #6 (dead Plan a workout stub)
+
+## Test Plan
+- [ ] \`extractWodBlocks\` unit tests pass (\`bun test src/lib/wodBlockExtract.test.ts\`)
+- [ ] TypeScript: \`bun x tsc --noEmit\` — clean
+- [ ] Manual: import from collection works end-to-end
+- [ ] Manual: import from history works end-to-end
+- [ ] Manual: Collections preview panel visible after click"
+```
+
+---
+
+## File Summary
+
+| File | Status |
+|------|--------|
+| `src/lib/wodBlockExtract.ts` | Create |
+| `src/lib/wodBlockExtract.test.ts` | Create |
+| `src/components/command-palette/strategies/CollectionImportStrategy.ts` | Create |
+| `src/components/command-palette/strategies/HistoryImportStrategy.ts` | Create |
+| `src/hooks/useCollectionImport.ts` | Create |
+| `src/panels/plan-panel.tsx` | Modify |
+| `src/app/pages/CollectionsPage.tsx` | Modify (×2) |
+
+**No new dependencies required.** All primitives (`cmdk`, `CommandStrategy`, `IContentProvider`) already exist.

--- a/docs/plans/fragment-first-runtime-storage.md
+++ b/docs/plans/fragment-first-runtime-storage.md
@@ -1,0 +1,506 @@
+# Fragment-First Runtime Storage Plan
+
+**Date**: December 2025  
+**Status**: Design Proposal  
+**Objective**: Eliminate the metrics-to-fragments adapter layer by storing runtime data as `ICodeFragment[]` directly
+
+---
+
+## Problem Statement
+
+Currently, the runtime system maintains **two parallel data representations**:
+
+| Stage | Format | Purpose |
+|-------|--------|---------|
+| Parse Time | `ICodeFragment[]` | Parsed from workout script, used for UI display |
+| Runtime | `SpanMetrics` / `RuntimeMetric` / `MetricValue` | Collected during execution, requires conversion for UI |
+
+This creates a conversion layer (`metricsToFragments.ts`) that:
+1. Adds complexity and potential for bugs
+2. Creates semantic drift between parsed and runtime data
+3. Requires adapters for UI binding
+4. Fragments (parsed) and metrics (runtime) represent the **same units of data** semantically
+
+### Current Flow (With Adapters)
+
+```
+Parse: WodScript → Parser → ICodeFragment[] → UI ✅
+                                      ↑
+                               (direct binding)
+
+Runtime: Block → SpanMetrics → metricsToFragments() → ICodeFragment[] → UI
+                       ↑                    ↑
+                  (different format)    (adapter needed)
+```
+
+### Goal: Unified Fragment-Based Storage
+
+```
+Parse: WodScript → Parser → ICodeFragment[] → UI ✅
+
+Runtime: Block → ICodeFragment[] → UI ✅
+                      ↑
+                (same format - NO adapter needed)
+```
+
+---
+
+## Current Architecture Analysis
+
+### ICodeFragment (src/core/models/CodeFragment.ts)
+
+```typescript
+// Pure data interface - no metric methods
+interface ICodeFragment {
+  readonly image?: string;         // Display text ("10 reps", "95 lb")
+  readonly value?: unknown;        // Parsed/computed value
+  readonly type: string;           // Type string
+  readonly meta?: CodeMetadata;
+  readonly fragmentType: FragmentType;  // Enum type
+  readonly origin: MetricOrigin;   // Where this fragment was created
+  readonly unit?: string;          // Unit of measurement
+}
+
+enum FragmentType {
+  Timer, Rep, Effort, Distance, Rounds, 
+  Action, Increment, Lap, Text, Resistance
+}
+```
+
+### SpanMetrics (src/runtime/models/ExecutionSpan.ts)
+
+```typescript
+interface SpanMetrics {
+  exerciseId?: string;
+  reps?: MetricValueWithTimestamp<number>;
+  weight?: MetricValueWithTimestamp<number>;
+  distance?: MetricValueWithTimestamp<number>;
+  duration?: MetricValueWithTimestamp<number>;
+  currentRound?: number;
+  totalRounds?: number;
+  // ... 15+ fields
+}
+```
+
+### MetricValue (src/runtime/RuntimeMetric.ts)
+
+```typescript
+type MetricValue = {
+  type: "repetitions" | "resistance" | "distance" | ...;
+  value: number | undefined;
+  unit: string;
+};
+```
+
+### Key Observation
+
+`FragmentType` enum and `MetricValue.type` have **direct 1:1 mappings** (see `METRIC_TO_FRAGMENT_TYPE` in metricsToFragments.ts):
+
+| MetricValue.type | FragmentType |
+|------------------|--------------|
+| `repetitions` | `Rep` |
+| `resistance` | `Resistance` |
+| `distance` | `Distance` |
+| `time` / `timestamp` | `Timer` |
+| `rounds` | `Rounds` |
+| `effort` | `Effort` |
+| `action` | `Action` |
+
+This mapping proves they represent the **same semantic units**.
+
+---
+
+## Proposed Architecture: Fragment-First Storage
+
+### Phase 1: Extend ICodeFragment for Runtime
+
+Add optional runtime-specific fields to `ICodeFragment`:
+
+```typescript
+// src/core/models/CodeFragment.ts
+interface ICodeFragment {
+  // Existing fields
+  readonly image?: string;
+  readonly value?: any;
+  readonly type: string;
+  readonly fragmentType: FragmentType;
+  readonly meta?: CodeMetadata;
+  
+  // === NEW: Runtime Context (optional) ===
+  /** Timestamp when this fragment was recorded (runtime only) */
+  readonly recordedAt?: number;
+  /** Source block/behavior that produced this fragment */
+  readonly source?: string;
+  /** Original MetricValue unit for analytics compatibility */
+  readonly unit?: string;
+  /** Controls whether the fragment is shown in UI or kept for analytics only */
+  readonly visibility?: FragmentVisibility;
+}
+```
+
+### Phase 2: Replace SpanMetrics with Fragment Array
+
+Modify `ExecutionSpan` to use fragments directly:
+
+```typescript
+// src/runtime/models/ExecutionSpan.ts
+interface ExecutionSpan {
+  // Identity, status, timing - unchanged
+  id: string;
+  blockId: string;
+  parentSpanId: string | null;
+  type: SpanType;
+  label: string;
+  status: SpanStatus;
+  startTime: number;
+  endTime?: number;
+  
+  // === CHANGED: Fragment-based metrics ===
+  /** 
+   * All collected data as fragments - ready for UI binding
+   * No conversion needed!
+   */
+  fragments: ICodeFragment[];
+  
+  // Segments still use fragments
+  segments: TimeSegment[];
+}
+
+interface TimeSegment {
+  id: string;
+  parentSpanId: string;
+  type: SegmentType;
+  label: string;
+  startTime: number;
+  endTime?: number;
+  
+  // Segment-specific fragments
+  fragments: ICodeFragment[];
+}
+```
+
+### Phase 3: Fragment-Based Metric Recording
+
+Update metric emission to create fragments directly:
+
+```typescript
+// Before: EmitMetricAction creates RuntimeMetric
+const metric: RuntimeMetric = {
+  exerciseId: 'pushups',
+  values: [{ type: 'repetitions', value: 10, unit: 'reps' }],
+  timeSpans: [...]
+};
+return [new EmitMetricAction(metric)];
+
+// After: EmitFragmentAction creates ICodeFragment[]
+const fragments: ICodeFragment[] = [
+  {
+    fragmentType: FragmentType.Effort,
+    type: 'effort',
+    value: 'pushups',
+    image: 'Pushups'
+  },
+  {
+    fragmentType: FragmentType.Rep,
+    type: 'rep',
+    value: 10,
+    image: '10 reps',
+    recordedAt: Date.now(),
+    source: 'effort-block'
+  }
+];
+return [new EmitFragmentAction(fragments)];
+```
+
+---
+
+## UI Binding Analysis
+
+### Components Currently Using Metrics
+
+| Component | Current Input | After Migration |
+|-----------|---------------|-----------------|
+| `RuntimeHistoryLog` | `SpanMetrics` → `spanMetricsToFragments()` → `ICodeFragment[]` | `ICodeFragment[]` (direct) |
+| `HistoryRow` | `HistoryItem.fragments` | `ICodeFragment[]` (unchanged) |
+| `FragmentVisualizer` | `ICodeFragment[]` | `ICodeFragment[]` (unchanged) |
+| `WodScriptVisualizer` | `ICodeStatement.fragments` | `ICodeFragment[]` (unchanged) |
+| `AnalyticsTransformer` | `SpanMetrics` → extract values | `ICodeFragment[]` (extract values) |
+
+### Analytics Engine Compatibility
+
+The analytics engine needs numeric values for calculations. Fragment-first approach preserves this:
+
+```typescript
+// Extract numeric values from fragments for analytics
+function fragmentsToAnalyticsData(fragments: ICodeFragment[]): Record<string, number> {
+  const data: Record<string, number> = {};
+  
+  for (const f of fragments) {
+    if (typeof f.value === 'number') {
+      // Map fragmentType to analytics key
+      const key = fragmentTypeToAnalyticsKey(f.fragmentType);
+      data[key] = f.value;
+    }
+  }
+  
+  return data;
+}
+
+function fragmentTypeToAnalyticsKey(type: FragmentType): string {
+  const mapping: Record<FragmentType, string> = {
+    [FragmentType.Rep]: 'repetitions',
+    [FragmentType.Resistance]: 'resistance',
+    [FragmentType.Distance]: 'distance',
+    [FragmentType.Timer]: 'time',
+    [FragmentType.Rounds]: 'rounds',
+    // ...
+  };
+  return mapping[type] || type;
+}
+```
+
+---
+
+## Internal vs Display Fragments
+
+Some fragments are internal and shouldn't be displayed:
+
+```typescript
+// Add filter capability
+enum FragmentVisibility {
+  Display = 'display',    // Show in UI
+  Internal = 'internal',  // Analytics only
+  Debug = 'debug'         // Dev tools only
+}
+
+interface ICodeFragment {
+  // ... existing fields
+  readonly visibility?: FragmentVisibility;  // Default: 'display'
+}
+
+// UI filtering
+const displayFragments = span.fragments.filter(
+  f => !f.visibility || f.visibility === 'display'
+);
+```
+
+---
+
+## Migration Path
+
+### Step 1: Add Runtime Fields to ICodeFragment
+
+```diff
+// src/core/models/CodeFragment.ts
+export interface ICodeFragment {
+  readonly image?: string;
+  readonly value?: any;
+  readonly type: string;
+  readonly fragmentType: FragmentType;
+  readonly meta?: CodeMetadata;
++  readonly recordedAt?: number;
++  readonly source?: string;
++  readonly unit?: string;
++  readonly visibility?: FragmentVisibility;
+}
+```
+
+### Step 2: Create Fragment Helpers
+
+```typescript
+// src/runtime/utils/fragmentHelpers.ts
+
+/**
+ * Create a runtime fragment from metric data
+ */
+export function createRuntimeFragment(
+  type: FragmentType,
+  value: any,
+  unit?: string,
+  source?: string
+): ICodeFragment {
+  return {
+    fragmentType: type,
+    type: type.toLowerCase(),
+    value,
+    image: formatFragmentImage(type, value, unit),
+    recordedAt: Date.now(),
+    source,
+    unit
+  };
+}
+
+/**
+ * Create rep fragment
+ */
+export function createRepFragment(reps: number, source?: string): ICodeFragment {
+  return createRuntimeFragment(FragmentType.Rep, reps, 'reps', source);
+}
+
+/**
+ * Create weight fragment
+ */
+export function createWeightFragment(weight: number, unit: string, source?: string): ICodeFragment {
+  return createRuntimeFragment(FragmentType.Resistance, weight, unit, source);
+}
+
+// ... more helpers
+```
+
+### Step 3: Update ExecutionSpan Model
+
+```diff
+// src/runtime/models/ExecutionSpan.ts
+export interface ExecutionSpan {
+  id: string;
+  blockId: string;
+  parentSpanId: string | null;
+  type: SpanType;
+  label: string;
+  status: SpanStatus;
+  startTime: number;
+  endTime?: number;
+  
+-  metrics: SpanMetrics;
++  fragments: ICodeFragment[];
+  
++  // Legacy support during migration
++  /** @deprecated Use fragments instead */
++  metrics?: SpanMetrics;
+  
+  segments: TimeSegment[];
+}
+```
+
+### Step 4: Create EmitFragmentAction
+
+```typescript
+// src/runtime/actions/EmitFragmentAction.ts
+
+export class EmitFragmentAction implements IRuntimeAction {
+  readonly type = 'emit-fragment';
+  
+  constructor(
+    public readonly fragments: ICodeFragment[]
+  ) {}
+
+  do(runtime: IScriptRuntime): void {
+    const currentBlock = runtime.stack.current;
+    if (!currentBlock) return;
+    
+    const blockId = currentBlock.key.toString();
+    
+    // Record fragments to ExecutionSpan
+    if (runtime.tracker) {
+      runtime.tracker.recordFragments(blockId, this.fragments);
+    }
+  }
+}
+```
+
+### Step 5: Update ExecutionTracker
+
+```typescript
+// src/runtime/ExecutionTracker.ts
+
+class ExecutionTracker {
+  /**
+   * Record fragments to the active span
+   */
+  recordFragments(blockId: string, fragments: ICodeFragment[]): void {
+    const span = this.activeSpans.get(blockId);
+    if (!span) return;
+    
+    // Append to existing fragments
+    span.fragments = [...span.fragments, ...fragments];
+    
+    // Notify subscribers
+    this.notifyUpdate(span);
+  }
+}
+```
+
+### Step 6: Remove Adapter Layer (Final)
+
+Once all components use fragments directly:
+
+```diff
+// src/components/history/RuntimeHistoryLog.tsx
+const fragments = useMemo(() => {
+-  return spanMetricsToFragments(span.metrics, span.label, span.type);
++  return span.fragments;  // Direct binding - no adapter!
+}, [span]);
+```
+
+---
+
+## Files to Modify
+
+### Core Model Changes
+- `src/core/models/CodeFragment.ts` - Add runtime fields
+- `src/runtime/models/ExecutionSpan.ts` - Replace metrics with fragments
+
+### New Files
+- `src/runtime/utils/fragmentHelpers.ts` - Fragment creation utilities
+- `src/runtime/actions/EmitFragmentAction.ts` - New action type
+
+### Updated Runtime Files
+- `src/runtime/ExecutionTracker.ts` - Fragment recording
+- `src/runtime/behaviors/HistoryBehavior.ts` - Use fragment emission
+- `src/runtime/blocks/EffortBlock.ts` - Use fragment emission
+- `src/runtime/strategies/*.ts` - Update compiled metrics to fragments
+
+### UI Components (Simplify)
+- `src/components/history/RuntimeHistoryLog.tsx` - Remove adapter
+- `src/services/AnalyticsTransformer.ts` - Read from fragments
+
+### Deprecate/Remove
+- `src/runtime/utils/metricsToFragments.ts` - No longer needed
+- `src/runtime/RuntimeMetric.ts` - Mark as legacy
+
+---
+
+## Benefits
+
+1. **No Adapter Needed**: UI binds directly to `ICodeFragment[]` everywhere
+2. **Single Data Model**: Parsed and runtime data use same format
+3. **Type Safety**: `FragmentType` enum ensures valid types
+4. **Analytics Compatible**: Numeric values preserved for calculations
+5. **Simpler Codebase**: Remove ~300 lines of conversion code
+6. **Consistent Visualization**: Same styling/colors for parsed and runtime data
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Analytics needs numeric extraction | `fragmentsToAnalyticsData()` helper |
+| Legacy RuntimeMetric consumers | Keep optional `metrics` field during migration |
+| Internal fragments shown in UI | `visibility` field to filter |
+| Breaking existing tests | Gradual migration with dual support |
+
+---
+
+## Timeline
+
+| Phase | Duration | Deliverables |
+|-------|----------|--------------|
+| 1. Model Extension | 1 day | Extended `ICodeFragment`, helpers |
+| 2. ExecutionSpan Migration | 2 days | Fragment-based spans |
+| 3. Behavior Updates | 2 days | Blocks emit fragments |
+| 4. UI Simplification | 1 day | Remove adapter calls |
+| 5. Cleanup | 1 day | Remove deprecated code |
+
+**Total**: ~7 days
+
+---
+
+## Success Criteria
+
+1. ✅ `RuntimeHistoryLog` binds to `span.fragments` directly
+2. ✅ `FragmentVisualizer` works unchanged
+3. ✅ Analytics engine extracts data from fragments
+4. ✅ `metricsToFragments.ts` marked deprecated/removed
+5. ✅ All existing tests pass
+6. ✅ UI renders identically before/after migration

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -22,6 +22,7 @@ import { FullscreenTimer } from '@/components/Editor/overlays/FullscreenTimer'
 import { RuntimeTimerPanel } from '@/components/Editor/overlays/RuntimeTimerPanel'
 import { getAnalyticsFromLogs } from '@/services/AnalyticsTransformer'
 import type { Segment } from '@/core/models/AnalyticsModels'
+import { ReviewGrid } from '@/components/review-grid/ReviewGrid'
 import type { WorkoutResults } from '@/components/Editor/types'
 import { MacOSChrome } from '../components/MacOSChrome'
 import { ButtonGroup } from '@/components/ui/ButtonGroup'
@@ -334,6 +335,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
   const [panelMode, setPanelMode] = useState<PanelMode>('editor')
   const [viewTimerBlock, setViewTimerBlock] = useState<WodBlock | null>(null)
   const [reviewSegments, setReviewSegments] = useState<Segment[]>([])
+  const [selectedSegmentIds, setSelectedSegmentIds] = useState<Set<number>>(new Set())
   // Block that was last launched in view mode — kept for reconnect support
   const activeViewBlockRef = useRef<WodBlock | null>(null)
 
@@ -386,6 +388,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
     } else {
       setReviewSegments([])
     }
+    setSelectedSegmentIds(new Set())
     setPanelMode('review')
   }, [])
 
@@ -568,15 +571,32 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
             Back to editor
           </button>
           <div className="flex-1 min-h-0 overflow-auto">
-            <div className="p-3">
-              {reviewSegments.length > 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  Workout complete — {reviewSegments.length} segment{reviewSegments.length !== 1 ? 's' : ''} recorded.
-                </p>
-              ) : (
-                <p className="text-xs text-muted-foreground">Workout complete.</p>
-              )}
-            </div>
+            <ReviewGrid
+              runtime={null}
+              segments={reviewSegments}
+              selectedSegmentIds={selectedSegmentIds}
+              onSelectSegment={(id, modifiers, visibleIds) => {
+                setSelectedSegmentIds(prev => {
+                  const next = new Set(prev)
+                  if (modifiers?.ctrlKey) {
+                    if (next.has(id)) next.delete(id); else next.add(id)
+                  } else if (modifiers?.shiftKey && visibleIds) {
+                    const lastId = Array.from(prev).pop()
+                    if (lastId !== undefined) {
+                      const startIdx = visibleIds.indexOf(lastId)
+                      const endIdx = visibleIds.indexOf(id)
+                      if (startIdx !== -1 && endIdx !== -1) {
+                        const min = Math.min(startIdx, endIdx)
+                        const max = Math.max(startIdx, endIdx)
+                        for (let i = min; i <= max; i++) next.add(visibleIds[i])
+                      } else { next.add(id) }
+                    } else { next.add(id) }
+                  } else { next.clear(); next.add(id) }
+                  return next
+                })
+              }}
+              groups={[]}
+            />
           </div>
         </div>
       )


### PR DESCRIPTION
## Problem

When completing a workout via the **Try This** button on canvas/docs pages, the review panel displayed a plain text fallback:

> Workout complete — 15 segments recorded.

...instead of the ReviewGrid component with segment data.

## Root Cause

MarkdownCanvasPage.tsx collected segments correctly via getAnalyticsFromLogs but the review panel render block contained only a text stub — the ReviewGrid component was never wired up.

## Fix

- Import ReviewGrid component
- Add selectedSegmentIds state (local to canvas page, reset on each review entry)
- Replace text stub with full ReviewGrid render, passing collected segments
- Reset selection state when entering review mode

## Testing

Navigate to any canvas page with a Try This button (e.g. https://wod.wiki/the-basics), run through the workout, confirm the results grid appears on completion.
