### PR TITLE
Implement auto-versioning and fix playground redirects

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -24,29 +24,37 @@ jobs:
 
       - name: Compute and set next version
         run: |
-          # Resolve latest git tag (the most recent semver tag on any branch)
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          # Find the highest semver tag across all refs (not just HEAD-reachable)
+          LATEST_TAG=$(git for-each-ref refs/tags \
+            --sort=-v:refname \
+            --format '%(refname:short)' \
+            | grep -E '^v?[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+            | head -1)
 
           if [ -n "$LATEST_TAG" ]; then
             VERSION="${LATEST_TAG#v}"
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
             MINOR=$(echo "$VERSION" | cut -d. -f2)
-            echo "Latest tag: $LATEST_TAG  →  MAJOR=$MAJOR  MINOR=$MINOR"
-            COMMITS=$(git log "${LATEST_TAG}..HEAD" --format="%s")
+            echo "Latest semver tag: $LATEST_TAG  →  MAJOR=$MAJOR  MINOR=$MINOR"
+            # Include both subject (%s) and body (%b) to catch BREAKING CHANGE footers
+            COMMITS=$(git log "${LATEST_TAG}..HEAD" --format="%s%n%b")
           else
             PKG_VERSION=$(node -p "require('./package.json').version")
             MAJOR=$(echo "$PKG_VERSION" | cut -d. -f1)
             MINOR=$(echo "$PKG_VERSION" | cut -d. -f2)
-            echo "No tags found; seeding from package.json $PKG_VERSION  →  MAJOR=$MAJOR  MINOR=$MINOR"
-            COMMITS=$(git log --format="%s")
+            echo "No semver tags found; seeding from package.json $PKG_VERSION  →  MAJOR=$MAJOR  MINOR=$MINOR"
+            COMMITS=$(git log --format="%s%n%b")
           fi
 
-          # Determine version bump from conventional commit prefixes
-          # breaking: → major  |  feature: → minor  |  fix: (or anything else) → patch only
+          # Determine version bump using Conventional Commits conventions:
+          #   breaking: / breaking( / feat! / fix! / <type>!: / BREAKING CHANGE: → major
+          #   feature: / feature( / feat: / feat( → minor
+          #   fix: or anything else → patch only
           BUMP="patch"
-          if echo "$COMMITS" | grep -qiE "^breaking[:(]"; then
+          if echo "$COMMITS" | grep -qE "^(breaking[:(]|BREAKING CHANGE:)" || \
+             echo "$COMMITS" | grep -qiE "^[a-z]+(\([^)]*\))?!:"; then
             BUMP="major"
-          elif echo "$COMMITS" | grep -qiE "^feature[:(]"; then
+          elif echo "$COMMITS" | grep -qiE "^(feature[:(]|feat[:(])"; then
             BUMP="minor"
           fi
           echo "Detected bump: $BUMP"
@@ -132,8 +140,10 @@ jobs:
             const sha = context.sha;
 
             let tagExistsAtSha = false;
+            let tagExists = false;
             try {
               const ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+              tagExists = true;
               tagExistsAtSha = ref.data.object.sha === sha;
             } catch (error) {
               if (error.status !== 404) {
@@ -142,12 +152,24 @@ jobs:
             }
 
             if (!tagExistsAtSha) {
-              await github.rest.git.createRef({
-                owner,
-                repo,
-                ref: `refs/tags/${tag}`,
-                sha,
-              });
+              if (tagExists) {
+                // Tag exists at a different SHA (e.g., a previous failed run with the
+                // same run_number); move it forward to this commit.
+                await github.rest.git.updateRef({
+                  owner,
+                  repo,
+                  ref: `tags/${tag}`,
+                  sha,
+                  force: true,
+                });
+              } else {
+                await github.rest.git.createRef({
+                  owner,
+                  repo,
+                  ref: `refs/tags/${tag}`,
+                  sha,
+                });
+              }
             }
 
             try {

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -22,28 +22,54 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate release version is available for this commit
-        uses: actions/github-script@v7
-        with:
-          script: |
+      - name: Compute and set next version
+        run: |
+          # Resolve latest git tag (the most recent semver tag on any branch)
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -n "$LATEST_TAG" ]; then
+            VERSION="${LATEST_TAG#v}"
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            echo "Latest tag: $LATEST_TAG  →  MAJOR=$MAJOR  MINOR=$MINOR"
+            COMMITS=$(git log "${LATEST_TAG}..HEAD" --format="%s")
+          else
+            PKG_VERSION=$(node -p "require('./package.json').version")
+            MAJOR=$(echo "$PKG_VERSION" | cut -d. -f1)
+            MINOR=$(echo "$PKG_VERSION" | cut -d. -f2)
+            echo "No tags found; seeding from package.json $PKG_VERSION  →  MAJOR=$MAJOR  MINOR=$MINOR"
+            COMMITS=$(git log --format="%s")
+          fi
+
+          # Determine version bump from conventional commit prefixes
+          # breaking: → major  |  feature: → minor  |  fix: (or anything else) → patch only
+          BUMP="patch"
+          if echo "$COMMITS" | grep -qiE "^breaking[:(]"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qiE "^feature[:(]"; then
+            BUMP="minor"
+          fi
+          echo "Detected bump: $BUMP"
+
+          # Apply bump; PATCH is always the GitHub Actions run number for uniqueness
+          if [ "$BUMP" = "major" ]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+          elif [ "$BUMP" = "minor" ]; then
+            MINOR=$((MINOR + 1))
+          fi
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${{ github.run_number }}"
+          echo "New version: $NEW_VERSION"
+
+          # Write back to package.json so all downstream steps pick it up
+          node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-            const tag = pkg.version;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const sha = context.sha;
-
-            try {
-              const ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
-              if (ref.data.object.sha !== sha) {
-                core.setFailed(`Tag ${tag} already exists at ${ref.data.object.sha}. Bump package.json before merging another main release.`);
-                return;
-              }
-            } catch (error) {
-              if (error.status !== 404) {
-                throw error;
-              }
-            }
+            pkg.version = '${NEW_VERSION}';
+            fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "package.json updated to $NEW_VERSION"
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -17,7 +17,6 @@ import { ThemeProvider, useTheme } from '@/components/theme/ThemeProvider'
 import { AudioProvider } from '@/components/audio/AudioContext'
 import { BrowserRouter, Routes, Route, useNavigate, useParams, useLocation } from 'react-router-dom'
 import { HomeView as _HomeView } from './views/HomeView' // kept for potential re-use; not rendered on '/' anymore
-import { PlaygroundLandingPage } from './pages/PlaygroundLandingPage'
 import { findCanvasPage, canvasRoutes } from './canvas/canvasRoutes'
 import { MarkdownCanvasPage } from './canvas/MarkdownCanvasPage'
 import { JournalWeeklyPage } from './views/ListViews'
@@ -47,8 +46,7 @@ import { Toaster } from '@/components/ui/toaster'
 import { PageActions } from './pages/shared/PageActions'
 import { ActionsMenu } from './pages/shared/PageToolbar'
 import { mapIndexToL3 } from './pages/shared/pageUtils'
-import { DEFAULT_PLAYGROUND_CONTENT } from './templates/defaultPlaygroundContent'
-import { createPlaygroundPage } from './services/createPlaygroundPage'
+import { PlaygroundRedirect } from './pages/PlaygroundRedirect'
 
 // ── Constants for Sidebar Navigation ────────────────────────────────
 
@@ -84,33 +82,6 @@ export interface WorkoutItem {
   /** When true, this item is excluded from all search results (front matter: `search: hidden`) */
   searchHidden?: boolean
 }
-/**
- * Navigate to the most-recently edited playground page, or create one if none
- * exist yet. Used by the / route.
- */
-function PlaygroundRedirect() {
-  const navigate = useNavigate()
-
-  useEffect(() => {
-    ;(async () => {
-      const pages = await playgroundDB.getPagesByCategory('playground')
-      if (pages.length > 0) {
-        const latest = pages.sort((a, b) => b.updatedAt - a.updatedAt)[0]!
-        navigate(`/playground/${encodeURIComponent(latest.name)}`, { replace: true })
-      } else {
-        const id = await createPlaygroundPage(DEFAULT_PLAYGROUND_CONTENT.content)
-        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
-      }
-    })()
-  }, [navigate])
-
-  return (
-    <div className="flex-1 flex items-center justify-center text-zinc-400">
-      Loading…
-    </div>
-  )
-}
-
 function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<() => void> }) {
   const navigate = useNavigate()
   const { category: urlCategory, name: urlName, id: playgroundId } = useParams<{ category: string; name: string; id: string }>()
@@ -649,7 +620,7 @@ export function App() {
                 <Route path="/collections/:slug" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/workout/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/load" element={<LoadZipPage />} />
-                <Route path="/playground" element={<PlaygroundLandingPage />} />
+                <Route path="/playground" element={<PlaygroundRedirect />} />
                 <Route path="/playground/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/note/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                 <Route path="/journal/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { render, waitFor } from '@testing-library/react'
+
+const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
+const createPlaygroundPageCalls: string[] = []
+
+mock.module('react-router-dom', () => ({
+  useNavigate: () => (to: string, options?: { replace?: boolean }) => {
+    navigateCalls.push({ to, options })
+  },
+}))
+
+mock.module('../services/createPlaygroundPage', () => ({
+  createPlaygroundPage: async (content: string) => {
+    createPlaygroundPageCalls.push(content)
+    return '2026-05-19 15.30'
+  },
+}))
+
+mock.module('../templates/defaultPlaygroundContent', () => ({
+  EMPTY_PLAYGROUND_CONTENT: {
+    content: '# New playground\n',
+  },
+}))
+
+const componentModule = import('./PlaygroundRedirect')
+
+beforeEach(() => {
+  navigateCalls.length = 0
+  createPlaygroundPageCalls.length = 0
+})
+
+describe('PlaygroundRedirect', () => {
+  it('creates a fresh playground note and redirects to its canonical route', async () => {
+    const { PlaygroundRedirect } = await componentModule
+
+    render(<PlaygroundRedirect />)
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual(['# New playground\n'])
+      expect(navigateCalls).toEqual([
+        {
+          to: '/playground/2026-05-19%2015.30',
+          options: { replace: true },
+        },
+      ])
+    })
+  })
+})

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
-import { render, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
 const createPlaygroundPageCalls: string[] = []
+let shouldFailCreatePlaygroundPage = false
 
 mock.module('react-router-dom', () => ({
   useNavigate: () => (to: string, options?: { replace?: boolean }) => {
@@ -10,11 +11,16 @@ mock.module('react-router-dom', () => ({
   },
 }))
 
+const createPlaygroundPageMock = mock(async (content: string) => {
+  createPlaygroundPageCalls.push(content)
+  if (shouldFailCreatePlaygroundPage) {
+    throw new DOMException('Blocked by browser', 'SecurityError')
+  }
+  return '2026-05-19 15.30'
+})
+
 mock.module('../services/createPlaygroundPage', () => ({
-  createPlaygroundPage: async (content: string) => {
-    createPlaygroundPageCalls.push(content)
-    return '2026-05-19 15.30'
-  },
+  createPlaygroundPage: createPlaygroundPageMock,
 }))
 
 mock.module('../templates/defaultPlaygroundContent', () => ({
@@ -28,6 +34,8 @@ const componentModule = import('./PlaygroundRedirect')
 beforeEach(() => {
   navigateCalls.length = 0
   createPlaygroundPageCalls.length = 0
+  shouldFailCreatePlaygroundPage = false
+  createPlaygroundPageMock.mockClear()
 })
 
 describe('PlaygroundRedirect', () => {
@@ -44,6 +52,28 @@ describe('PlaygroundRedirect', () => {
           options: { replace: true },
         },
       ])
+    })
+  })
+
+  it('renders a retry state when note creation fails, then redirects after retry', async () => {
+    const { PlaygroundRedirect } = await componentModule
+    shouldFailCreatePlaygroundPage = true
+
+    render(<PlaygroundRedirect />)
+
+    await screen.findByText('Unable to create a new playground note.')
+    expect(navigateCalls).toEqual([])
+
+    shouldFailCreatePlaygroundPage = false
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls.length).toBeGreaterThanOrEqual(2)
+      expect(createPlaygroundPageCalls.every(content => content === '# New playground\n')).toBe(true)
+      expect(navigateCalls).toContainEqual({
+        to: '/playground/2026-05-19%2015.30',
+        options: { replace: true },
+      })
     })
   })
 })

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { createPlaygroundPage } from '../services/createPlaygroundPage'
+import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
+
+/**
+ * Canonical entry route for both `/` and `/playground`.
+ *
+ * Always creates a fresh playground note, then redirects to `/playground/:id`.
+ */
+export function PlaygroundRedirect() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
+      if (!cancelled) {
+        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [navigate])
+
+  return (
+    <div className="flex-1 flex items-center justify-center text-zinc-400">
+      Loading…
+    </div>
+  )
+}

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { createPlaygroundPage } from '../services/createPlaygroundPage'
@@ -11,21 +11,47 @@ import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
  */
 export function PlaygroundRedirect() {
   const navigate = useNavigate()
+  const [error, setError] = useState(false)
+  const [attempt, setAttempt] = useState(0)
 
   useEffect(() => {
     let cancelled = false
 
     ;(async () => {
-      const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
-      if (!cancelled) {
-        navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+      try {
+        const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
+        if (!cancelled) {
+          navigate(`/playground/${encodeURIComponent(id)}`, { replace: true })
+        }
+      } catch {
+        if (!cancelled) {
+          setError(true)
+        }
       }
     })()
 
     return () => {
       cancelled = true
     }
-  }, [navigate])
+  }, [navigate, attempt])
+
+  if (error) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-3 text-zinc-300 px-4 text-center">
+        <p role="alert">Unable to create a new playground note.</p>
+        <button
+          type="button"
+          className="rounded border border-zinc-600 px-3 py-1 text-sm hover:bg-zinc-800"
+          onClick={() => {
+            setError(false)
+            setAttempt(value => value + 1)
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="flex-1 flex items-center justify-center text-zinc-400">


### PR DESCRIPTION
This pull request introduces a new, more robust approach for handling the `/playground` route in the Playground app, ensuring that visiting this route always creates a fresh playground note and handles failures gracefully. It also refactors and improves the release workflow to better manage version bumps and tag creation. The most important changes are grouped below.

### Playground Route Handling

* Introduced a new `PlaygroundRedirect` component that always creates a new playground note and redirects to its canonical route, with improved error handling and a retry mechanism. This replaces the previous logic that redirected to the most recently edited note or created one if none existed. (`playground/src/pages/PlaygroundRedirect.tsx`, `playground/src/App.tsx`) [[1]](diffhunk://#diff-6e42ae7e479ad4c31e365cb68576e4fe804ef89ec94f5bab9038478e4dcdd15cR1-R61) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L50-R49) [[3]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L652-R623) [[4]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L87-L113) [[5]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L20)
* Added comprehensive tests for the new `PlaygroundRedirect` behavior, including note creation, redirection, and error/retry handling. (`playground/src/pages/PlaygroundRedirect.test.tsx`)

### Release Workflow Improvements

* Replaced the previous release version validation with a script that computes the next version based on semantic versioning and Conventional Commits, updating `package.json` accordingly. This ensures consistent and automated version management. (`.github/workflows/_release.yml`)
* Improved tag management in the release workflow: if a tag exists at a different commit (e.g., due to a failed run), the workflow now force-updates the tag to the current commit, ensuring releases are not blocked by tag collisions. (`.github/workflows/_release.yml`) [[1]](diffhunk://#diff-6803ac041add8fc8f66baf57b71c879650be38f412fa0996883ccc584b337cbeR143-R146) [[2]](diffhunk://#diff-6803ac041add8fc8f66baf57b71c879650be38f412fa0996883ccc584b337cbeR155-R173)