### PR TITLE
fix: unblock main release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
+  pages: write
+  id-token: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary
- grant the top-level main workflow the write/page/id-token permissions required by the reusable release workflow
- keep the release path aligned with the permissions already declared inside `.github/workflows/_release.yml`

## Validation
- `bunx prettier --parser yaml --check .github/workflows/main.yml`
- inspected failing startup_failure runs on main (`25927844914`, `25921570994`, `25900008140`) to confirm the reusable workflow permission mismatch pattern
