### PR TITLE
docs: add playground route audit and governance ADR

### DIFF
--- a/docs/adr/playground-route-governance.md
+++ b/docs/adr/playground-route-governance.md
@@ -1,0 +1,96 @@
+# ADR: Playground Route Governance
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Authors:** CTO audit from [WOD-490](/WOD/issues/WOD-490)
+- **Implementation follow-up:** [WOD-502](/WOD/issues/WOD-502), [WOD-503](/WOD/issues/WOD-503), [WOD-504](/WOD/issues/WOD-504), [WOD-505](/WOD/issues/WOD-505), [WOD-506](/WOD/issues/WOD-506), [WOD-507](/WOD/issues/WOD-507), [WOD-508](/WOD/issues/WOD-508)
+
+## Context
+
+The playground router grew into a mixed surface:
+
+- user workspace routes (`/playground`, `/journal`)
+- library/content routes (`/collections`, `/feeds`, generated docs pages)
+- runtime lifecycle routes (`/tracker/:runtimeId`, `/review/:runtimeId`)
+- compatibility aliases (`/note/:category/:name`)
+- a wildcard fallback that also resolves real generated pages
+
+That makes the route interface shallow: callers cannot infer ownership cleanly from the first segment, and related route families are split across multiple namespaces.
+
+## Decision
+
+### 1. Use a resource-first route model
+
+Future canonical routes should cluster by product concept:
+
+- personal workspace
+- library/content
+- execution lifecycle
+- compatibility redirects
+
+### 2. Keep readable browse/index namespaces
+
+Readable product nouns should remain canonical for browse/index surfaces:
+
+- `/playground`
+- `/journal`
+- `/collections`
+- `/feeds`
+- a dedicated docs namespace
+
+### 3. Normalize related families under shared namespaces
+
+The approved target shape is:
+
+- planning under `/journal/plan`
+- collection workouts under `/collections/:collection/:workout`
+- docs under `/guide/*`
+- runtime execution under `/run/:runtimeId`
+
+### 4. Compatibility paths should redirect, not compete
+
+Legacy paths should remain only as compatibility affordances:
+
+- `/note/playground/:id`
+- `/workout/:category/:name`
+- `/getting-started`
+- `/syntax/*`
+- `/tracker/:runtimeId`
+
+### 5. If detail routes are shortened later, do it narrowly
+
+Board feedback preferred shorter direct note/detail routes, but not a cryptic one-letter route tree everywhere.
+
+Applied rule:
+
+- if we shorten anything later, shorten only high-frequency direct note/detail entry
+- do **not** replace the readable browse/index namespaces with one-letter canonical paths
+
+Examples of the kind of shortening that was considered acceptable in planning:
+
+- playground note detail → short form
+- journal day detail → short form
+
+But these are a **future route-design choice**, not part of the current shipped contract on `dev`.
+
+## Consequences
+
+### Positive
+
+- route ownership becomes easier to reason about
+- related route families stop leaking product history into the public URL contract
+- redirects become intentional compatibility seams instead of undocumented behavior
+- future docs can distinguish current contract from migration targets
+
+### Negative
+
+- migration requires a redirect matrix
+- collection workout migration needs explicit handling for non-collection categories
+- wildcard removal requires an explicit not-found experience and generated route registration strategy
+
+## Validation path
+
+- route builders and docs should converge on the same canonical families
+- compatibility paths should be documented as redirects/aliases, not equal canonical routes
+- route additions should choose the owning namespace first, then the path shape
+- any future short detail-route decision must preserve readable browse/index namespaces

