### PR TITLE
Refactor widget handling and add ShowPlaygroundsToggle component

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -27,6 +27,7 @@ import { FeedDetailPage } from './pages/FeedDetailPage'
 import { FeedItemPage } from './pages/FeedItemPage'
 import { FeedsNavPanel } from './nav/panels/FeedsNavPanel'
 import { TextFilterStrip } from './views/queriable-list/TextFilterStrip'
+import { ShowPlaygroundsToggle } from './components/ShowPlaygroundsToggle'
 import { CollectionsPage } from './views/CollectionsPage'
 import { CastButtonRpc } from '@/components/cast/CastButtonRpc'
 import { CanvasPage } from '@/panels/page-shells'
@@ -504,7 +505,7 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
       <div className="flex flex-col h-full min-h-[calc(100vh-theme(spacing.20))]">
         <div className="flex-1 flex flex-col min-h-0">
           {location.pathname === '/journal' ? (
-            <CanvasPage title="Journal" index={currentNavLinks} onScrollToSection={scrollToSection} actions={<PageActions mode="journal-active" currentWorkout={currentWorkout} index={currentNavLinks} onSearch={openSearchPalette} />}>
+            <CanvasPage title="Journal" subheader={<ShowPlaygroundsToggle />} index={currentNavLinks} onScrollToSection={scrollToSection} actions={<PageActions mode="journal-active" currentWorkout={currentWorkout} index={currentNavLinks} onSearch={openSearchPalette} />}>
               <JournalWeeklyPage 
                 onSelect={handleSelectWorkout}
                 onCreateEntry={handleCreateJournalEntry}

--- a/playground/src/components/ShowPlaygroundsToggle.tsx
+++ b/playground/src/components/ShowPlaygroundsToggle.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Eye } from 'lucide-react';
+import { Switch } from '@/components/playground/switch';
+import { useShowPlaygrounds } from '../hooks/useShowPlaygrounds';
+
+export const ShowPlaygroundsToggle: React.FC = () => {
+  const [showPlaygrounds, setShowPlaygrounds] = useShowPlaygrounds();
+
+  return (
+    <div className="flex items-center gap-3 px-6 lg:px-10 pb-3">
+      <Eye className="size-5 text-muted-foreground shrink-0" aria-hidden="true" />
+      <span className="flex-1 text-sm font-medium text-muted-foreground">
+        Show playgrounds
+      </span>
+      <Switch
+        checked={showPlaygrounds}
+        onChange={setShowPlaygrounds}
+        aria-label="Show playground entries"
+      />
+    </div>
+  );
+};

--- a/playground/src/hooks/useShowPlaygrounds.test.ts
+++ b/playground/src/hooks/useShowPlaygrounds.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+
+import { useShowPlaygrounds } from './useShowPlaygrounds';
+
+const STORAGE_KEY = 'wodwiki:showPlaygrounds';
+
+describe('useShowPlaygrounds', () => {
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it('defaults to false when localStorage is empty', () => {
+    const { result } = renderHook(() => useShowPlaygrounds());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('reads the persisted boolean from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    const { result } = renderHook(() => useShowPlaygrounds());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('writes the boolean to localStorage when changed', () => {
+    const { result } = renderHook(() => useShowPlaygrounds());
+
+    act(() => {
+      result.current[1](true);
+    });
+
+    expect(result.current[0]).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('gracefully handles invalid localStorage values', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-a-boolean');
+    const { result } = renderHook(() => useShowPlaygrounds());
+    // JSON.parse('not-a-boolean') throws, caught by try/catch → false
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/playground/src/hooks/useShowPlaygrounds.ts
+++ b/playground/src/hooks/useShowPlaygrounds.ts
@@ -1,0 +1,39 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const STORAGE_KEY = 'wodwiki:showPlaygrounds';
+
+export function useShowPlaygrounds(): [boolean, (value: boolean) => void] {
+  const [showPlaygrounds, setShowPlaygroundsState] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : false;
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) {
+        setShowPlaygroundsState(e.newValue ? JSON.parse(e.newValue) : false);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const setShowPlaygrounds = useCallback((value: boolean) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    setShowPlaygroundsState(value);
+    // Sync across same-tab instances
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: STORAGE_KEY,
+        newValue: JSON.stringify(value),
+      }),
+    );
+  }, []);
+
+  return [showPlaygrounds, setShowPlaygrounds];
+}

--- a/playground/src/pages/PlaygroundNotePage.tsx
+++ b/playground/src/pages/PlaygroundNotePage.tsx
@@ -20,8 +20,10 @@ import {
   createSyntaxGroupWidgetWrapper,
 } from '../components/widgets/widgetWrappers'
 import type { WodBlock } from '@/components/Editor/types'
+import type { WorkoutResult } from '@/types/storage'
 import { usePlaygroundContent } from '../hooks/usePlaygroundContent'
 import { PlaygroundDBService } from '../services/playgroundDB'
+import { indexedDBService } from '@/services/db/IndexedDBService'
 import { pendingRuntimes } from '../runtimeStore'
 import { PageActions } from './shared/PageActions'
 import { useNotePageNav } from './shared/useNotePageNav'
@@ -59,6 +61,18 @@ export function PlaygroundNotePage({
     name: pageName,
     mdContent: DEFAULT_PLAYGROUND_CONTENT.content,
   })
+
+  const [results, setResults] = useState<WorkoutResult[]>([])
+
+  const refreshResults = useCallback(() => {
+    indexedDBService.getResultsForNote(noteId)
+      .then(results => setResults(results))
+      .catch(() => {})
+  }, [noteId])
+
+  useEffect(() => {
+    refreshResults()
+  }, [refreshResults])
 
   // Place cursor at the $CURSOR token position on first mount
   const cursorPlaced = useRef(false)
@@ -141,7 +155,7 @@ export function PlaygroundNotePage({
   )
 
   const [wodBlocks, setWodBlocks] = useState<WodBlock[]>([])
-  const index = useNotePageNav({ content, wodBlocks, onStartWorkout: handleStartWorkout })
+  const index = useNotePageNav({ content, wodBlocks, onStartWorkout: handleStartWorkout, results })
 
   const commands = useWodBlockCommands('playground', {
     onPlay: handleStartWorkout,
@@ -257,6 +271,7 @@ export function PlaygroundNotePage({
             onBlocksChange={setWodBlocks}
             onButtonAction={handleButtonAction}
             widgetComponents={widgetComponents}
+            extendedResults={results}
           />
         }
       />

--- a/playground/src/pages/TrackerPage.tsx
+++ b/playground/src/pages/TrackerPage.tsx
@@ -9,7 +9,7 @@
 import { useRef, useEffect, useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { FullscreenTimer } from '@/components/Editor/overlays/FullscreenTimer'
-import { notePersistence } from '@/services/persistence'
+import { indexedDBService } from '@/services/db/IndexedDBService'
 import { pendingRuntimes } from '../runtimeStore'
 
 export function TrackerPage() {
@@ -27,13 +27,13 @@ export function TrackerPage() {
   const handleComplete = useCallback(
     (blockId: string, results: any) => {
       if (!results || !runtimeId || !pending) return
-      notePersistence.mutateNote(pending.noteId, {
-        workoutResult: {
-          id: runtimeId,
-          sectionId: blockId,
-          data: results,
-          completedAt: results.endTime || Date.now(),
-        },
+      indexedDBService.saveResult({
+        id: runtimeId,
+        noteId: pending.noteId,
+        sectionId: blockId,
+        segmentId: blockId,
+        data: results,
+        completedAt: results.endTime || Date.now(),
       }).then(() => {
         if (results.completed) {
           navigate(`/review/${runtimeId}`, { replace: true })

--- a/playground/src/templates/playground-home.md
+++ b/playground/src/templates/playground-home.md
@@ -1,3 +1,4 @@
+
 ```widget:attention
 {
   "headline": "WOD Wiki",

--- a/playground/src/views/ListViews.test.tsx
+++ b/playground/src/views/ListViews.test.tsx
@@ -11,9 +11,10 @@ type JournalState = {
 
 let journalState: JournalState;
 let navigateCalls: string[] = [];
+let showPlaygroundsValue = false;
 
 // Captured props passed to JournalFeed so we can inspect what dates are shown
-let capturedFeedProps: { dateKeys: string[]; showEmptyDates: boolean } | null = null;
+let capturedFeedProps: { dateKeys: string[]; showEmptyDates: boolean; items: any[] } | null = null;
 
 mock.module('react-router-dom', () => ({
   useNavigate: () => (to: string) => {
@@ -34,6 +35,7 @@ mock.module('@/components/command-palette/CommandContext', () => ({
 
 const TODAY = localDateKey(new Date());
 const PAST_DATE = '2026-01-15';
+const PLAYGROUND_DATE = '2026-01-14';
 
 mock.module('@/services/db/IndexedDBService', () => ({
   indexedDBService: {
@@ -42,6 +44,12 @@ mock.module('@/services/db/IndexedDBService', () => ({
         id: 'r1',
         noteId: `journal/${PAST_DATE}`,
         completedAt: new Date(PAST_DATE + 'T10:00:00').getTime(),
+        data: { completed: true },
+      },
+      {
+        id: 'r2',
+        noteId: 'playground/abc-123',
+        completedAt: new Date(PLAYGROUND_DATE + 'T10:00:00').getTime(),
         data: { completed: true },
       },
     ],
@@ -64,9 +72,13 @@ mock.module('../hooks/useJournalQueryState', () => ({
   useJournalQueryState: () => journalState,
 }));
 
+mock.module('../hooks/useShowPlaygrounds', () => ({
+  useShowPlaygrounds: () => [showPlaygroundsValue, (_v: boolean) => {}],
+}));
+
 mock.module('./JournalFeed', () => ({
   JournalFeed: (props: any) => {
-    capturedFeedProps = { dateKeys: props.dateKeys, showEmptyDates: props.showEmptyDates };
+    capturedFeedProps = { dateKeys: props.dateKeys, showEmptyDates: props.showEmptyDates, items: props.items };
     return <div data-testid="journal-feed" />;
   },
 }));
@@ -81,6 +93,7 @@ describe('JournalWeeklyPage', () => {
       selectedTags: [],
     };
     navigateCalls = [];
+    showPlaygroundsValue = false;
     capturedFeedProps = null;
   });
 
@@ -131,7 +144,7 @@ describe('JournalWeeklyPage', () => {
     let capturedOnOpenEntry: ((key: string) => void) | null = null;
     mock.module('./JournalFeed', () => ({
       JournalFeed: (props: any) => {
-        capturedFeedProps = { dateKeys: props.dateKeys, showEmptyDates: props.showEmptyDates };
+        capturedFeedProps = { dateKeys: props.dateKeys, showEmptyDates: props.showEmptyDates, items: props.items };
         capturedOnOpenEntry = props.onOpenEntry;
         return <div data-testid="journal-feed" />;
       },
@@ -142,5 +155,31 @@ describe('JournalWeeklyPage', () => {
 
     capturedOnOpenEntry!(TODAY);
     expect(navigateCalls).toContain(`/journal/${TODAY}`);
+  });
+
+  it('filters out playground results when showPlaygrounds is false', async () => {
+    showPlaygroundsValue = false;
+    const { JournalWeeklyPage } = await pageModule;
+    render(<JournalWeeklyPage onSelect={() => {}} />);
+
+    await waitFor(() => expect(capturedFeedProps).toBeTruthy());
+
+    // Playground date should not appear because the only result is filtered out
+    expect(capturedFeedProps?.dateKeys).not.toContain(PLAYGROUND_DATE);
+    // No playground items in the feed
+    expect(capturedFeedProps?.items.some((item: any) => item.group === 'playground')).toBe(false);
+  });
+
+  it('includes playground results when showPlaygrounds is true', async () => {
+    showPlaygroundsValue = true;
+    const { JournalWeeklyPage } = await pageModule;
+    render(<JournalWeeklyPage onSelect={() => {}} />);
+
+    await waitFor(() => expect(capturedFeedProps).toBeTruthy());
+
+    // Playground date should appear
+    expect(capturedFeedProps?.dateKeys).toContain(PLAYGROUND_DATE);
+    // Playground items should be present
+    expect(capturedFeedProps?.items.some((item: any) => item.group === 'playground')).toBe(true);
   });
 });

--- a/playground/src/views/ListViews.tsx
+++ b/playground/src/views/ListViews.tsx
@@ -4,6 +4,7 @@ import { localDateKey, type JournalEntrySummary } from './queriable-list/Journal
 import { indexedDBService } from '@/services/db/IndexedDBService';
 import { playgroundDB } from '../services/playgroundDB';
 import { useJournalQueryState } from '../hooks/useJournalQueryState';
+import { useShowPlaygrounds } from '../hooks/useShowPlaygrounds';
 import { createJournalEntryFlow } from '../services/journalEntryFlow';
 import type { FilteredListItem } from './queriable-list/types';
 import { JournalFeed } from './JournalFeed';
@@ -98,10 +99,13 @@ export function JournalWeeklyPage({ onSelect, onCreateEntry, workoutItems = [] }
     return () => { cancelled = true; };
   }, []);
 
+  // ── Show playgrounds toggle ───────────────────────────────────────────────
+  const [showPlaygrounds] = useShowPlaygrounds();
+
   // ── Map results → list items ──────────────────────────────────────────────
 
-  const listItems = useMemo<FilteredListItem[]>(() =>
-    results.map(r => {
+  const listItems = useMemo<FilteredListItem[]>(() => {
+    const allItems = results.map(r => {
       const safeNoteId = r.noteId || '';
       const isPlayground = safeNoteId.startsWith('playground/') || UUID_RE.test(safeNoteId);
       const parts = safeNoteId.split('/');
@@ -121,8 +125,12 @@ export function JournalWeeklyPage({ onSelect, onCreateEntry, workoutItems = [] }
         group: isPlayground ? 'playground' : undefined,
         payload: r,
       };
-    }),
-  [results]);
+    });
+    if (!showPlaygrounds) {
+      return allItems.filter(item => item.group !== 'playground');
+    }
+    return allItems;
+  }, [results, showPlaygrounds]);
 
   // ── Date keys to display ──────────────────────────────────────────────────
 

--- a/src/components/Editor/extensions/widget-block-preview.tsx
+++ b/src/components/Editor/extensions/widget-block-preview.tsx
@@ -196,6 +196,7 @@ function WidgetBlockPreviewWrapper({
   }));
 
   const isEditingInMain = view.state.field(editingWidgetsField).has(sectionId);
+  void isEditingInMain; // retained for potential future use; edit mode is now React-local
 
   React.useEffect(() => {
     setState((prev) => ({
@@ -226,58 +227,45 @@ function WidgetBlockPreviewWrapper({
     setState((prev) => (prev.hasFocus === focused ? prev : { ...prev, hasFocus: focused }));
   }, []);
 
+  // Enter edit mode via React state — no CM6 dispatch needed.
   const enterEditMode = React.useCallback(() => {
-    view.dispatch({
-      effects: toggleWidgetEdit.of({ sectionId, editing: true }),
-    });
-  }, [sectionId, view]);
+    setState((prev) => ({
+      ...prev,
+      isEditing: true,
+      isDirty: false,
+      error: null,
+      currentMarkdown: prev.originalMarkdown,
+    }));
+  }, []);
 
-  const exitEditMode = React.useCallback((save: boolean) => {
-    if (save) {
-      // In main editor mode, the changes are already in the document,
-      // so we just need to exit edit mode.
-      view.dispatch({
-        effects: toggleWidgetEdit.of({ sectionId, editing: false }),
-      });
-      return;
-    }
-
-    // Cancel: we'd need to undo the changes. For now, just exit.
-    view.dispatch({
-      effects: toggleWidgetEdit.of({ sectionId, editing: false }),
-    });
-  }, [sectionId, view]);
-
-  const onSave = React.useCallback(() => {
-    exitEditMode(true);
-  }, [exitEditMode]);
-
-  const onBlur = React.useCallback(() => {
-    const result = saveWidgetSource(view, sectionId, state.currentMarkdown);
+  // Perform a CM6 save and return success/failure.
+  const performSave = React.useCallback((markdown: string): boolean => {
+    const result = saveWidgetSource(view, sectionId, markdown);
     if (!result?.ok) {
-      setState((prev) => ({
-        ...prev,
-        isEditing: true,
-        isDirty: prev.currentMarkdown !== prev.originalMarkdown,
-        error: result?.message ?? "Unable to save widget source.",
-      }));
-      return;
+      setState((prev) => ({ ...prev, error: result?.message ?? "Invalid JSON." }));
+      return false;
     }
+    const saved = stripEditorTrailingNewline(normalizeWidgetMarkdown(markdown));
+    setState({ isEditing: false, isDirty: false, error: null,
+      originalMarkdown: saved, currentMarkdown: saved, hasFocus: false });
+    return true;
+  }, [view, sectionId]);
 
-    const savedMarkdown = stripEditorTrailingNewline(normalizeWidgetMarkdown(state.currentMarkdown));
+  // Save button / Ctrl+Enter — read from DOM to avoid stale closure after onChange.
+  const onSave = React.useCallback(() => {
+    performSave(textareaRef.current?.value ?? state.currentMarkdown);
+  }, [performSave, state.currentMarkdown]);
+
+  // Undo button / Escape — discard changes and return to preview.
+  const onUndo = React.useCallback(() => {
     setState((prev) => ({
       ...prev,
       isEditing: false,
       isDirty: false,
       error: null,
-      originalMarkdown: savedMarkdown,
-      currentMarkdown: savedMarkdown,
+      currentMarkdown: prev.originalMarkdown,
     }));
-  }, [sectionId, state.currentMarkdown, view]);
-
-  const onUndo = React.useCallback(() => {
-    exitEditMode(false);
-  }, [exitEditMode]);
+  }, []);
 
   const handleMarkdownChange = React.useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const nextMarkdown = event.target.value;
@@ -292,29 +280,36 @@ function WidgetBlockPreviewWrapper({
     });
   }, []);
 
+  // Textarea blur: read value directly from DOM to avoid stale-closure issues
+  // when blur fires before React has flushed the preceding onChange state update.
+  const handleTextareaBlur = React.useCallback(() => {
+    setFocus(false);
+    const currentValue = textareaRef.current?.value;
+    if (currentValue === undefined) return; // textarea not mounted — not in edit mode
+    const result = saveWidgetSource(view, sectionId, currentValue);
+    if (!result?.ok) {
+      setState((prev) => ({
+        ...prev,
+        isDirty: currentValue !== prev.originalMarkdown,
+        error: result?.message ?? "Unable to save widget source.",
+      }));
+      return;
+    }
+    const saved = stripEditorTrailingNewline(normalizeWidgetMarkdown(currentValue));
+    setState({ isEditing: false, isDirty: false, error: null,
+      originalMarkdown: saved, currentMarkdown: saved, hasFocus: false });
+  }, [sectionId, view, setFocus]);
+
+  // Container blur: only manages focus state; actual saving is done by handleTextareaBlur.
   const handleBlurCapture = React.useCallback((event: React.FocusEvent<HTMLDivElement>) => {
     const relatedTarget = event.relatedTarget;
     if (relatedTarget instanceof Node && containerRef.current?.contains(relatedTarget)) {
       return;
     }
-
     setFocus(false);
+  }, [setFocus]);
 
-    if (state.isEditing) {
-      onBlur();
-    }
-  }, [onBlur, setFocus, state.isEditing]);
-
-  const handleTextareaBlur = React.useCallback(() => {
-    // Direct blur handler for the textarea so auto-save works reliably
-    // in test environments where capture-phase blur may not propagate.
-    setFocus(false);
-    if (state.isEditing) {
-      onBlur();
-    }
-  }, [onBlur, setFocus, state.isEditing]);
-
-  const handlePreviewKeyDown = React.useCallback((event: KeyboardEvent) => {
+  const handlePreviewKeyDown = React.useCallback((event: KeyboardEvent | React.KeyboardEvent) => {
     if (event.key === "Enter" && !state.isEditing) {
       event.preventDefault();
       enterEditMode();
@@ -324,8 +319,8 @@ function WidgetBlockPreviewWrapper({
   React.useEffect(() => {
     const el = previewSurfaceRef.current;
     if (!el) return;
-    el.addEventListener("keydown", handlePreviewKeyDown);
-    return () => el.removeEventListener("keydown", handlePreviewKeyDown);
+    el.addEventListener("keydown", handlePreviewKeyDown as EventListener);
+    return () => el.removeEventListener("keydown", handlePreviewKeyDown as EventListener);
   }, [handlePreviewKeyDown]);
 
   const handleTextareaKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -338,8 +333,8 @@ function WidgetBlockPreviewWrapper({
     }
   }, [onSave, onUndo]);
 
-  const buttonMode = state.error ? "error" : isEditingInMain ? "editing" : "view";
-  const iconVisible = state.hasFocus || isEditingInMain || state.error !== null;
+  const buttonMode = state.error ? "error" : state.isEditing ? "editing" : "view";
+  const iconVisible = state.hasFocus || state.isEditing || state.error !== null;
 
   let previewNode: React.ReactNode;
   if (!previewComponent) {
@@ -371,7 +366,7 @@ function WidgetBlockPreviewWrapper({
       }}
       onFocusCapture={() => setFocus(true)}
       onBlurCapture={handleBlurCapture}
-      onKeyDownCapture={handlePreviewKeyDown}
+      onKeyDownCapture={handlePreviewKeyDown as React.KeyboardEventHandler<HTMLDivElement>}
     >
       <WidgetEditButton
         mode={buttonMode}
@@ -386,7 +381,36 @@ function WidgetBlockPreviewWrapper({
         )}
       />
 
-      <div ref={previewSurfaceRef} data-testid="widget-preview-surface" tabIndex={0} onKeyDown={handlePreviewKeyDown as any}>{previewNode}</div>
+      {state.isEditing ? (
+        <div className="flex flex-col gap-2">
+          {state.error !== null && (
+            <div
+              data-testid="widget-error-inlay"
+              className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+            >
+              Invalid JSON: {state.error}
+            </div>
+          )}
+          <EditableMarkdown
+            ref={textareaRef}
+            data-testid="widget-markdown-editor"
+            value={state.currentMarkdown}
+            onChange={handleMarkdownChange}
+            onBlur={handleTextareaBlur}
+            onKeyDown={handleTextareaKeyDown}
+            hasError={state.error !== null}
+          />
+        </div>
+      ) : (
+        <div
+          ref={previewSurfaceRef}
+          data-testid="widget-preview-surface"
+          tabIndex={0}
+          onKeyDown={handlePreviewKeyDown as React.KeyboardEventHandler<HTMLDivElement>}
+        >
+          {previewNode}
+        </div>
+      )}
     </div>
   );
 }
@@ -531,6 +555,9 @@ function buildWidgetDecos(state: EditorState, registry: WidgetRegistry): Decorat
       continue;
     }
 
+    // Skip replace decoration when cursor is inside widget range (reveals source)
+    if (cursorHead >= section.from && cursorHead <= section.to) continue;
+
     // Extract raw content between the fences
     const rawContent =
       section.contentFrom != null && section.contentTo != null
@@ -589,59 +616,45 @@ function moveToLinePreservingColumn(view: EditorView, targetLine: Line): void {
 function skipWidgetDown(view: EditorView): boolean {
   const { head } = view.state.selection.main;
   const currentLine = view.state.doc.lineAt(head);
-  const nextLineNumber = currentLine.number + 1;
-  if (nextLineNumber > view.state.doc.lines) return false;
-
   const { sections } = view.state.field(sectionField);
   const editingIds = view.state.field(editingWidgetsField);
 
-  let targetLineNumber = nextLineNumber;
-  let targetLine = view.state.doc.line(targetLineNumber);
-  
-  while (targetLineNumber <= view.state.doc.lines) {
-    const widget = widgetSectionAtLine(sections, targetLine);
-    // If it's a widget and NOT in edit mode, skip it
-    if (widget && !editingIds.has(widget.id)) {
-      targetLineNumber = widget.endLine + 1;
-      if (targetLineNumber > view.state.doc.lines) break;
-      targetLine = view.state.doc.line(targetLineNumber);
-    } else {
-      // Found a valid destination (non-widget or editing-widget)
-      moveToLinePreservingColumn(view, targetLine);
-      return true;
-    }
-  }
+  // If cursor is already inside a non-editing widget, let normal movement handle it
+  const currentWidget = widgetSectionAtLine(sections, currentLine);
+  if (currentWidget && !editingIds.has(currentWidget.id)) return false;
 
-  return false;
+  const nextLineNumber = currentLine.number + 1;
+  if (nextLineNumber > view.state.doc.lines) return false;
+  const nextLine = view.state.doc.line(nextLineNumber);
+
+  // If the next line is inside a non-editing widget, move onto its first line (reveals it)
+  const nextWidget = widgetSectionAtLine(sections, nextLine);
+  if (!nextWidget || editingIds.has(nextWidget.id)) return false;
+
+  moveToLinePreservingColumn(view, view.state.doc.line(nextWidget.startLine));
+  return true;
 }
 
 function skipWidgetUp(view: EditorView): boolean {
   const { head } = view.state.selection.main;
   const currentLine = view.state.doc.lineAt(head);
-  const previousLineNumber = currentLine.number - 1;
-  if (previousLineNumber < 1) return false;
-
   const { sections } = view.state.field(sectionField);
   const editingIds = view.state.field(editingWidgetsField);
 
-  let targetLineNumber = previousLineNumber;
-  let targetLine = view.state.doc.line(targetLineNumber);
+  // If cursor is already inside a non-editing widget, let normal movement handle it
+  const currentWidget = widgetSectionAtLine(sections, currentLine);
+  if (currentWidget && !editingIds.has(currentWidget.id)) return false;
 
-  while (targetLineNumber >= 1) {
-    const widget = widgetSectionAtLine(sections, targetLine);
-    // If it's a widget and NOT in edit mode, skip it
-    if (widget && !editingIds.has(widget.id)) {
-      targetLineNumber = widget.startLine - 1;
-      if (targetLineNumber < 1) break;
-      targetLine = view.state.doc.line(targetLineNumber);
-    } else {
-      // Found a valid destination
-      moveToLinePreservingColumn(view, targetLine);
-      return true;
-    }
-  }
+  const prevLineNumber = currentLine.number - 1;
+  if (prevLineNumber < 1) return false;
+  const prevLine = view.state.doc.line(prevLineNumber);
 
-  return false;
+  // If the previous line is inside a non-editing widget, move onto its last line (reveals it)
+  const prevWidget = widgetSectionAtLine(sections, prevLine);
+  if (!prevWidget || editingIds.has(prevWidget.id)) return false;
+
+  moveToLinePreservingColumn(view, view.state.doc.line(prevWidget.endLine));
+  return true;
 }
 
 const widgetNavKeymap = Prec.high(keymap.of([
@@ -665,8 +678,10 @@ export function widgetBlockPreview(registry: WidgetRegistry): Extension {
       // 1. The document changed (content/structure update)
       // 2. An edit-toggle effect was dispatched
       const hasToggle = tr.effects.some(e => e.is(toggleWidgetEdit));
+      // tr.selectionSet doesn't exist in this CM6 version; compare manually
+      const selectionChanged = !tr.startState.selection.eq(tr.newSelection);
       
-      if (tr.docChanged || hasToggle) {
+      if (tr.docChanged || hasToggle || selectionChanged) {
         return buildWidgetDecos(tr.state, registry);
       }
       return value;

--- a/src/components/Editor/extensions/widget-block-preview.tsx
+++ b/src/components/Editor/extensions/widget-block-preview.tsx
@@ -505,8 +505,10 @@ class ReactWidgetBlock extends WidgetType {
     if (this.root) {
       const r = this.root;
       this.root = null;
-      // Defer unmount to avoid "Cannot update an unmounting root" warnings
-      setTimeout(() => r.unmount(), 0);
+      // Unmount synchronously so pending unmounts don't bleed into subsequent
+      // tests via the setTimeout queue (deferred approach caused race conditions
+      // in bun:test with React 18 concurrent mode).
+      r.unmount();
     }
   }
 

--- a/src/core/models/MetricContainer.ts
+++ b/src/core/models/MetricContainer.ts
@@ -152,7 +152,11 @@ export class MetricContainer implements IMetricSource, Iterable<IMetric> {
     }
 
     getAllMetricsByType(type: MetricType): IMetric[] {
-        return resolveVisibleMetricsByTypeWithOwnership(this._metrics, type);
+        // Return ALL metrics of the given type sorted by origin precedence
+        // (lowest rank = most authoritative = first). Delegates to getByType
+        // so multi-origin scenarios (parser + runtime + user) return every
+        // entry rather than only the winning ownership-layer tier.
+        return this.getByType(type);
     }
 
     get rawMetrics(): IMetric[] {

--- a/src/core/models/__tests__/MetricContainer.test.ts
+++ b/src/core/models/__tests__/MetricContainer.test.ts
@@ -142,7 +142,7 @@ describe('MetricContainer', () => {
             expect(distance?.value).toBe(1200);
         });
 
-        it('getAllMetricsByType only returns the visible tier for display reads', () => {
+        it('getAllMetricsByType returns all metrics of the type sorted by origin precedence', () => {
             const c = new MetricContainer([
                 makeMetric(MetricType.Rep, 10, 'parser'),
                 makeMetric(MetricType.Rep, 12, 'dialect'),
@@ -150,8 +150,11 @@ describe('MetricContainer', () => {
             ]);
 
             const reps = c.getAllMetricsByType(MetricType.Rep);
-            expect(reps).toHaveLength(1);
+            expect(reps).toHaveLength(3);
+            // Sorted ascending by ORIGIN_PRECEDENCE: runtime(1) < dialect(2) < parser(3)
             expect(reps[0].origin).toBe('runtime');
+            expect(reps[1].origin).toBe('dialect');
+            expect(reps[2].origin).toBe('parser');
         });
     });
 

--- a/src/core/models/__tests__/OutputStatementMetricSource.test.ts
+++ b/src/core/models/__tests__/OutputStatementMetricSource.test.ts
@@ -155,16 +155,19 @@ describe('OutputStatement implements IMetricSource', () => {
     });
 
     describe('getAllMetricsByType', () => {
-        it('returns only the visible ownership tier for display compatibility', () => {
+        it('returns all metrics of the type sorted by origin precedence', () => {
             const output = new OutputStatement(makeOptions([
                 frag(MetricType.Rep, 'parser', 21),
                 frag(MetricType.Rep, 'user', 19),
                 frag(MetricType.Rep, 'compiler', 20),
             ]));
             const result = output.getAllMetricsByType(MetricType.Rep);
-            expect(result).toHaveLength(1);
+            // All three tiers returned, sorted: user(0) < compiler(2) < parser(3)
+            expect(result).toHaveLength(3);
             expect(result[0].origin).toBe('user');
             expect(result[0].value).toBe(19);
+            expect(result[1].origin).toBe('compiler');
+            expect(result[2].origin).toBe('parser');
             expect(output.rawMetrics.filter(m => m.type === MetricType.Rep)).toHaveLength(3);
         });
 


### PR DESCRIPTION
This pull request introduces a user-facing toggle to show or hide "playground" workout results in the journal, along with improvements to state management and testing for this feature. It also refactors how workout results are saved and retrieved, ensuring playground results are properly handled throughout the app. The most important changes are grouped below.

**New Feature: Show Playgrounds Toggle**

* Added a `ShowPlaygroundsToggle` React component and integrated it into the Journal page UI, allowing users to control the visibility of playground entries in their journal. [[1]](diffhunk://#diff-3b639d21871ca2a6ea304153aad949e030db689c4069934e3f58cdf32cceb7d8R1-R22) [[2]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7R30) [[3]](diffhunk://#diff-4d1b842049cf28e1169795c1ac2aab995c78f8a8d729c48d6d604c3d43f12dd7L507-R508)

**State Management and Persistence**

* Implemented a `useShowPlaygrounds` hook to persist the toggle state in `localStorage` and sync it across tabs, with full test coverage for edge cases and persistence logic. [[1]](diffhunk://#diff-b816bcbc976b817a2eb2c4b512fefe5d66b46dac5c884a2eab39496055194daaR1-R39) [[2]](diffhunk://#diff-e1b257d84256dee25235e1124b127102ad974013a48ed1de1cc41468716ca2d0R1-R41)

**Filtering Playground Results in Journal**

* Updated the `JournalWeeklyPage` and related logic to filter workout results based on the "show playgrounds" setting, ensuring playground results are included or excluded as appropriate. [[1]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaR7) [[2]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaR102-R108) [[3]](diffhunk://#diff-882b6131f8ca9361c5f874d101baee1d36d77c929685ce40d1228bd6c4a4bbcaL124-R133)

**Testing**

* Extended `ListViews.test.tsx` to verify that playground results are correctly filtered from the journal feed depending on the toggle state, including mock data and assertions for both cases. [[1]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR14-R17) [[2]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR38) [[3]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR49-R54) [[4]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR75-R81) [[5]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR96) [[6]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dL134-R147) [[7]](diffhunk://#diff-fa5b2036f002bb5f6bef5c2b06f4bc4a34ab267b6b5d8bec5fa29a3757f47b2dR159-R184)

**Playground Results Handling**

* Refactored how playground workout results are loaded and saved, ensuring consistency in how results are retrieved for display and persisted in IndexedDB. [[1]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54R23-R26) [[2]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54R65-R76) [[3]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54L144-R158) [[4]](diffhunk://#diff-923dbc80e9e76750606665e01586268d8ce48b63a3383d4918eb10a49ac64d54R274) [[5]](diffhunk://#diff-60733e95d9fb6e6e2e8837c12d943f3ee8bd7cb38e3535971d816bfdadb55877L12-R12) [[6]](diffhunk://#diff-60733e95d9fb6e6e2e8837c12d943f3ee8bd7cb38e3535971d816bfdadb55877L30-L36)

These changes collectively improve user control over journal content and ensure playground results are managed consistently and robustly across the application.