### PR TITLE
refactor: unify service-layer event buses behind IServiceEventBus<T>

### DIFF
--- a/src/services/WorkbenchEventBus.ts
+++ b/src/services/WorkbenchEventBus.ts
@@ -1,4 +1,5 @@
 import { WodBlock } from '../components/Editor/types';
+import { SimpleEventBus } from './events/SimpleEventBus';
 
 export enum WorkbenchEvent {
     // Navigation / Sync
@@ -30,64 +31,58 @@ export interface StartWorkoutPayload {
     block: WodBlock;
 }
 
-// Simple EventEmitter implementation compatible with browser
-class SimpleEventEmitter {
-    private listeners: Record<string, Function[]> = {};
+export type WorkbenchEventPayload =
+    | { type: WorkbenchEvent.SCROLL_TO_BLOCK; payload: ScrollToBlockPayload }
+    | { type: WorkbenchEvent.HIGHLIGHT_BLOCK; payload: HighlightBlockPayload }
+    | { type: WorkbenchEvent.BLOCK_CLICKED; payload: ScrollToBlockPayload }
+    | { type: WorkbenchEvent.NAVIGATE_TO; payload: NavigateToPayload }
+    | { type: WorkbenchEvent.START_WORKOUT; payload: StartWorkoutPayload };
 
-    emit(event: string, ...args: any[]) {
-        if (!this.listeners[event]) return;
-        this.listeners[event].forEach(listener => listener(...args));
-    }
+class WorkbenchEventBus {
+    private bus = new SimpleEventBus<WorkbenchEventPayload>();
 
-    on(event: string, listener: Function) {
-        if (!this.listeners[event]) {
-            this.listeners[event] = [];
-        }
-        this.listeners[event].push(listener);
-        return () => this.off(event, listener);
-    }
+    // --- emit helpers ---
 
-    off(event: string, listener: Function) {
-        if (!this.listeners[event]) return;
-        this.listeners[event] = this.listeners[event].filter(l => l !== listener);
-    }
-}
-
-class WorkbenchEventBus extends SimpleEventEmitter {
     emitScrollToBlock(blockId: string, source: string = 'unknown') {
-        this.emit(WorkbenchEvent.SCROLL_TO_BLOCK, { blockId, source } as ScrollToBlockPayload);
+        this.bus.emit({ type: WorkbenchEvent.SCROLL_TO_BLOCK, payload: { blockId, source } });
     }
 
     emitHighlightBlock(blockId: string, source: string = 'unknown') {
-        this.emit(WorkbenchEvent.HIGHLIGHT_BLOCK, { blockId, source } as HighlightBlockPayload);
+        this.bus.emit({ type: WorkbenchEvent.HIGHLIGHT_BLOCK, payload: { blockId, source } });
     }
 
     emitStartWorkout(block: WodBlock) {
-        this.emit(WorkbenchEvent.START_WORKOUT, { block } as StartWorkoutPayload);
+        this.bus.emit({ type: WorkbenchEvent.START_WORKOUT, payload: { block } });
     }
 
     emitNavigateTo(entryId: string, view?: string) {
-        this.emit(WorkbenchEvent.NAVIGATE_TO, { entryId, view } as NavigateToPayload);
+        this.bus.emit({ type: WorkbenchEvent.NAVIGATE_TO, payload: { entryId, view } });
     }
 
-    onScrollToBlock(callback: (payload: ScrollToBlockPayload) => void) {
-        this.on(WorkbenchEvent.SCROLL_TO_BLOCK, callback);
-        return () => this.off(WorkbenchEvent.SCROLL_TO_BLOCK, callback);
+    // --- subscribe helpers ---
+
+    onScrollToBlock(callback: (payload: ScrollToBlockPayload) => void): () => void {
+        return this.bus.subscribe(e => {
+            if (e.type === WorkbenchEvent.SCROLL_TO_BLOCK) callback(e.payload);
+        });
     }
 
-    onHighlightBlock(callback: (payload: HighlightBlockPayload) => void) {
-        this.on(WorkbenchEvent.HIGHLIGHT_BLOCK, callback);
-        return () => this.off(WorkbenchEvent.HIGHLIGHT_BLOCK, callback);
+    onHighlightBlock(callback: (payload: HighlightBlockPayload) => void): () => void {
+        return this.bus.subscribe(e => {
+            if (e.type === WorkbenchEvent.HIGHLIGHT_BLOCK) callback(e.payload);
+        });
     }
 
-    onStartWorkout(callback: (payload: StartWorkoutPayload) => void) {
-        this.on(WorkbenchEvent.START_WORKOUT, callback);
-        return () => this.off(WorkbenchEvent.START_WORKOUT, callback);
+    onStartWorkout(callback: (payload: StartWorkoutPayload) => void): () => void {
+        return this.bus.subscribe(e => {
+            if (e.type === WorkbenchEvent.START_WORKOUT) callback(e.payload);
+        });
     }
 
-    onNavigateTo(callback: (payload: NavigateToPayload) => void) {
-        this.on(WorkbenchEvent.NAVIGATE_TO, callback);
-        return () => this.off(WorkbenchEvent.NAVIGATE_TO, callback);
+    onNavigateTo(callback: (payload: NavigateToPayload) => void): () => void {
+        return this.bus.subscribe(e => {
+            if (e.type === WorkbenchEvent.NAVIGATE_TO) callback(e.payload);
+        });
     }
 }
 

--- a/src/services/WorkoutEventBus.ts
+++ b/src/services/WorkoutEventBus.ts
@@ -1,131 +1,86 @@
 /**
- * WorkoutEventBus - Centralized event system for workout lifecycle events
- * 
- * This event bus decouples workout actions from component hierarchies.
- * Instead of passing callbacks through 4+ component layers, any component
- * can emit events and any component can subscribe to them.
- * 
+ * WorkoutEventBus - Centralized event system for workout lifecycle events.
+ *
+ * Backed by SimpleEventBus<WorkoutEvent>.  Public API is unchanged so all
+ * existing callers continue to work without modification.
+ *
  * Event Types:
  * - start-workout: User wants to start tracking a workout block
- * - stop-workout: User stopped/completed a workout
+ * - stop-workout:  User stopped/completed a workout
  * - pause-workout: User paused the workout
  * - resume-workout: User resumed the workout
- * 
+ * - next-segment:  (deprecated — will move to runtime.dispatch() per doctrine)
+ *
  * @example
  * ```typescript
- * // Emitting an event (from any component)
  * import { workoutEventBus } from '@/services/WorkoutEventBus';
+ *
+ * // Emit
  * workoutEventBus.emit({ type: 'start-workout', block: wodBlock });
- * 
- * // Subscribing to events (usually in a hook or provider)
+ *
+ * // Subscribe (returns unsubscribe function)
  * useEffect(() => {
  *   return workoutEventBus.subscribe((event) => {
- *     if (event.type === 'start-workout') {
- *       // Handle start workout
- *     }
+ *     if (event.type === 'start-workout') { ... }
  *   });
  * }, []);
  * ```
  */
 
 import type { WodBlock, WorkoutResults } from '../components/Editor/types';
+import { SimpleEventBus } from './events/SimpleEventBus';
 
 /**
- * Union type for all workout-related events
+ * Union type for all workout-related events.
+ *
+ * Note: `next-segment` is a runtime-internal concern that leaked here.
+ * It will be removed in a follow-up and routed via runtime.dispatch().
  */
-export type WorkoutEvent = 
+export type WorkoutEvent =
   | { type: 'start-workout'; block: WodBlock }
   | { type: 'stop-workout'; results: WorkoutResults }
   | { type: 'pause-workout' }
   | { type: 'resume-workout' }
   | { type: 'next-segment' };
 
-/**
- * Event subscriber function type
- */
+/** @deprecated Use the unsubscribe function returned by subscribe() */
 export type WorkoutEventSubscriber = (event: WorkoutEvent) => void;
 
-/**
- * WorkoutEventBus class - Simple pub/sub event bus
- * 
- * Thread-safe for React's concurrent mode.
- * Subscribers are called synchronously in registration order.
- */
 class WorkoutEventBus {
-  private subscribers = new Set<WorkoutEventSubscriber>();
+  private bus = new SimpleEventBus<WorkoutEvent>();
   private debugMode = false;
 
-  /**
-   * Enable/disable debug logging
-   */
   setDebugMode(enabled: boolean): void {
     this.debugMode = enabled;
   }
 
-  /**
-   * Subscribe to workout events
-   * @param fn - Callback function to receive events
-   * @returns Unsubscribe function
-   */
   subscribe(fn: WorkoutEventSubscriber): () => void {
-    this.subscribers.add(fn);
-    
-    if (this.debugMode) {
-
-    }
-    
-    // Return unsubscribe function
-    return () => {
-      this.subscribers.delete(fn);
-      if (this.debugMode) {
-
-      }
-    };
+    return this.bus.subscribe(fn);
   }
 
-  /**
-   * Emit an event to all subscribers
-   * @param event - The workout event to emit
-   */
   emit(event: WorkoutEvent): void {
     if (this.debugMode) {
-
+      console.debug('[WorkoutEventBus] emit', event.type);
     }
-    
-    this.subscribers.forEach(fn => {
-      try {
-        fn(event);
-      } catch (error) {
-        console.error('[WorkoutEventBus] Subscriber error:', error);
-      }
-    });
+    try {
+      this.bus.emit(event);
+    } catch (error) {
+      console.error('[WorkoutEventBus] Subscriber error:', error);
+    }
   }
 
-  /**
-   * Get the current subscriber count (for debugging)
-   */
   get subscriberCount(): number {
-    return this.subscribers.size;
+    return this.bus.size;
   }
 
-  /**
-   * Clear all subscribers (mainly for testing)
-   */
   clear(): void {
-    this.subscribers.clear();
-    if (this.debugMode) {
-
-    }
+    // Replace the underlying bus so all listeners are dropped atomically.
+    (this as any).bus = new SimpleEventBus<WorkoutEvent>();
   }
 }
 
-/**
- * Singleton instance of the workout event bus
- * Import this from components that need to emit or subscribe to events
- */
 export const workoutEventBus = new WorkoutEventBus();
 
-// Enable debug mode in development
 const windowWithDebug = typeof window !== 'undefined' ? window as Window & { __WOD_WIKI_DEBUG__?: boolean } : null;
 if (windowWithDebug?.__WOD_WIKI_DEBUG__) {
   workoutEventBus.setDebugMode(true);

--- a/src/services/WorkoutEventBus.ts
+++ b/src/services/WorkoutEventBus.ts
@@ -75,7 +75,7 @@ class WorkoutEventBus {
 
   clear(): void {
     // Replace the underlying bus so all listeners are dropped atomically.
-    (this as any).bus = new SimpleEventBus<WorkoutEvent>();
+    this.bus = new SimpleEventBus<WorkoutEvent>();
   }
 }
 

--- a/src/services/events/IServiceEventBus.ts
+++ b/src/services/events/IServiceEventBus.ts
@@ -1,0 +1,20 @@
+/**
+ * IServiceEventBus — canonical interface for service-layer event buses.
+ *
+ * Used by WorkbenchEventBus and WorkoutEventBus. The runtime EventBus
+ * (src/runtime/events/EventBus.ts) implements IEventBus and is intentionally
+ * separate — it handles scoped, owner-filtered action dispatch for the block
+ * execution hierarchy.
+ */
+export interface IServiceEventBus<T> {
+  /**
+   * Emit an event to all current subscribers.
+   */
+  emit(event: T): void;
+
+  /**
+   * Subscribe to events.
+   * @returns Unsubscribe function — call it to remove the listener.
+   */
+  subscribe(fn: (event: T) => void): () => void;
+}

--- a/src/services/events/SimpleEventBus.ts
+++ b/src/services/events/SimpleEventBus.ts
@@ -1,0 +1,24 @@
+import type { IServiceEventBus } from './IServiceEventBus';
+
+/**
+ * SimpleEventBus — single generic implementation of IServiceEventBus<T>.
+ *
+ * Replace WorkbenchEventBus and WorkoutEventBus class bodies with typed
+ * wrappers around this class.  The runtime EventBus remains separate.
+ */
+export class SimpleEventBus<T> implements IServiceEventBus<T> {
+  private listeners = new Set<(event: T) => void>();
+
+  emit(event: T): void {
+    this.listeners.forEach(fn => fn(event));
+  }
+
+  subscribe(fn: (event: T) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+
+  get size(): number {
+    return this.listeners.size;
+  }
+}


### PR DESCRIPTION
## Summary

Implements [doctrine-event-bus-unification](https://notes.forest-adhara.ts.net/Projects/wod-wiki/doctrine-event-bus-unification).

**Decision:** Replace four ad-hoc event bus implementations with two canonical types — one for the service layer, one for the runtime layer.

## Files Changed

| Action | File |
|--------|------|
| Add | `src/services/events/IServiceEventBus.ts` |
| Add | `src/services/events/SimpleEventBus.ts` |
| Refactor | `src/services/WorkbenchEventBus.ts` — class body → SimpleEventBus wrapper |
| Refactor | `src/services/WorkoutEventBus.ts` — class body → SimpleEventBus wrapper |

## What Changed

- **`IServiceEventBus<T>`** — canonical interface: `emit(event: T)` + `subscribe(fn) → unsubscribe`
- **`SimpleEventBus<T>`** — single generic implementation backing both buses
- **`WorkbenchEventBus`** — drops inline `SimpleEventEmitter` class; typed helper methods (`emitScrollToBlock`, `onScrollToBlock`, etc.) are preserved with identical signatures
- **`WorkoutEventBus`** — drops custom class body; public API (`subscribe`, `emit`, `clear`, `subscriberCount`, `setDebugMode`) fully preserved — no callers need to change
- **Runtime `EventBus`** — intentionally untouched; it implements `IEventBus` for scoped, owner-filtered block-hierarchy dispatch and is a different concern

## Not In This PR (follow-ups per doctrine)

- Remove `next-segment` from `WorkoutEvent` and route via `runtime.dispatch()`
- Wrap singleton exports in a context provider/factory for DI and test isolation
- Standardize all subscription points onto `subscribe()` returning unsubscribe (removing any remaining `on()`/`off()` call sites)