--- a/docs/design-system/02.page-routes/Playground-Route-Inventory.md
+++ b/docs/design-system/02.page-routes/Playground-Route-Inventory.md
@@ -1,0 +1,98 @@
+# Playground Route Inventory
+
+> **Audited:** 2026-05-20  
+> **Primary sources:** `playground/src/App.tsx`, `playground/src/canvas/canvasRoutes.ts`, route page components under `playground/src/pages/` and `playground/src/views/`
+
+This document records the playground browser routes supported by the current router and the route-governance gaps identified in [WOD-490](/WOD/issues/WOD-490).
+
+It is intentionally source-first: every route below traces back to the router or generated canvas registration.
+
+## Current explicit routes
+
+| Route | Handler | Notes |
+|---|---|---|
+| `/` | `HomeRoute` | Redirects into playground creation unless an `id` query param is present. |
+| `/getting-started` | `AppContent` | Generated canvas docs route. |
+| `/syntax` | `AppContent` | Generated canvas docs route. |
+| `/journal` | `AppContent` → `JournalWeeklyPage` | Journal index / timeline. |
+| `/plan` | `AppContent` → `PlanPage` | Planning surface. |
+| `/feeds` | `AppContent` → `FeedsPage` | Feed index. |
+| `/feeds/:feedSlug` | `AppContent` → `FeedDetailPage` | Feed detail. |
+| `/feeds/:feedSlug/:feedDate/:feedItem` | `AppContent` → `FeedItemPage` | Feed item/editor route. |
+| `/collections` | `AppContent` → `CollectionsPage` | Collection directory. |
+| `/collections/:slug` | `AppContent` | Collection canvas route via `findCanvasPage()`. |
+| `/workout/:category/:name` | `AppContent` → `WorkoutEditorPage` | Bundled workout note route. |
+| `/load` | `LoadZipPage` | Shared-content import utility. |
+| `/playground` | `PlaygroundRedirect` | Canonical new playground-note entry point. |
+| `/playground/:id` | `AppContent` → `PlaygroundNotePage` | Playground note route. |
+| `/note/:category/:name` | `AppContent` | Compatibility note alias. |
+| `/journal/:id` | `AppContent` → `JournalPage` | Journal note route. |
+| `/tracker/:runtimeId` | `TrackerPage` | Runtime execution route. |
+| `/review/:runtimeId` | `ReviewPage` | Persisted review route. |
+| `*` | `AppContent` | Wildcard fallback; currently also acts as route resolver for generated pages. |
+
+## Generated routes
+
+### Canvas routes from `markdown/canvas/**/*.md`
+
+Current generated browser routes:
+
+- `/` from `markdown/canvas/home/README.md` (**shadowed** by the explicit home/playground entry flow)
+- `/getting-started` from `markdown/canvas/getting-started/README.md`
+- `/syntax` from `markdown/canvas/syntax/README.md`
+- `/syntax/basics` from `markdown/canvas/syntax/basics.md`
+- `/syntax/complex` from `markdown/canvas/syntax/complex.md`
+- `/syntax/protocols` from `markdown/canvas/syntax/protocols.md`
+- `/syntax/structure` from `markdown/canvas/syntax/structure.md`
+
+### Collection README routes from `markdown/collections/**/README.md`
+
+Collection READMEs are registered as `/collections/:slug` pages at build time.
+
+Examples:
+
+- `/collections/crossfit-games-2024`
+- `/collections/crossfit-girls`
+- `/collections/dan-john`
+- `/collections/girevoy-sport`
+- `/collections/mark-wildman`
+- `/collections/strongfirst`
+- `/collections/unconventional`
+
+## Route-model problems found in the audit
+
+1. **Mixed mental models at the top level**
+   - personal surfaces: `/playground`, `/journal`
+   - library/content surfaces: `/collections`, `/feeds`, docs pages
+   - execution lifecycle pages: `/tracker/:runtimeId`, `/review/:runtimeId`
+   - compatibility aliases: `/note/:category/:name`
+
+2. **One resource can have multiple URL shapes**
+   - playground notes can be reached through `/playground/:id` and `/note/playground/:id`
+
+3. **Generated routes are partially hidden behind `*`**
+   - today the wildcard fallback is not just a 404 path; it is part of the real route-resolution model
+
+4. **Collection workouts are outside the collection namespace**
+   - `/collections/:slug` and `/workout/:category/:name` belong to the same conceptual family but use different top-level namespaces
+
+5. **The docs namespace is long and inconsistent**
+   - `/getting-started` and `/syntax/*` are product docs, but they sit beside user/library/runtime surfaces at the top level
+
+## Approved direction from this issue
+
+The follow-on route-governance ADR recommends a more consistent resource-first route model:
+
+- keep readable browse/index namespaces
+- nest related pages together
+- treat legacy shapes as redirects instead of first-class canonical URLs
+- if shorter note-detail URLs are added later, apply them narrowly to high-frequency direct note routes rather than collapsing the whole tree into one-letter paths
+
+See [ADR: Playground Route Governance](../../adr/playground-route-governance.md).
+
+## Validation checklist
+
+- compare this inventory against `playground/src/App.tsx`
+- compare generated route claims against `playground/src/canvas/canvasRoutes.ts`
+- verify shadowed `/` content is documented as shadowed, not public
+- verify wildcard behavior is called out as a current risk rather than ignored

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,6 @@
+# Design System
+
+This directory contains route audits, page-route notes, and related documentation for the playground app.
+
+## Guides
+- [Playground Route Inventory](./02.page-routes/Playground-Route-Inventory.md)


### PR DESCRIPTION
## Summary
- add a source-first audit of the current playground/browser routes
- add an ADR capturing the approved route-governance direction from WOD-490
- add a small docs index entry for the new route inventory

## Why
This closes the missing SCM/review path for [WOD-490](/WOD/issues/WOD-490): the audit and route-governance artifacts now live on a dedicated branch with a PR into `dev`.

## Notes
- this PR is documentation/planning only
- it does **not** claim the follow-on route cleanup is already implemented on `dev`
- execution remains tracked on WOD-502 through WOD-508
