### PR TITLE
fix: complete release publish path

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -50,6 +50,12 @@ jobs:
         with:
           bun-version: 1.3.x
 
+      - name: Set up Node.js for npm publication
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -146,12 +152,62 @@ jobs:
               });
             }
 
+      - name: Validate npm publication prerequisites
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+
+          if (!pkg.name || typeof pkg.name !== 'string') {
+            throw new Error('package.json must define a publishable package name.');
+          }
+
+          if (!pkg.version || typeof pkg.version !== 'string') {
+            throw new Error('package.json must define a publishable version.');
+          }
+
+          if (pkg.private) {
+            throw new Error('package.json#private=true blocks npm publication.');
+          }
+
+          console.log(`Preparing npm publish for ${pkg.name}@${pkg.version}`);
+          NODE
+
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "NPM_TOKEN secret is required for release publication." >&2
+            exit 1
+          fi
+
+      - name: Publish package to npm (idempotent)
+        id: npm_publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "Package ${NAME}@${VERSION} already exists on npm; skipping publish."
+            exit 0
+          fi
+
+          npm publish --provenance --access public
+          echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "published_version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Write release summary
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
           cat <<EOF >> "$GITHUB_STEP_SUMMARY"
           ## Release summary
 
           - Released version: $VERSION
           - Pages URL: ${{ steps.deployment.outputs.page_url }}
+          - npm package: ${PACKAGE_NAME}@${{ steps.npm_publish.outputs.published_version }}
+          - npm publish executed: ${{ steps.npm_publish.outputs.published }}
           EOF

--- a/package.json
+++ b/package.json
@@ -3,6 +3,22 @@
   "version": "0.5.0",
   "description": "A React component library for parsing, displaying, and executing workout definitions using a specialized syntax. Features include a Monaco Editor integration for editing workout scripts, a runtime engine for execution, and components styled with Tailwind CSS.",
   "homepage": "https://github.com/SergeiGolos/wod-wiki#readme",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "style": "./dist/index.css",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bugs": {
     "url": "https://github.com/SergeiGolos/wod-wiki/issues"
   },

--- a/src/runtime/compiler/strategies/index.ts
+++ b/src/runtime/compiler/strategies/index.ts
@@ -10,7 +10,8 @@
  */
 
 // Root / Direct-build strategies
-export { IdleBlockStrategy, IdleBlockConfig, idleBlockStrategy } from './IdleBlockStrategy';
+export { IdleBlockStrategy, idleBlockStrategy } from './IdleBlockStrategy';
+export type { IdleBlockConfig } from './IdleBlockStrategy';
 export { SessionRootStrategy, sessionRootStrategy } from './SessionRootStrategy';
 export { WaitingToStartStrategy } from './WaitingToStartStrategy';
 


### PR DESCRIPTION
## Summary
- add npm publication to the reusable release workflow
- add publish metadata so the package can ship from CI
- include the library-build fix required for the release path to clear

## Validation
- `bunx prettier --check package.json .github/workflows/_release.yml`
- `bun install --frozen-lockfile`
- `bun run build-library`
- `npm pack --dry-run`
