### PR TITLE
fix: redirect bare /playground to a fresh note

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -17,7 +17,6 @@ import { ThemeProvider, useTheme } from '@/components/theme/ThemeProvider'
 import { AudioProvider } from '@/components/audio/AudioContext'
 import { BrowserRouter, Routes, Route, useNavigate, useParams, useLocation } from 'react-router-dom'
 import { HomeView as _HomeView } from './views/HomeView' // kept for potential re-use; not rendered on '/' anymore
-import { PlaygroundLandingPage } from './pages/PlaygroundLandingPage'
 import { findCanvasPage, canvasRoutes } from './canvas/canvasRoutes'
 import { MarkdownCanvasPage } from './canvas/MarkdownCanvasPage'
 import { JournalWeeklyPage } from './views/ListViews'
@@ -47,8 +46,7 @@ import { Toaster } from '@/components/ui/toaster'
 import { PageActions } from './pages/shared/PageActions'
 import { ActionsMenu } from './pages/shared/PageToolbar'
 import { mapIndexToL3 } from './pages/shared/pageUtils'
-import { DEFAULT_PLAYGROUND_CONTENT } from './templates/defaultPlaygroundContent'
-import { createPlaygroundPage } from './services/createPlaygroundPage'
+import { PlaygroundRedirect } from './pages/PlaygroundRedirect'
 
 // ── Constants for Sidebar Navigation ────────────────────────────────
 
@@ -84,33 +82,6 @@ export interface WorkoutItem {
   /** When true, this item is excluded from all search results (front matter: `search: hidden`) */
   searchHidden?: boolean
 }
-/**
- * Navigate to the most-recently edited playground page, or create one if none
- * exist yet. Used by the / route.
- */
-function PlaygroundRedirect() {
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    ;(async () => {
-      const pages = await playgroundDB.getPagesByCategory('playground')
-      if (pages.length > 0) {
-        const latest = pages.sort((a, b) => b.updatedAt - a.updatedAt)[0]!
-        navigate(`/playground/${encodeURIComponent(latest.name)}`, { replace: true })
-      } else {
-        const id = await createPlaygroundPage(DEFAULT_PLAYGROUND_CONTENT.content)
-        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
-      }
-    })()
-  }, [navigate])
-
-  return (
-    <div className="flex-1 flex items-center justify-center text-zinc-400">
-      Loading…
-    </div>
-  )
-}
-
 function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<() => void> }) {
   const navigate = useNavigate()
   const { category: urlCategory, name: urlName, id: playgroundId } = useParams<{ category: string; name: string; id: string }>()
@@ -649,7 +620,7 @@ export function App() {
                 <Route path="/collections/:slug" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/workout/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/load" element={<LoadZipPage />} />
-                <Route path="/playground" element={<PlaygroundLandingPage />} />
+                <Route path="/playground" element={<PlaygroundRedirect />} />
                 <Route path="/playground/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/note/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/journal/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { render, waitFor } from '@testing-library/react'
+
+const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
+const createPlaygroundPageCalls: string[] = []
+
+mock.module('react-router-dom', () => ({
+  useNavigate: () => (to: string, options?: { replace?: boolean }) => {
+    navigateCalls.push({ to, options })
+  },
+}))
+
+mock.module('../services/createPlaygroundPage', () => ({
+  createPlaygroundPage: async (content: string) => {
+    createPlaygroundPageCalls.push(content)
+    return '2026-05-19 15.30'
+  },
+}))
+
+mock.module('../templates/defaultPlaygroundContent', () => ({
+  EMPTY_PLAYGROUND_CONTENT: {
+    content: '# New playground\n',
+  },
+}))
+
+const componentModule = import('./PlaygroundRedirect')
+
+beforeEach(() => {
+  navigateCalls.length = 0
+  createPlaygroundPageCalls.length = 0
+})
+
+describe('PlaygroundRedirect', () => {
+  it('creates a fresh playground note and redirects to its canonical route', async () => {
+    const { PlaygroundRedirect } = await componentModule
+
+    render(<PlaygroundRedirect />)
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual(['# New playground\n'])
+      expect(navigateCalls).toEqual([
+        {
+          to: '/playground/2026-05-19%2015.30',
+          options: { replace: true },
+        },
+      ])
+    })
+  })
+})

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
 const createPlaygroundPageCalls: string[] = []
+let shouldFailCreatePlaygroundPage = false
 
 mock.module('react-router-dom', () => ({
   useNavigate: () => (to: string, options?: { replace?: boolean }) => {
@@ -10,11 +11,16 @@ mock.module('react-router-dom', () => ({
   },
 }))
 
+const createPlaygroundPageMock = mock(async (content: string) => {
+  createPlaygroundPageCalls.push(content)
+  if (shouldFailCreatePlaygroundPage) {
+    throw new DOMException('Blocked by browser', 'SecurityError')
+  }
+  return '2026-05-19 15.30'
+})
+
 mock.module('../services/createPlaygroundPage', () => ({
-  createPlaygroundPage: async (content: string) => {
-    createPlaygroundPageCalls.push(content)
-    return '2026-05-19 15.30'
-  },
+  createPlaygroundPage: createPlaygroundPageMock,
 }))
 
 mock.module('../templates/defaultPlaygroundContent', () => ({
@@ -28,6 +34,8 @@ const componentModule = import('./PlaygroundRedirect')
 beforeEach(() => {
   navigateCalls.length = 0
   createPlaygroundPageCalls.length = 0
+  shouldFailCreatePlaygroundPage = false
+  createPlaygroundPageMock.mockClear()
 })
 
 describe('PlaygroundRedirect', () => {
@@ -44,6 +52,28 @@ describe('PlaygroundRedirect', () => {
           options: { replace: true },
         },
       ])
+    })
+  })
+
+  it('renders a retry state when note creation fails, then redirects after retry', async () => {
+    const { PlaygroundRedirect } = await componentModule
+    shouldFailCreatePlaygroundPage = true
+
+    render(<PlaygroundRedirect />)
+
+    await screen.findByText('Unable to create a new playground note.')
+    expect(navigateCalls).toEqual([])
+
+    shouldFailCreatePlaygroundPage = false
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls.length).toBeGreaterThanOrEqual(2)
+      expect(createPlaygroundPageCalls.every(content => content === '# New playground\n')).toBe(true)
+      expect(navigateCalls).toContainEqual({
+        to: '/playground/2026-05-19%2015.30',
+        options: { replace: true },
+      })
     })
   })
 })

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { createPlaygroundPage } from '../services/createPlaygroundPage'
+import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
+
+/**
+ * Canonical entry route for both `/` and `/playground`.
+ *
+ * Always creates a fresh playground note, then redirects to `/playground/:id`.
+ */
+export function PlaygroundRedirect() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
+      if (!cancelled) {
+        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate])
+
+  return (
+    <div className="flex-1 flex items-center justify-center text-zinc-400">
+      Loading…
+    </div>
+  )
+}

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { createPlaygroundPage } from '../services/createPlaygroundPage'
@@ -11,21 +11,47 @@ import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
  */
 export function PlaygroundRedirect() {
   const navigate = useNavigate()
+  const [error, setError] = useState(false)
+  const [attempt, setAttempt] = useState(0)
 
   useEffect(() => {
     let cancelled = false
 
     ;(async () => {
-      const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
-      if (!cancelled) {
-        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+      try {
+        const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
+        if (!cancelled) {
+          navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true)
+        }
       }
     })()
 
     return () => {
       cancelled = true
     }
-  }, [navigate])
+  }, [navigate, attempt])
+
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 text-zinc-300 px-4 text-center">
+        <p role="alert">Unable to create a new playground note.</p>
+        <button
+          type="button"
+          className="rounded border border-zinc-600 px-3 py-1 text-sm hover:bg-zinc-800"
+          onClick={() => {
+            setError(false)
+            setAttempt(value => value + 1)
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="flex-1 flex items-center justify-center text-zinc-400">


### PR DESCRIPTION
## Summary
- make `/playground` use the same canonical redirect flow as `/`
- create a fresh playground note, then redirect to `/playground/:id`
- add focused regression coverage for the redirect component

## Validation
- `bun test playground/src/pages/PlaygroundRedirect.test.tsx --preload ./tests/unit-setup.ts --isolate`
- `bun run build:app`
