### PR TITLE
Fix playground canonical routes and ship route audit docs

### DIFF
--- a/docs/adr/playground-route-governance.md
+++ b/docs/adr/playground-route-governance.md
@@ -1,0 +1,78 @@
+# ADR: Playground Route Governance
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Authors:** CTO audit from [WOD-490](/WOD/issues/WOD-490)
+- **Implemented by:** [WOD-503](/WOD/issues/WOD-503), [WOD-504](/WOD/issues/WOD-504), [WOD-505](/WOD/issues/WOD-505), [WOD-506](/WOD/issues/WOD-506), [WOD-507](/WOD/issues/WOD-507)
+- **Related:** `playground/src/lib/routes.tsx`, `playground/src/App.tsx`, `docs/design-system/02.page-routes/Playground-Route-Inventory.md`
+
+## Context
+
+The playground router had drift between documented URLs and the live app contract:
+
+- docs pages still described legacy `/getting-started`, `/syntax*`, `/tracker/:runtimeId`, and `/workout/:category/:name` paths as primary routes
+- the old wildcard `*` route doubled as an implicit route resolver, which hid true 404s
+- playground-note compatibility aliases were not documented as compatibility-only
+- per-page route docs had fallen behind the code after the route cleanup work landed
+
+The stabilized router now has a single source of truth for canonical patterns and compatibility redirects in `playground/src/lib/routes.tsx`, with final route registration in `playground/src/App.tsx`.
+
+## Decision
+
+### 1. Canonical browser routes
+
+The canonical browser contract is:
+
+- `/` and `/playground` create a fresh playground note, then redirect to `/playground/:id`
+- `/playground/:id` is the canonical playground note URL
+- `/journal` and `/journal/:id` remain the journal index and journal note routes
+- `/plan` remains the planning surface
+- `/feeds`, `/feeds/:feedSlug`, and `/feeds/:feedSlug/:feedDate/:feedItem` are the feed surfaces
+- `/collections`, `/collections/:slug`, and `/collections/:collection/:workout` are the collection surfaces
+- `/guide/getting-started` and `/guide/syntax*` are the canonical documentation routes
+- `/run/:runtimeId` is the canonical runtime execution route
+- `/review/:runtimeId` is the persisted review route
+- `/load` remains the import utility route
+
+### 2. Compatibility paths stay explicit and limited
+
+Legacy URLs are preserved only as compatibility affordances:
+
+- `/note/playground/:name` → `/playground/:name`
+- `/workout/:category/:name` → `/collections/:category/:name`
+- `/getting-started` and `/getting-started/*` → `/guide/getting-started`
+- `/syntax` and `/syntax/*` → `/guide/syntax*`
+- `/tracker/:runtimeId` → `/run/:runtimeId`
+- `/note/:category/:name` remains supported for non-playground note surfaces, but it is not the canonical published URL for bundled workouts
+
+### 3. Generated docs routes must be explicit product routes
+
+Generated markdown canvas routes are registered explicitly from `canvasRoutes` rather than being discovered through a permissive wildcard fallback. Unknown paths now resolve to `NotFoundPage`.
+
+### 4. Short note-detail routes are not part of the shipped contract
+
+The live router does **not** implement `/p/:id` or `/j/:date`.
+Until code adds them, documentation must treat `/playground/:id` and `/journal/:id` as the canonical note-detail URLs and must not imply a shipped short-route contract.
+
+## Consequences
+
+### Positive
+
+- route ownership is centralized in `ROUTE_PATTERNS`, path builders, and redirect rules
+- canonical vs compatibility paths are explicit
+- documentation can be verified directly against the router
+- unknown URLs now produce an intentional 404 experience
+
+### Negative
+
+- legacy links still need compatibility maintenance
+- generated `/` canvas content still exists in markdown but is not browser-reachable because `/` is reserved for playground-note creation
+- future route work must update both `routes.tsx` and the route docs together
+
+## Validation path
+
+- verify `playground/src/lib/routes.tsx` matches `playground/src/App.tsx`
+- verify `/guide/*`, `/run/:runtimeId`, `/collections/:collection/:workout`, and explicit generated routes are documented as canonical
+- verify compatibility redirects are documented as redirects or aliases, not as primary paths
+- verify `*` is documented as `NotFoundPage`, not as a resolver
+- verify no route docs claim shipped `/p/:id` or `/j/:date` support

--- a/docs/design-system/02.page-routes/Playground-Route-Inventory.md
+++ b/docs/design-system/02.page-routes/Playground-Route-Inventory.md
@@ -1,0 +1,126 @@
+# Playground Route Inventory
+
+> **Audited:** 2026-05-20  
+> **Primary sources:** `playground/src/lib/routes.tsx`, `playground/src/App.tsx`, `playground/src/canvas/canvasRoutes.ts`, route page components under `playground/src/pages/` and `playground/src/views/`
+
+This document is the live browser-route contract for the playground app. It is source-first: if this file disagrees with `routes.tsx` or `App.tsx`, the code wins.
+
+## Canonical router table
+
+### First-class routes
+
+| Route | Handler | Contract |
+|---|---|---|
+| `/` | `PlaygroundRedirect` | Creates a fresh playground note, then redirects to `/playground/:id`. |
+| `/playground` | `PlaygroundRedirect` | Same create-and-redirect entry as `/`. |
+| `/playground/:id` | `AppContent` → `PlaygroundNotePage` | Canonical playground note route. |
+| `/journal` | `AppContent` → `JournalWeeklyPage` | Journal index / timeline surface. |
+| `/journal/:id` | `AppContent` → `JournalPage` | Canonical journal note route. |
+| `/plan` | `AppContent` → `PlanPage` | Forward-looking planning surface. |
+| `/feeds` | `AppContent` → `FeedsPage` | Feed index across all configured feeds. |
+| `/feeds/:feedSlug` | `AppContent` → `FeedDetailPage` | Single-feed timeline. |
+| `/feeds/:feedSlug/:feedDate/:feedItem` | `AppContent` → `FeedItemPage` | Feed workout detail/editor surface. |
+| `/collections` | `AppContent` → `CollectionsPage` | Collection directory plus injected collection intro canvas. |
+| `/collections/:slug` | `AppContent` → `MarkdownCanvasPage` via `findCanvasPage()` | Collection README canvas page. |
+| `/collections/:collection/:workout` | `AppContent` → `WorkoutEditorPage` | Canonical bundled workout note route. |
+| `/guide/getting-started` | explicit generated canvas route | Canonical getting-started docs page. |
+| `/guide/syntax` | explicit generated canvas route | Canonical syntax index page. |
+| `/guide/syntax/basics` | explicit generated canvas route | Canonical syntax sub-page. |
+| `/guide/syntax/structure` | explicit generated canvas route | Canonical syntax sub-page. |
+| `/guide/syntax/protocols` | explicit generated canvas route | Canonical syntax sub-page. |
+| `/guide/syntax/complex` | explicit generated canvas route | Canonical syntax sub-page. |
+| `/run/:runtimeId` | `TrackerPage` | Canonical transient runtime execution route. |
+| `/review/:runtimeId` | `ReviewPage` | Canonical persisted review route. |
+| `/load` | `LoadZipPage` | Import / shared-content utility route. |
+| `*` | `NotFoundPage` | Dedicated 404 surface. |
+
+### Compatibility routes and redirects
+
+| Route | Behavior | Canonical destination |
+|---|---|---|
+| `/note/playground/:name` | Redirect component | `/playground/:name` |
+| `/note/:category/:name` | Supported compatibility route for note surfaces | Usually equivalent to `/collections/:category/:name` for bundled workouts |
+| `/workout/:category/:name` | Redirect component | `/collections/:category/:name` |
+| `/getting-started` | Redirect component | `/guide/getting-started` |
+| `/getting-started/*` | Redirect component | `/guide/getting-started` |
+| `/syntax` | Redirect component | `/guide/syntax` |
+| `/syntax/*` | Redirect component | `/guide/syntax/*` |
+| `/tracker/:runtimeId` | Redirect component | `/run/:runtimeId` |
+
+## Generated route registration
+
+`playground/src/canvas/canvasRoutes.ts` builds explicit route entries from markdown at build time.
+
+### Generated canvas routes from `markdown/canvas/**/*.md`
+
+| Route | Source markdown | Reachable in browser? |
+|---|---|---|
+| `/` | `markdown/canvas/home/README.md` | **No** — shadowed by the explicit `/` playground redirect. |
+| `/guide/getting-started` | `markdown/canvas/getting-started/README.md` | Yes |
+| `/guide/syntax` | `markdown/canvas/syntax/README.md` | Yes |
+| `/guide/syntax/basics` | `markdown/canvas/syntax/basics.md` | Yes |
+| `/guide/syntax/structure` | `markdown/canvas/syntax/structure.md` | Yes |
+| `/guide/syntax/protocols` | `markdown/canvas/syntax/protocols.md` | Yes |
+| `/guide/syntax/complex` | `markdown/canvas/syntax/complex.md` | Yes |
+
+### Generated collection README routes
+
+Collection `README.md` files are registered explicitly as `/collections/:slug` routes at build time.
+
+Examples:
+
+- `/collections/crossfit-games-2024`
+- `/collections/crossfit-girls`
+- `/collections/dan-john`
+- `/collections/girevoy-sport`
+- `/collections/mark-wildman`
+- `/collections/strongfirst`
+- `/collections/unconventional`
+
+## Route-resolution rules that matter to product behavior
+
+### 1. `/` is a note-creation entry point, not a content page
+
+The browser route `/` always runs `PlaygroundRedirect`. The legacy home canvas markdown still exists as hidden content, but it is not the public route contract.
+
+### 2. Docs pages live under `/guide/*`
+
+The product contract for syntax and getting-started docs is `/guide/getting-started` and `/guide/syntax*`. Old `/getting-started` and `/syntax*` URLs are compatibility redirects only.
+
+### 3. Runtime execution is `/run/:runtimeId`
+
+`/tracker/:runtimeId` is preserved for external links but immediately redirects to `/run/:runtimeId`.
+
+### 4. Generated routes are explicit now
+
+The router registers every generated canvas route directly via `canvasRoutes.map(...)`. The old wildcard resolver is gone.
+
+### 5. Unknown paths hit a real 404
+
+`*` now renders `NotFoundPage`, so unsupported paths no longer fall through to generic editor surfaces.
+
+### 6. Short note-detail routes are not shipped
+
+The live router does **not** define `/p/:id` or `/j/:date`. Current canonical note-detail URLs remain `/playground/:id` and `/journal/:id`.
+
+## Route families and ownership
+
+| Route family | Canonical surface | Primary source |
+|---|---|---|
+| Playground creation | `/`, `/playground` | `playground/src/pages/PlaygroundRedirect.tsx` |
+| Playground notes | `/playground/:id` | `playground/src/pages/PlaygroundNotePage.tsx` |
+| Journal | `/journal`, `/journal/:id`, `/plan` | `playground/src/views/ListViews.tsx`, `playground/src/pages/JournalPage.tsx`, `playground/src/views/PlanPage.tsx` |
+| Feeds | `/feeds`, `/feeds/:feedSlug`, `/feeds/:feedSlug/:feedDate/:feedItem` | `playground/src/views/FeedsPage.tsx`, `playground/src/pages/FeedDetailPage.tsx`, `playground/src/pages/FeedItemPage.tsx` |
+| Collections | `/collections`, `/collections/:slug`, `/collections/:collection/:workout` | `playground/src/views/CollectionsPage.tsx`, `playground/src/canvas/canvasRoutes.ts`, `playground/src/pages/WorkoutEditorPage.tsx` |
+| Guide docs | `/guide/getting-started`, `/guide/syntax*` | `markdown/canvas/**`, `playground/src/canvas/canvasRoutes.ts` |
+| Runtime / review | `/run/:runtimeId`, `/review/:runtimeId` | `playground/src/pages/TrackerPage.tsx`, `playground/src/pages/ReviewPage.tsx` |
+| Import utility | `/load` | `playground/src/pages/LoadZipPage.tsx` |
+
+## Validation checklist
+
+- compare this file against `ROUTE_PATTERNS`, path builders, and `ROUTE_REDIRECTS`
+- confirm canonical docs routes use `/guide/*`
+- confirm canonical runtime docs use `/run/:runtimeId`
+- confirm collection workout docs use `/collections/:collection/:workout`
+- confirm wildcard behavior is documented as `NotFoundPage`
+- confirm no docs claim shipped `/p/:id` or `/j/:date`

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,14 @@
+# Design System
+
+This directory contains the WOD Wiki design system documentation, including layouts, templates, and components.
+
+## Overview
+- [Design System Overview](./Overview.md)
+- [Layout Template](./00.layout-template/)
+- [Page Templates](./01.page-templates/)
+- [Page Routes](./02.page-routes/)
+
+## Guides
+- [Playground Route Inventory](./02.page-routes/Playground-Route-Inventory.md)
+- [Color Remediation Plan](../audits/color-remediation-plan.md)
+- [Atomic Design Audit](../audits/atomic-design-audit.md)

--- a/playground/index.html
+++ b/playground/index.html
@@ -5,27 +5,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Wod.Wiki Playground</title>
-  <link rel="icon" type="image/png" href="/images/wod-wiki-logo-light.png" />
-  <!-- Self-hosted Inter: preload the two weights the app uses -->
-  <link rel="preload" as="font" type="font/woff2" href="/fonts/Inter-Regular.woff2" crossorigin="anonymous" />
-  <link rel="preload" as="font" type="font/woff2" href="/fonts/Inter-SemiBold.woff2" crossorigin="anonymous" />
-  <style>
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 400;
-      font-display: swap;
-      src: url('/fonts/Inter-Regular.woff2') format('woff2');
-    }
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 600;
-      font-display: swap;
-      src: url('/fonts/Inter-SemiBold.woff2') format('woff2');
-    }
-    :root { font-family: 'Inter', ui-sans-serif, system-ui, sans-serif; }
-  </style>
+  <link rel="icon" type="image/png" href="%BASE_URL%images/wod-wiki-logo-light.png" />
+  <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/geist@1/dist/fonts/geist-mono/style.css">
   <!-- Google tag (gtag.js) -->
   <!-- Dev placeholder G-PROD-ID is replaced during production build -->

--- a/playground/public/404.html
+++ b/playground/public/404.html
@@ -4,16 +4,18 @@
   <meta charset="utf-8">
   <title>WOD Wiki</title>
   <script>
-    // GitHub Pages SPA routing trick.
-    // When GitHub Pages 404s on a deep route, it serves this page.
-    // Store the intended path, then redirect to the project root so the app
-    // can boot and BrowserRouter restores the route.
-    //
-    // NOTE: wod.wiki is deployed at the root (/), not a subdirectory.
-    // Always redirect to '/' — the first-segment trick would loop on paths
-    // like /playground/ because that segment has no real file and 404s again.
+    // SPA fallback routing.
+    // Store the intended path, then redirect to app root so index.html can boot
+    // and BrowserRouter restores the original route.
     sessionStorage.setItem('spa-redirect', location.href);
-    location.href = '/';
+
+    // GitHub project pages are hosted at /<repo>/ on *.github.io, but custom
+    // domains are served from '/'.
+    var isGithubIo = /\.github\.io$/i.test(location.hostname);
+    var firstSegment = location.pathname.split('/').filter(Boolean)[0];
+    var base = isGithubIo && firstSegment ? '/' + firstSegment + '/' : '/';
+
+    location.replace(base);
   </script>
 </head>
 <body></body>

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -15,8 +15,20 @@ import { globalSearchSource } from './services/paletteDataSources'
 import { createJournalEntryFlow } from './services/journalEntryFlow'
 import { ThemeProvider, useTheme } from '@/components/theme/ThemeProvider'
 import { AudioProvider } from '@/components/audio/AudioContext'
-import { BrowserRouter, Routes, Route, useNavigate, useParams, useLocation, Navigate } from 'react-router-dom'
-import { useQueryState } from 'nuqs'
+import { BrowserRouter, Routes, Route, useNavigate, useParams, useLocation } from 'react-router-dom'
+import {
+  ROUTE_PATTERNS,
+  isPlaygroundNotePath,
+  isJournalEntryPath,
+  workoutPath,
+  journalEntryPath,
+  reviewPath,
+  NotePlaygroundRedirect,
+  WorkoutRedirect,
+  GettingStartedRedirect,
+  SyntaxRedirect,
+  TrackerRedirect,
+} from './lib/routes'
 import { HomeView as _HomeView } from './views/HomeView' // kept for potential re-use; not rendered on '/' anymore
 import { findCanvasPage, canvasRoutes } from './canvas/canvasRoutes'
 import { MarkdownCanvasPage } from './canvas/MarkdownCanvasPage'
@@ -46,6 +58,7 @@ const TrackerPage = lazy(() => import('./pages/TrackerPage').then(m => ({ defaul
 const ReviewPage  = lazy(() => import('./pages/ReviewPage').then(m => ({ default: m.ReviewPage })))
 const LoadZipPage = lazy(() => import('./pages/LoadZipPage').then(m => ({ default: m.LoadZipPage })))
 // ── Toast ────────────────────────────────────────────────────────────────────
+import { NotFoundPage } from './pages/NotFoundPage'
 import { Toaster } from '@/components/ui/toaster'
 import { PageActions } from './pages/shared/PageActions'
 import { ActionsMenu } from './pages/shared/PageToolbar'
@@ -88,21 +101,16 @@ export interface WorkoutItem {
 }
 function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<() => void> }) {
   const navigate = useNavigate()
-  const { category: urlCategory, name: urlName, id: playgroundId } = useParams<{ category: string; name: string; id: string }>()
+  const { category: urlCategory, name: urlName, collection: urlCollection, workout: urlWorkout, id: playgroundId } = useParams<{ category: string; name: string; collection: string; workout: string; id: string }>()
   const location = useLocation()
   
   const { theme } = useTheme()
   const [recentResults, setRecentResults] = useState<WorkoutResult[]>([])
 
-  const [idParam] = useQueryState('id')
-
-  // Unified note route: /note/playground/:name behaves like /playground/:name
-  const isNotePlayground = location.pathname.startsWith('/note/playground/')
-  const isPlaygroundRoute = location.pathname.startsWith('/playground/') || isNotePlayground || (location.pathname === '/' && !!idParam)
-  // For /note/playground/:name, use urlName as the playground ID
-  const effectivePlaygroundId = playgroundId || idParam || (isNotePlayground ? urlName : undefined)
-  // Journal entry route: /journal/:id  — note: the route param is :id → playgroundId
-  const isJournalEntryRoute = location.pathname.startsWith('/journal/') && (!!urlName || !!playgroundId)
+  // Route-family detection via canonical helpers
+  const isPlaygroundRoute = isPlaygroundNotePath(location.pathname)
+  const effectivePlaygroundId = playgroundId || (location.pathname.startsWith('/note/playground/') ? urlName : undefined)
+  const isJournalEntryRoute = isJournalEntryPath(location.pathname)
   const journalEntryId = isJournalEntryRoute ? decodeURIComponent(urlName ?? playgroundId!) : undefined
 
   // Feed route detection — parsed from pathname since AppContent useParams only
@@ -145,8 +153,7 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
   }, [workoutFiles])
 
   // Canvas page for the current pathname (null if not a canvas route)
-  // We prioritize playground notes (via idParam) over the home canvas page.
-  const canvasPage = !idParam ? findCanvasPage(location.pathname) : null
+  const canvasPage = findCanvasPage(location.pathname)
 
   // Find current content based on URL
   const currentWorkout = useMemo(() => {
@@ -165,21 +172,22 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
       '/journal': 'Journal',
       '/plan': 'Plan',
       '/feeds': 'Feeds',
-      '/getting-started': 'Zero to Hero',
-      '/syntax': 'Syntax',
+      '/guide/getting-started': 'Zero to Hero',
+      '/guide/syntax': 'Syntax',
       '/collections': 'Collections',
     }
     const namedMatch = named[location.pathname]
     if (namedMatch) {
       return { name: namedMatch, content: PLAYGROUND_CONTENT, category: 'General' }
     }
-    if (!urlName) {
+    const effectiveName = urlWorkout || urlName
+    if (!effectiveName) {
       return { name: 'Home', content: PLAYGROUND_CONTENT, category: 'General' }
     }
-    const name = decodeURIComponent(urlName)
-    const category = urlCategory ? decodeURIComponent(urlCategory) : 'General'
+    const name = decodeURIComponent(effectiveName)
+    const category = (urlCollection || urlCategory) ? decodeURIComponent(urlCollection || urlCategory!) : 'General'
     return workoutItems.find(item => item.name === name && item.category === category) || { name, content: PLAYGROUND_CONTENT, category: 'General' }
-  }, [urlCategory, urlName, workoutItems, location.pathname, isPlaygroundRoute, isJournalEntryRoute, journalEntryId])
+  }, [urlCategory, urlName, urlCollection, urlWorkout, workoutItems, location.pathname, isPlaygroundRoute, isJournalEntryRoute, journalEntryId])
 
   // Load recent workout results from IndexedDB
   const refreshResults = useCallback(() => {
@@ -195,10 +203,9 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
   const handleSelectWorkout = useCallback((item: any) => {
     const workout = item as { name: string; category?: string; content?: string }
     if (workout.name === 'Home') {
-      navigate('/')
+      navigate(ROUTE_PATTERNS.home)
     } else {
-      const category = workout.category || 'General'
-      navigate(`/workout/${encodeURIComponent(category)}/${encodeURIComponent(workout.name)}`)
+      navigate(workoutPath(workout.category || 'General', workout.name))
     }
   }, [navigate])
 
@@ -272,8 +279,8 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
     }
 
     // 2. Docs pages
-    if (location.pathname === '/getting-started') return ZERO_TO_HERO_LINKS
-    if (location.pathname === '/syntax') return SYNTAX_LINKS
+    if (location.pathname === ROUTE_PATTERNS.guideGettingStarted) return ZERO_TO_HERO_LINKS
+    if (location.pathname === ROUTE_PATTERNS.guideSyntax) return SYNTAX_LINKS
     
     // 3. Journal list page
     if (location.pathname === '/journal') {
@@ -316,7 +323,7 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
       onCreated: async (content) => {
         const id = `journal/${dateKey}`
         await playgroundDB.savePage({ id, name: dateKey, category: 'journal', content, updatedAt: Date.now() })
-        navigate(`/journal/${dateKey}`)
+        navigate(journalEntryPath(dateKey))
       },
     })
   }, [navigate, workoutItems])
@@ -334,7 +341,7 @@ function AppContent({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<(
       } else if (item.type === 'workout') {
         handleSelectWorkout(item.payload)
       } else if (item.type === 'journal-entry') {
-        navigate(`/review/${item.id}`)
+        navigate(reviewPath(item.id))
       }
     })
   }, [workoutItems, handleSelectWorkout, navigate])
@@ -600,14 +607,6 @@ function GlobalState() {
   return null
 }
 
-function HomeRoute({ searchHandlerRef }: { searchHandlerRef: MutableRefObject<() => void> }) {
-  const [idParam] = useQueryState('id')
-  if (idParam) {
-    return <AppContent searchHandlerRef={searchHandlerRef} />
-  }
-  return <PlaygroundRedirect />
-}
-
 export function App() {
   // Stable ref so AppContent can inject its openSearchPalette callback after mount.
   // The nav tree is built once; the search item calls the ref's current value.
@@ -625,25 +624,33 @@ export function App() {
             <CommandProvider>
               <NavProvider tree={navTree}>
                 <Routes>
-                  <Route path="/" element={<HomeRoute searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/getting-started" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/syntax" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/journal" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/plan" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/feeds" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/feeds/:feedSlug" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/feeds/:feedSlug/:feedDate/:feedItem" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/collections" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/collections/:slug" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/workout/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/load" element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><LoadZipPage /></Suspense>} />
-                  <Route path="/playground" element={<PlaygroundRedirect />} />
-                  <Route path="/playground/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/note/:category/:name" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/journal/:id" element={<AppContent searchHandlerRef={searchHandlerRef} />} />
-                  <Route path="/tracker/:runtimeId" element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><TrackerPage /></Suspense>} />
-                  <Route path="/review/:runtimeId" element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><ReviewPage /></Suspense>} />
-                  <Route path="*" element={<Navigate to="/" replace />} />
+                  <Route path={ROUTE_PATTERNS.home} element={<PlaygroundRedirect />} />
+                  <Route path="/getting-started" element={<GettingStartedRedirect />} />
+                  <Route path="/getting-started/*" element={<GettingStartedRedirect />} />
+                  <Route path="/syntax" element={<SyntaxRedirect />} />
+                  <Route path="/syntax/*" element={<SyntaxRedirect />} />
+                  <Route path={ROUTE_PATTERNS.journal} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.plan} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.feeds} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.feedDetail} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.feedItem} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.collections} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.collectionDetail} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.collectionWorkout} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.load} element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><LoadZipPage /></Suspense>} />
+                  <Route path={ROUTE_PATTERNS.playgroundRoot} element={<PlaygroundRedirect />} />
+                  <Route path={ROUTE_PATTERNS.playground} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.notePlaygroundAlias} element={<NotePlaygroundRedirect />} />
+                  <Route path={ROUTE_PATTERNS.note} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.journalEntry} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  <Route path={ROUTE_PATTERNS.run} element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><TrackerPage /></Suspense>} />
+                  <Route path={ROUTE_PATTERNS.tracker} element={<TrackerRedirect />} />
+                  <Route path={ROUTE_PATTERNS.review} element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><ReviewPage /></Suspense>} />
+                  <Route path="/workout/:category/:name" element={<WorkoutRedirect />} />
+                  {canvasRoutes.map(({ route }) => (
+                    <Route key={route} path={route} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
+                  ))}
+                  <Route path="*" element={<NotFoundPage />} />
                 </Routes>
               </NavProvider>
             </CommandProvider>

--- a/playground/src/canvas/MarkdownCanvasPage.tsx
+++ b/playground/src/canvas/MarkdownCanvasPage.tsx
@@ -37,6 +37,7 @@ import type { ParsedCanvasPage, CanvasSection, PipelineStep, OpenMode } from './
 import type { WodBlock } from '@/components/Editor/types'
 import type { WorkoutItem } from '../App'
 import { pendingRuntimes, activeRuntimes } from '../runtimeStore'
+import { runPath } from '../lib/routes'
 import { CollectionWorkoutsList } from '../views/queriable-list/CollectionWorkoutsList'
 
 // Match the existing parallax constants exactly
@@ -368,7 +369,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
         return
       }
 
-      navigate(`/workout/${encodeURIComponent(item.category)}/${encodeURIComponent(item.name)}`)
+      navigate(`/collections/${encodeURIComponent(item.category)}/${encodeURIComponent(item.name)}`)
     },
     [navigate, onSelect],
   )
@@ -549,7 +550,7 @@ export function MarkdownCanvasPage({ page, wodFiles, theme, workoutItems, onSele
         else if (open === 'route') {
           const runtimeId = uuidv4()
           pendingRuntimes.set(runtimeId, { block, noteId: canvasNoteId })
-          navigate(`/tracker/${runtimeId}`)
+          navigate(runPath(runtimeId))
         } else {
           setFullscreenBlock(block)
         }

--- a/playground/src/components/HomeWelcome.tsx
+++ b/playground/src/components/HomeWelcome.tsx
@@ -21,31 +21,31 @@ const inlineDocLinkClassName = 'mx-1 inline-flex h-auto items-center gap-1 px-0 
 
 const WRITE_NOTE_DOC_LINKS = {
   movement: {
-    to: '/getting-started?h=statement',
+    to: '/guide/getting-started?h=statement',
     label: 'Movement',
   },
   reps: {
-    to: '/syntax/structure?h=rep-schemes',
+    to: '/guide/syntax/structure?h=rep-schemes',
     label: 'Reps',
   },
   timers: {
-    to: '/syntax/protocols',
+    to: '/guide/syntax/protocols',
     label: 'Timers',
   },
   rounds: {
-    to: '/syntax/structure?h=simple-rounds',
+    to: '/guide/syntax/structure?h=simple-rounds',
     label: 'Rounds',
   },
   load: {
-    to: '/syntax/basics?h=measurements',
+    to: '/guide/syntax/basics?h=measurements',
     label: 'Load',
   },
   rest: {
-    to: '/syntax/protocols?h=timers-and-rest',
+    to: '/guide/syntax/protocols?h=timers-and-rest',
     label: 'Rest',
   },
   sectionLabels: {
-    to: '/syntax/structure?h=named-groups',
+    to: '/guide/syntax/structure?h=named-groups',
     label: 'Section Labels',
   },
 } as const
@@ -148,7 +148,7 @@ export function HomeWelcome({ onOpenSearch, onRun, onResults }: HomeWelcomeProps
               <p className="mt-1 text-sm font-medium leading-relaxed text-muted-foreground">
                 Start with simple whiteboard text in the example. Powered by
                 <ButtonLink
-                  href="https://pluto.forest-adhara.ts.net:5173/syntax"
+                  href="https://pluto.forest-adhara.ts.net:5173/guide/syntax"
                   target="_blank"
                   rel="noreferrer"
                   variant="link"

--- a/playground/src/components/PlaygroundGuidePanel.test.tsx
+++ b/playground/src/components/PlaygroundGuidePanel.test.tsx
@@ -18,7 +18,7 @@ describe('PlaygroundGuidePanel', () => {
     expect(screen.getByText('Playground Flow')).toBeTruthy()
     expect(screen.getByText(/write the workout, then turn the unknown parts into measured output/i)).toBeTruthy()
     expect(collectionsLink.getAttribute('href')).toBe('/collections')
-    expect(syntaxLink.getAttribute('href')).toBe('/getting-started')
+    expect(syntaxLink.getAttribute('href')).toBe('/guide/getting-started')
     expect(screen.getByText(/what maps cleanly here/i)).toBeTruthy()
   })
 })

--- a/playground/src/components/PlaygroundGuidePanel.tsx
+++ b/playground/src/components/PlaygroundGuidePanel.tsx
@@ -4,23 +4,23 @@ import { ButtonLink } from '@/components/ui/ButtonLink'
 
 const DOC_LINKS = {
   movement: {
-    to: '/getting-started?h=statement',
+    to: '/guide/getting-started?h=statement',
     label: 'Movement',
   },
   reps: {
-    to: '/syntax/structure?h=rep-schemes',
+    to: '/guide/syntax/structure?h=rep-schemes',
     label: 'Reps',
   },
   timers: {
-    to: '/syntax/protocols',
+    to: '/guide/syntax/protocols',
     label: 'Timers',
   },
   rounds: {
-    to: '/syntax/structure?h=simple-rounds',
+    to: '/guide/syntax/structure?h=simple-rounds',
     label: 'Rounds',
   },
   load: {
-    to: '/syntax/basics?h=measurements',
+    to: '/guide/syntax/basics?h=measurements',
     label: 'Load',
   },
 } as const
@@ -95,7 +95,7 @@ export function PlaygroundGuidePanel() {
               Browse Collections
             </ButtonLink>
             <ButtonLink
-              to="/getting-started"
+              to="/guide/getting-started"
               variant="outline"
               size="sm"
               className="inline-flex items-center gap-2"

--- a/playground/src/hooks/useZipProcessor.ts
+++ b/playground/src/hooks/useZipProcessor.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryState } from 'nuqs';
+import { playgroundPath, ROUTE_PATTERNS } from '../lib/routes';
 import { decodeZip } from '../services/decodeZip';
 import { playgroundDB, PlaygroundDBService } from '../services/playgroundDB';
 import { formatPlaygroundTimestampId } from '@/lib/playgroundDisplay';
@@ -31,12 +32,12 @@ export function useZipProcessor() {
         });
         
         if (!cancelled) {
-          navigate(`/?id=${id}`, { replace: true });
+          navigate(playgroundPath(id), { replace: true });
         }
       } catch (err) {
         console.error('Failed to decode zip:', err);
         if (!cancelled) {
-          navigate('/', { replace: true });
+          navigate(ROUTE_PATTERNS.playgroundRoot, { replace: true });
         }
       }
     })();

--- a/playground/src/lib/routes.test.tsx
+++ b/playground/src/lib/routes.test.tsx
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+
+// ── Mutable mock state for react-router-dom ───────────────────────────────
+let mockParams: Record<string, string> = {}
+let lastNavigateTo: string | null = null
+let lastNavigateReplace: boolean | undefined
+const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
+
+mock.module('react-router-dom', () => ({
+  useParams: () => mockParams,
+  useNavigate: () => (to: string, options?: { replace?: boolean }) => {
+    navigateCalls.push({ to, options })
+  },
+  Navigate: ({ to, replace }: { to: string; replace?: boolean }) => {
+    lastNavigateTo = to
+    lastNavigateReplace = replace
+    return <div data-testid="navigate" />
+  },
+}))
+
+// ── Import pure functions first (no react-router-dom dependency) ──────────
+import {
+  ROUTE_PATTERNS,
+  resolveRedirect,
+  ROUTE_REDIRECTS,
+  playgroundPath,
+  notePath,
+  journalEntryPath,
+  journalEntryAutoStartPath,
+  workoutPath,
+  runPath,
+  reviewPath,
+  trackerPath,
+  loadPath,
+  feedDetailPath,
+  feedItemPath,
+  collectionDetailPath,
+  isPlaygroundNotePath,
+  isJournalEntryPath,
+  isTrackerPath,
+  isReviewPath,
+  isCollectionWorkoutPath,
+} from './routes'
+
+// ── Dynamic imports for components that consume react-router-dom mocks ────
+let redirectComponents: typeof import('./routes') | null = null
+
+beforeEach(async () => {
+  mockParams = {}
+  lastNavigateTo = null
+  lastNavigateReplace = undefined
+  navigateCalls.length = 0
+  cleanup()
+
+  if (!redirectComponents) {
+    redirectComponents = await import('./routes')
+  }
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Redirect matrix (ROUTE_REDIRECTS + resolveRedirect)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('resolveRedirect', () => {
+  it('redirects /note/playground/:name → /playground/:name', () => {
+    expect(resolveRedirect('/note/playground/hello-world')).toBe(
+      '/playground/hello-world',
+    )
+  })
+
+  it('redirects /workout/:category/:name → /collections/:category/:name', () => {
+    expect(resolveRedirect('/workout/dan-john/simple-strength')).toBe(
+      '/collections/dan-john/simple-strength',
+    )
+  })
+
+  it('redirects /getting-started → /guide/getting-started', () => {
+    expect(resolveRedirect('/getting-started')).toBe('/guide/getting-started')
+  })
+
+  it('redirects /syntax → /guide/syntax', () => {
+    expect(resolveRedirect('/syntax')).toBe('/guide/syntax')
+  })
+
+  it('redirects /syntax/basics → /guide/syntax/basics', () => {
+    expect(resolveRedirect('/syntax/basics')).toBe('/guide/syntax/basics')
+  })
+
+  it('redirects /syntax/protocols → /guide/syntax/protocols', () => {
+    expect(resolveRedirect('/syntax/protocols')).toBe('/guide/syntax/protocols')
+  })
+
+  it('redirects /tracker/:runtimeId → /run/:runtimeId', () => {
+    expect(resolveRedirect('/tracker/abc-123')).toBe('/run/abc-123')
+  })
+
+  it('returns null for already-canonical paths', () => {
+    expect(resolveRedirect('/playground/my-note')).toBeNull()
+    expect(resolveRedirect('/journal/2026-05-19')).toBeNull()
+    expect(resolveRedirect('/collections/dan-john/simple-strength')).toBeNull()
+    expect(resolveRedirect('/guide/getting-started')).toBeNull()
+    expect(resolveRedirect('/guide/syntax')).toBeNull()
+    expect(resolveRedirect('/run/abc-123')).toBeNull()
+    expect(resolveRedirect('/review/abc-123')).toBeNull()
+  })
+
+  it('returns null for unknown paths', () => {
+    expect(resolveRedirect('/unknown-path')).toBeNull()
+    expect(resolveRedirect('/foo/bar/baz')).toBeNull()
+    expect(resolveRedirect('')).toBeNull()
+  })
+
+  it('handles URL-encoded characters in legacy paths', () => {
+    expect(resolveRedirect('/note/playground/hello%20world')).toBe(
+      '/playground/hello%20world',
+    )
+    expect(resolveRedirect('/workout/cat%201/name%202')).toBe(
+      '/collections/cat%201/name%202',
+    )
+  })
+
+  it('does not partially match substrings', () => {
+    expect(resolveRedirect('/prefix/getting-started')).toBeNull()
+    expect(resolveRedirect('/tracker')).toBeNull()
+    expect(resolveRedirect('/note/playground')).toBeNull()
+  })
+})
+
+describe('ROUTE_REDIRECTS structure', () => {
+  it('contains exactly the declared legacy aliases', () => {
+    expect(ROUTE_REDIRECTS).toHaveLength(5)
+  })
+
+  it('every rule has a match function and a to function', () => {
+    for (const rule of ROUTE_REDIRECTS) {
+      expect(typeof rule.match).toBe('function')
+      expect(typeof rule.to).toBe('function')
+    }
+  })
+
+  it('match returns false for non-matching paths', () => {
+    for (const rule of ROUTE_REDIRECTS) {
+      expect(rule.match('/totally-unrelated-path')).toBe(false)
+    }
+  })
+
+  it('match returns a params object for matching paths', () => {
+    const params = ROUTE_REDIRECTS[0]!.match('/note/playground/test')
+    expect(params).not.toBe(false)
+    expect(params).toEqual({ name: 'test' })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Path builders
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('path builders', () => {
+  it('playgroundPath encodes the id', () => {
+    expect(playgroundPath('hello world')).toBe('/playground/hello%20world')
+  })
+
+  it('notePath encodes category and name', () => {
+    expect(notePath('cat 1', 'name 2')).toBe('/note/cat%201/name%202')
+  })
+
+  it('journalEntryPath encodes the id', () => {
+    expect(journalEntryPath('2026-05-19')).toBe('/journal/2026-05-19')
+  })
+
+  it('journalEntryAutoStartPath appends query param', () => {
+    expect(journalEntryAutoStartPath('2026-05-19', 'run-42')).toBe(
+      '/journal/2026-05-19?autoStart=run-42',
+    )
+  })
+
+  it('workoutPath encodes collection and workout', () => {
+    expect(workoutPath('dan john', 'simple strength')).toBe(
+      '/collections/dan%20john/simple%20strength',
+    )
+  })
+
+  it('runPath encodes runtimeId', () => {
+    expect(runPath('abc-123')).toBe('/run/abc-123')
+  })
+
+  it('reviewPath encodes runtimeId', () => {
+    expect(reviewPath('abc-123')).toBe('/review/abc-123')
+  })
+
+  it('trackerPath encodes runtimeId (legacy alias)', () => {
+    expect(trackerPath('abc-123')).toBe('/tracker/abc-123')
+  })
+
+  it('loadPath returns static path', () => {
+    expect(loadPath()).toBe('/load')
+  })
+
+  it('feedDetailPath encodes slug', () => {
+    expect(feedDetailPath('my feed')).toBe('/feeds/my%20feed')
+  })
+
+  it('feedItemPath encodes all three segments', () => {
+    expect(feedItemPath('my feed', '2026-05-19', 'item 1')).toBe(
+      '/feeds/my%20feed/2026-05-19/item%201',
+    )
+  })
+
+  it('collectionDetailPath encodes slug', () => {
+    expect(collectionDetailPath('dan-john')).toBe('/collections/dan-john')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Route family helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('route family helpers', () => {
+  it('isPlaygroundNotePath detects canonical and alias paths', () => {
+    expect(isPlaygroundNotePath('/playground/my-note')).toBe(true)
+    expect(isPlaygroundNotePath('/note/playground/my-note')).toBe(true)
+    expect(isPlaygroundNotePath('/playground')).toBe(false)
+    expect(isPlaygroundNotePath('/journal/my-note')).toBe(false)
+    expect(isPlaygroundNotePath('/')).toBe(false)
+  })
+
+  it('isJournalEntryPath detects /journal/:id but not /journal index', () => {
+    expect(isJournalEntryPath('/journal/2026-05-19')).toBe(true)
+    expect(isJournalEntryPath('/journal/abc')).toBe(true)
+    expect(isJournalEntryPath('/journal')).toBe(false)
+    expect(isJournalEntryPath('/journal/')).toBe(true)
+    expect(isJournalEntryPath('/playground/note')).toBe(false)
+  })
+
+  it('isTrackerPath detects /tracker and /run', () => {
+    expect(isTrackerPath('/tracker/abc')).toBe(true)
+    expect(isTrackerPath('/run/abc')).toBe(true)
+    expect(isTrackerPath('/tracker')).toBe(false)
+    expect(isTrackerPath('/run')).toBe(false)
+    expect(isTrackerPath('/review/abc')).toBe(false)
+  })
+
+  it('isReviewPath detects /review', () => {
+    expect(isReviewPath('/review/abc')).toBe(true)
+    expect(isReviewPath('/review')).toBe(false)
+    expect(isReviewPath('/run/abc')).toBe(false)
+  })
+
+  it('isCollectionWorkoutPath detects /collections/:c/:w', () => {
+    expect(isCollectionWorkoutPath('/collections/dan-john/simple')).toBe(true)
+    expect(isCollectionWorkoutPath('/collections/dan-john')).toBe(false)
+    expect(isCollectionWorkoutPath('/collections')).toBe(false)
+    expect(isCollectionWorkoutPath('/collections/a/')).toBe(false)
+    expect(isCollectionWorkoutPath('/playground/note')).toBe(false)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Redirect components
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('NotePlaygroundRedirect', () => {
+  it('renders Navigate to /playground/:name with replace', async () => {
+    mockParams = { name: 'my-playground' }
+    const { NotePlaygroundRedirect } = redirectComponents!
+    render(<NotePlaygroundRedirect />)
+
+    expect(lastNavigateTo).toBe('/playground/my-playground')
+    expect(lastNavigateReplace).toBe(true)
+    expect(screen.getByTestId('navigate')).toBeDefined()
+  })
+
+  it('handles encoded names', async () => {
+    mockParams = { name: 'hello world' }
+    const { NotePlaygroundRedirect } = redirectComponents!
+    render(<NotePlaygroundRedirect />)
+
+    expect(lastNavigateTo).toBe('/playground/hello%20world')
+  })
+})
+
+describe('WorkoutRedirect', () => {
+  it('renders Navigate to /collections/:category/:name with replace', async () => {
+    mockParams = { category: 'dan-john', name: 'simple-strength' }
+    const { WorkoutRedirect } = redirectComponents!
+    render(<WorkoutRedirect />)
+
+    expect(lastNavigateTo).toBe('/collections/dan-john/simple-strength')
+    expect(lastNavigateReplace).toBe(true)
+  })
+})
+
+describe('TrackerRedirect', () => {
+  it('renders Navigate to /run/:runtimeId with replace', async () => {
+    mockParams = { runtimeId: 'abc-123' }
+    const { TrackerRedirect } = redirectComponents!
+    render(<TrackerRedirect />)
+
+    expect(lastNavigateTo).toBe('/run/abc-123')
+    expect(lastNavigateReplace).toBe(true)
+  })
+})
+
+describe('GettingStartedRedirect', () => {
+  it('renders Navigate to /guide/getting-started with replace', async () => {
+    const { GettingStartedRedirect } = redirectComponents!
+    render(<GettingStartedRedirect />)
+
+    expect(lastNavigateTo).toBe('/guide/getting-started')
+    expect(lastNavigateReplace).toBe(true)
+  })
+})
+
+describe('SyntaxRedirect', () => {
+  it('redirects bare /syntax to /guide/syntax', async () => {
+    mockParams = {}
+    const { SyntaxRedirect } = redirectComponents!
+    render(<SyntaxRedirect />)
+
+    expect(lastNavigateTo).toBe('/guide/syntax')
+    expect(lastNavigateReplace).toBe(true)
+  })
+
+  it('redirects /syntax/basics to /guide/syntax/basics', async () => {
+    mockParams = { '*': 'basics' }
+    const { SyntaxRedirect } = redirectComponents!
+    render(<SyntaxRedirect />)
+
+    expect(lastNavigateTo).toBe('/guide/syntax/basics')
+    expect(lastNavigateReplace).toBe(true)
+  })
+
+  it('redirects /syntax/protocols to /guide/syntax/protocols', async () => {
+    mockParams = { '*': 'protocols' }
+    const { SyntaxRedirect } = redirectComponents!
+    render(<SyntaxRedirect />)
+
+    expect(lastNavigateTo).toBe('/guide/syntax/protocols')
+    expect(lastNavigateReplace).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. NotFoundPage
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('NotFoundPage', () => {
+  it('renders 404 messaging', async () => {
+    const { NotFoundPage } = await import('../pages/NotFoundPage')
+    render(<NotFoundPage />)
+
+    expect(screen.getByText('Page not found')).toBeDefined()
+    expect(
+      screen.getByText(
+        'The page you are looking for does not exist or has been moved.',
+      ),
+    ).toBeDefined()
+  })
+
+  it('navigates home when Go home button is clicked', async () => {
+    const { NotFoundPage } = await import('../pages/NotFoundPage')
+    render(<NotFoundPage />)
+
+    const button = screen.getByRole('button', { name: /Go home/i })
+    expect(button).toBeDefined()
+
+    fireEvent.click(button)
+    expect(navigateCalls).toEqual([{ to: '/', options: undefined }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. Canonical route patterns
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('ROUTE_PATTERNS', () => {
+  it('declares all canonical route families', () => {
+    expect(ROUTE_PATTERNS.home).toBe('/')
+    expect(ROUTE_PATTERNS.playgroundRoot).toBe('/playground')
+    expect(ROUTE_PATTERNS.playground).toBe('/playground/:id')
+    expect(ROUTE_PATTERNS.notePlaygroundAlias).toBe('/note/playground/:name')
+    expect(ROUTE_PATTERNS.note).toBe('/note/:category/:name')
+    expect(ROUTE_PATTERNS.journal).toBe('/journal')
+    expect(ROUTE_PATTERNS.journalEntry).toBe('/journal/:id')
+    expect(ROUTE_PATTERNS.plan).toBe('/plan')
+    expect(ROUTE_PATTERNS.guideGettingStarted).toBe('/guide/getting-started')
+    expect(ROUTE_PATTERNS.guideSyntax).toBe('/guide/syntax')
+    expect(ROUTE_PATTERNS.feeds).toBe('/feeds')
+    expect(ROUTE_PATTERNS.feedDetail).toBe('/feeds/:feedSlug')
+    expect(ROUTE_PATTERNS.feedItem).toBe('/feeds/:feedSlug/:feedDate/:feedItem')
+    expect(ROUTE_PATTERNS.collections).toBe('/collections')
+    expect(ROUTE_PATTERNS.collectionDetail).toBe('/collections/:slug')
+    expect(ROUTE_PATTERNS.collectionWorkout).toBe('/collections/:collection/:workout')
+    expect(ROUTE_PATTERNS.tracker).toBe('/tracker/:runtimeId')
+    expect(ROUTE_PATTERNS.run).toBe('/run/:runtimeId')
+    expect(ROUTE_PATTERNS.review).toBe('/review/:runtimeId')
+    expect(ROUTE_PATTERNS.load).toBe('/load')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. Short canonical routes — not yet implemented
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('short canonical routes (not yet registered in router)', () => {
+  it.skip('/p/:id should resolve as a canonical playground note route', () => {
+    // Expected: /p/:id either renders PlaygroundNotePage directly or
+    // redirects to /playground/:id. Currently no route pattern exists.
+    expect(resolveRedirect('/p/my-note')).not.toBeNull()
+  })
+
+  it.skip('/j/:date should resolve as a canonical journal entry route', () => {
+    // Expected: /j/:date either renders JournalPage directly or
+    // redirects to /journal/:date. Currently no route pattern exists.
+    expect(resolveRedirect('/j/2026-05-19')).not.toBeNull()
+  })
+})

--- a/playground/src/lib/routes.tsx
+++ b/playground/src/lib/routes.tsx
@@ -1,0 +1,241 @@
+/**
+ * Playground Route Definitions — canonical paths, builders, and redirect matrix.
+ *
+ * This is the single source of truth for all browser-level routes in the
+ * playground app.  Route patterns, path builders, and legacy aliases live
+ * here so nothing else hard-codes a path literal.
+ *
+ */
+
+import { Navigate, useParams } from 'react-router-dom'
+import type { ReactNode } from 'react'
+
+// ---------------------------------------------------------------------------
+// React-Router path patterns (used by <Route path="...">)
+// ---------------------------------------------------------------------------
+
+export const ROUTE_PATTERNS = {
+  home: '/',
+  playgroundRoot: '/playground',
+  playground: '/playground/:id',
+  notePlaygroundAlias: '/note/playground/:name',
+  note: '/note/:category/:name',
+  journal: '/journal',
+  journalEntry: '/journal/:id',
+  plan: '/plan',
+  guideGettingStarted: '/guide/getting-started',
+  guideSyntax: '/guide/syntax',
+  feeds: '/feeds',
+  feedDetail: '/feeds/:feedSlug',
+  feedItem: '/feeds/:feedSlug/:feedDate/:feedItem',
+  collections: '/collections',
+  collectionDetail: '/collections/:slug',
+  collectionWorkout: '/collections/:collection/:workout',
+  tracker: '/tracker/:runtimeId',
+  run: '/run/:runtimeId',
+  review: '/review/:runtimeId',
+  load: '/load',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Canonical path builders
+// ---------------------------------------------------------------------------
+
+/** /playground/:id */
+export function playgroundPath(id: string): string {
+  return `/playground/${encodeURIComponent(id)}`;
+}
+
+/** /note/:category/:name */
+export function notePath(category: string, name: string): string {
+  return `/note/${encodeURIComponent(category)}/${encodeURIComponent(name)}`;
+}
+
+/** /journal/:id */
+export function journalEntryPath(id: string): string {
+  return `/journal/${encodeURIComponent(id)}`;
+}
+
+/** /journal/:id?autoStart=<runtimeId> */
+export function journalEntryAutoStartPath(id: string, runtimeId: string): string {
+  return `/journal/${encodeURIComponent(id)}?autoStart=${encodeURIComponent(runtimeId)}`;
+}
+
+/** /feeds/:feedSlug */
+export function feedDetailPath(feedSlug: string): string {
+  return `/feeds/${encodeURIComponent(feedSlug)}`;
+}
+
+/** /feeds/:feedSlug/:feedDate/:feedItem */
+export function feedItemPath(feedSlug: string, feedDate: string, feedItem: string): string {
+  return `/feeds/${encodeURIComponent(feedSlug)}/${encodeURIComponent(feedDate)}/${encodeURIComponent(feedItem)}`;
+}
+
+/** /collections/:slug */
+export function collectionDetailPath(slug: string): string {
+  return `/collections/${encodeURIComponent(slug)}`;
+}
+
+/** /collections/:collection/:workout */
+export function workoutPath(collection: string, workout: string): string {
+  return `/collections/${encodeURIComponent(collection)}/${encodeURIComponent(workout)}`;
+}
+
+/** /tracker/:runtimeId (legacy redirect alias — preserved for external links) */
+export function trackerPath(runtimeId: string): string {
+  return `/tracker/${encodeURIComponent(runtimeId)}`;
+}
+
+/** /run/:runtimeId (canonical runtime seam for WOD-505) */
+export function runPath(runtimeId: string): string {
+  return `/run/${encodeURIComponent(runtimeId)}`;
+}
+
+/** /review/:runtimeId */
+export function reviewPath(runtimeId: string): string {
+  return `/review/${encodeURIComponent(runtimeId)}`;
+}
+
+/** /load */
+export function loadPath(): string {
+  return '/load';
+}
+
+// ---------------------------------------------------------------------------
+// Legacy-alias redirect components
+// ---------------------------------------------------------------------------
+
+/** Redirect /note/playground/:name → /playground/:name */
+export function NotePlaygroundRedirect(): ReactNode {
+  const { name } = useParams<{ name: string }>()
+  return <Navigate to={playgroundPath(name!)} replace />
+}
+
+/** Redirect /workout/:category/:name → /collections/:category/:name */
+export function WorkoutRedirect(): ReactNode {
+  const { category, name } = useParams<{ category: string; name: string }>()
+  return <Navigate to={workoutPath(category!, name!)} replace />
+}
+
+/** Redirect /tracker/:runtimeId → /run/:runtimeId */
+export function TrackerRedirect(): ReactNode {
+  const { runtimeId } = useParams<{ runtimeId: string }>()
+  return <Navigate to={runPath(runtimeId!)} replace />
+}
+
+/** Redirect /getting-started → /guide/getting-started */
+export function GettingStartedRedirect(): ReactNode {
+  return <Navigate to="/guide/getting-started" replace />
+}
+
+/** Redirect /syntax/* → /guide/syntax/* */
+export function SyntaxRedirect(): ReactNode {
+  const { '*': splat } = useParams()
+  return <Navigate to={splat ? `/guide/syntax/${splat}` : '/guide/syntax'} replace />
+}
+
+// ---------------------------------------------------------------------------
+// Legacy-alias → canonical redirect matrix
+// ---------------------------------------------------------------------------
+
+export interface RedirectRule {
+  /** Return captured params (or true for empty) when the pathname matches. */
+  match: (pathname: string) => Record<string, string> | false;
+  /** Build the destination from captured params. */
+  to: (params: Record<string, string>) => string;
+}
+
+/**
+ * Ordered list of legacy aliases that should redirect to their canonical
+ * shape.  Checked in order; first match wins.
+ */
+export const ROUTE_REDIRECTS: RedirectRule[] = [
+  // /note/playground/:name  →  /playground/:name
+  {
+    match: (p) => {
+      const m = p.match(/^\/note\/playground\/([^/]+)$/);
+      if (!m) return false;
+      return { name: decodeURIComponent(m[1]!) };
+    },
+    to: ({ name }) => playgroundPath(name),
+  },
+  // /workout/:category/:name  →  /collections/:category/:name
+  {
+    match: (p) => {
+      const m = p.match(/^\/workout\/([^/]+)\/([^/]+)$/);
+      if (!m) return false;
+      return { collection: decodeURIComponent(m[1]!), workout: decodeURIComponent(m[2]!) };
+    },
+    to: ({ collection, workout }) => workoutPath(collection, workout),
+  },
+  // /getting-started  →  /guide/getting-started
+  {
+    match: (p) => {
+      if (p !== '/getting-started') return false;
+      return {};
+    },
+    to: () => '/guide/getting-started',
+  },
+  // /syntax/*  →  /guide/syntax/*
+  {
+    match: (p) => {
+      const m = p.match(/^\/syntax(\/.+)?$/);
+      if (!m) return false;
+      return { rest: m[1] ?? '' };
+    },
+    to: ({ rest }) => `/guide/syntax${rest}`,
+  },
+  // /tracker/:runtimeId  →  /run/:runtimeId
+  {
+    match: (p) => {
+      const m = p.match(/^\/tracker\/([^/]+)$/);
+      if (!m) return false;
+      return { runtimeId: decodeURIComponent(m[1]!) };
+    },
+    to: ({ runtimeId }) => runPath(runtimeId),
+  },
+];
+
+/**
+ * Resolve a pathname against the redirect matrix.
+ *
+ * @returns The canonical destination string, or `null` when no alias matches.
+ */
+export function resolveRedirect(pathname: string): string | null {
+  for (const rule of ROUTE_REDIRECTS) {
+    const params = rule.match(pathname);
+    if (params !== false) {
+      return rule.to(params);
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Route-category helpers (used by navigation UI)
+// ---------------------------------------------------------------------------
+
+/** Detect whether a location pathname belongs to the playground note family. */
+export function isPlaygroundNotePath(pathname: string): boolean {
+  return pathname.startsWith('/playground/') || pathname.startsWith('/note/playground/');
+}
+
+/** Detect whether a location pathname belongs to the journal entry family. */
+export function isJournalEntryPath(pathname: string): boolean {
+  return pathname.startsWith('/journal/') && pathname !== '/journal';
+}
+
+/** Detect whether a location pathname belongs to the tracker/run family. */
+export function isTrackerPath(pathname: string): boolean {
+  return pathname.startsWith('/tracker/') || pathname.startsWith('/run/');
+}
+
+/** Detect whether a location pathname belongs to the review family. */
+export function isReviewPath(pathname: string): boolean {
+  return pathname.startsWith('/review/');
+}
+
+/** Detect whether a location pathname belongs to the collection workout family. */
+export function isCollectionWorkoutPath(pathname: string): boolean {
+  return pathname.startsWith('/collections/') && pathname.split('/').length >= 4 && pathname.split('/')[3] !== '';
+}

--- a/playground/src/nav/appNavTree.ts
+++ b/playground/src/nav/appNavTree.ts
@@ -32,6 +32,7 @@ import { CollectionsNavPanel } from './panels/CollectionsNavPanel'
 import { FeedsNavPanel }       from './panels/FeedsNavPanel'
 import { canvasRoutes }        from '../canvas/canvasRoutes'
 import { NON_COLLECTION_CATEGORIES } from '../pages/shared/pageUtils'
+import { ROUTE_PATTERNS } from '../lib/routes'
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -87,14 +88,14 @@ export function buildAppNavTree(_openSearch: () => void): NavItem[] {
       label: 'Home',
       level: 1,
       icon: HomeIcon,
-      action: { type: 'route', to: '/playground' },
+      action: { type: 'route', to: ROUTE_PATTERNS.playgroundRoot },
       isActive: (loc) =>
         loc.pathname === '/' ||
         loc.pathname === '' ||
-        loc.pathname === '/getting-started' ||
-        loc.pathname.startsWith('/syntax') ||
+        loc.pathname === ROUTE_PATTERNS.guideGettingStarted ||
+        loc.pathname.startsWith('/guide/syntax') ||
         loc.pathname.startsWith('/canvas') ||
-        loc.pathname === '/playground' ||
+        loc.pathname === ROUTE_PATTERNS.playgroundRoot ||
         loc.pathname.startsWith('/playground/'),
       children: homeChildren,
     },
@@ -104,8 +105,8 @@ export function buildAppNavTree(_openSearch: () => void): NavItem[] {
       label: 'Journal',
       level: 1,
       icon: RectangleStackIcon,
-      action: { type: 'route', to: '/journal' },
-      isActive: isRouteActive('/journal'),
+      action: { type: 'route', to: ROUTE_PATTERNS.journal },
+      isActive: isRouteActive(ROUTE_PATTERNS.journal),
       panel: JournalNavPanel,
     },
 
@@ -114,8 +115,8 @@ export function buildAppNavTree(_openSearch: () => void): NavItem[] {
       label: 'Plan',
       level: 1,
       icon: CalendarDaysIcon,
-      action: { type: 'route', to: '/plan' },
-      isActive: (loc: Location) => loc.pathname === '/plan',
+      action: { type: 'route', to: ROUTE_PATTERNS.plan },
+      isActive: (loc: Location) => loc.pathname === ROUTE_PATTERNS.plan,
       panel: JournalNavPanel,
     },
 
@@ -124,8 +125,8 @@ export function buildAppNavTree(_openSearch: () => void): NavItem[] {
       label: 'Feeds',
       level: 1,
       icon: RssIcon,
-      action: { type: 'route', to: '/feeds' },
-      isActive: (loc: Location) => loc.pathname.startsWith('/feeds'),
+      action: { type: 'route', to: ROUTE_PATTERNS.feeds },
+      isActive: (loc: Location) => loc.pathname.startsWith(ROUTE_PATTERNS.feeds),
       panel: FeedsNavPanel,
     },
 
@@ -134,8 +135,8 @@ export function buildAppNavTree(_openSearch: () => void): NavItem[] {
       label: 'Collections',
       level: 1,
       icon: FolderIcon,
-      action: { type: 'route', to: '/collections' },
-      isActive: (loc) => isRouteActive('/collections')(loc) || isCollectionWorkoutRoute(loc),
+      action: { type: 'route', to: ROUTE_PATTERNS.collections },
+      isActive: (loc) => isRouteActive(ROUTE_PATTERNS.collections)(loc) || isCollectionWorkoutRoute(loc),
       panel: CollectionsNavPanel,
     },
   ]

--- a/playground/src/nav/panels/CollectionsNavPanel.tsx
+++ b/playground/src/nav/panels/CollectionsNavPanel.tsx
@@ -4,7 +4,7 @@
  * Route modes:
  *   - /collections                  → category filter toggles
  *   - /collections/:slug            → this collection's category links
- *   - /workout/:category/:name      → parent collection + sibling workouts
+ *   - /collections/:collection/:workout  → parent collection + sibling workouts
  */
 
 import { useLocation, useNavigate } from 'react-router-dom'
@@ -20,7 +20,7 @@ export function CollectionsNavPanel(_props: NavPanelProps) {
   const navigate = useNavigate()
   const { selectedCategories, toggleCategory, clearCategories } = useCollectionsQueryState()
   const collectionMatch = location.pathname.match(/^\/collections\/([^/]+)$/)
-  const workoutMatch = location.pathname.match(/^\/workout\/([^/]+)\/([^/]+)$/)
+  const workoutMatch = location.pathname.match(/^\/collections\/([^/]+)\/([^/]+)$/)
 
   const collectionSlug = collectionMatch ? decodeURIComponent(collectionMatch[1]) : null
   const workoutCategory = workoutMatch ? decodeURIComponent(workoutMatch[1]) : null
@@ -58,7 +58,7 @@ export function CollectionsNavPanel(_props: NavPanelProps) {
             return (
               <button
                 key={item.id}
-                onClick={() => navigate(`/workout/${encodeURIComponent(workoutCollection.id)}/${encodeURIComponent(item.id)}`)}
+                onClick={() => navigate(`/collections/${encodeURIComponent(workoutCollection.id)}/${encodeURIComponent(item.id)}`)}
                 className={cn(
                   'flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-left transition-colors',
                   isActive

--- a/playground/src/nav/panels/__tests__/CollectionsNavPanel.test.tsx
+++ b/playground/src/nav/panels/__tests__/CollectionsNavPanel.test.tsx
@@ -181,12 +181,12 @@ describe('CollectionsNavPanel', () => {
   });
 
   describe('Workout Detail Page Mode', () => {
-    it('should render parent collection and sibling workouts on /workout/:category/:name', () => {
+    it('should render parent collection and sibling workouts on /collections/:category/:name', () => {
       const navState = createNavState();
       const props = createProps(navState);
 
       render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -201,7 +201,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       const { container } = render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -216,7 +216,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -230,7 +230,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -261,7 +261,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       const { container } = render(
-        <MemoryRouter initialEntries={['/workout/wod/custom-wod']}>
+        <MemoryRouter initialEntries={['/collections/wod/custom-wod']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -307,7 +307,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       const { container } = render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -322,7 +322,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       const { container } = render(
-        <MemoryRouter initialEntries={['/workout/cardio/5k-run']}>
+        <MemoryRouter initialEntries={['/collections/cardio/5k-run']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );
@@ -383,7 +383,7 @@ describe('CollectionsNavPanel', () => {
       const props = createProps(navState);
 
       const { container } = render(
-        <MemoryRouter initialEntries={['/workout/empty/workout']}>
+        <MemoryRouter initialEntries={['/collections/empty/workout']}>
           <CollectionsNavPanel {...props} />
         </MemoryRouter>
       );

--- a/playground/src/pages/FeedItemPage.tsx
+++ b/playground/src/pages/FeedItemPage.tsx
@@ -24,6 +24,7 @@ import { getWodFeedItem, getWodFeed } from '@/repositories/wod-feeds';
 import { usePlaygroundContent } from '../hooks/usePlaygroundContent';
 import { appendWorkoutToJournal } from '../services/journalWorkout';
 import { pendingRuntimes } from '../runtimeStore';
+import { runPath } from '../lib/routes';
 import { useNotePageNav } from './shared/useNotePageNav';
 import { useWodBlockCommands } from '../hooks/useWodBlockCommands';
 import { shareBlock, openBlockInPlayground } from '../services/openInPlayground';
@@ -85,7 +86,7 @@ export function FeedItemPage({
       } catch {
         const runtimeId = uuidv4();
         pendingRuntimes.set(runtimeId, { block, noteId });
-        navigate(`/tracker/${runtimeId}`);
+        navigate(runPath(runtimeId));
       }
     },
     [feed, feedItem, feedSlug, item, navigate, noteId],

--- a/playground/src/pages/NotFoundPage.tsx
+++ b/playground/src/pages/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+/**
+ * NotFoundPage — 404 fallback for unknown routes.
+ *
+ * Replaces the previous wildcard catch-all that silently rendered AppContent.
+ */
+
+import { useNavigate } from 'react-router-dom'
+import { FileQuestion, Home } from 'lucide-react'
+
+export function NotFoundPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="h-full flex flex-col items-center justify-center gap-6 p-8 text-center">
+      <div className="flex items-center justify-center w-16 h-16 rounded-full bg-muted">
+        <FileQuestion className="w-8 h-8 text-muted-foreground" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Page not found</h1>
+        <p className="text-muted-foreground max-w-sm">
+          The page you are looking for does not exist or has been moved.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+      >
+        <Home className="w-4 h-4" />
+        Go home
+      </button>
+    </div>
+  )
+}

--- a/playground/src/pages/PlaygroundLandingPage.tsx
+++ b/playground/src/pages/PlaygroundLandingPage.tsx
@@ -10,6 +10,7 @@ import { createPlaygroundPage } from '../services/createPlaygroundPage'
 import { AttentionWidget, type AttentionActionType, type AttentionWidgetConfig } from '../components/widgets/AttentionWidget'
 import { CodeExampleWidget, type CodeExampleWidgetConfig } from '../components/widgets/CodeExampleWidget'
 import { SyntaxGroupWidget, type SyntaxGroupWidgetConfig } from '../components/widgets/SyntaxGroupWidget'
+import { playgroundPath, reviewPath, workoutPath } from '../lib/routes'
 
 const ATTENTION_CONFIG: AttentionWidgetConfig = {
   headline: 'Build and preview widget-driven workout pages.',
@@ -55,7 +56,7 @@ const SYNTAX_GROUP_CONFIGS: SyntaxGroupWidgetConfig[] = [
     title: 'Rounds',
     description: 'Use parenthesis to repeat grouped blocks.',
     example: '(3)\n  8 Front Squats 95lb\n  *:45 Rest',
-    docsPath: '/syntax#groups',
+    docsPath: '/guide/syntax?h=groups',
   },
   {
     category: 'Timing',
@@ -63,7 +64,7 @@ const SYNTAX_GROUP_CONFIGS: SyntaxGroupWidgetConfig[] = [
     title: 'Timers',
     description: 'Countdowns and rest timers can mix in one block.',
     example: '2:00 Row\n*:30 Rest',
-    docsPath: '/syntax#timers',
+    docsPath: '/guide/syntax?h=timers',
   },
   {
     category: 'Loading',
@@ -71,7 +72,7 @@ const SYNTAX_GROUP_CONFIGS: SyntaxGroupWidgetConfig[] = [
     title: 'Rep schemes',
     description: 'Comma-separated reps compress descending sets.',
     example: '21,15,9 Thrusters 95lb',
-    docsPath: '/syntax#metrics',
+    docsPath: '/guide/syntax?h=metrics',
   },
 ]
 
@@ -115,7 +116,7 @@ export function PlaygroundLandingPage() {
   const handleSelectWorkout = useCallback(
     (item: { name: string; category?: string }) => {
       const category = item.category || 'General'
-      navigate(`/workout/${encodeURIComponent(category)}/${encodeURIComponent(item.name)}`)
+      navigate(workoutPath(category, item.name))
     },
     [navigate],
   )
@@ -140,7 +141,7 @@ export function PlaygroundLandingPage() {
     }
 
     if (item.type === 'journal-entry') {
-      navigate(`/review/${item.id}`)
+      navigate(reviewPath(item.id))
     }
   }, [handleSelectWorkout, navigate, workoutItems])
 
@@ -172,7 +173,7 @@ export function PlaygroundLandingPage() {
       ].join('\n')
 
       const id = await createPlaygroundPage(template)
-      navigate(`/playground/${encodeURIComponent(id)}`)
+      navigate(playgroundPath(id))
     },
     [navigate],
   )

--- a/playground/src/pages/PlaygroundNotePage.tsx
+++ b/playground/src/pages/PlaygroundNotePage.tsx
@@ -25,6 +25,7 @@ import { usePlaygroundContent } from '../hooks/usePlaygroundContent'
 import { PlaygroundDBService } from '../services/playgroundDB'
 import { indexedDBService } from '@/services/db/IndexedDBService'
 import { pendingRuntimes } from '../runtimeStore'
+import { runPath } from '../lib/routes'
 import { PageActions } from './shared/PageActions'
 import { useNotePageNav } from './shared/useNotePageNav'
 import { useWodBlockCommands } from '../hooks/useWodBlockCommands'
@@ -88,7 +89,7 @@ export function PlaygroundNotePage({
     (block: WodBlock) => {
       const runtimeId = uuidv4()
       pendingRuntimes.set(runtimeId, { block, noteId })
-      navigate(`/tracker/${runtimeId}`)
+      navigate(runPath(runtimeId))
     },
     [noteId, navigate],
   )

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -9,6 +9,8 @@ mock.module('react-router-dom', () => ({
   useNavigate: () => (to: string, options?: { replace?: boolean }) => {
     navigateCalls.push({ to, options })
   },
+  useParams: () => ({}),
+  Navigate: ({ to }: { to: string }) => null,
 }))
 
 const createPlaygroundPageMock = mock(async (content: string) => {

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { playgroundPath } from '../lib/routes'
 import { createPlaygroundPage } from '../services/createPlaygroundPage'
-import { DEFAULT_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
+import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
 
 /**
  * Canonical entry route for both `/` and `/playground`.
@@ -19,9 +20,9 @@ export function PlaygroundRedirect() {
 
     ;(async () => {
       try {
-        const id = await createPlaygroundPage(DEFAULT_PLAYGROUND_CONTENT.content)
+        const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
         if (!cancelled) {
-          navigate(`/?id=${encodeURIComponent(id)}`, { replace: true })
+          navigate(playgroundPath(id), { replace: true })
         }
       } catch {
         if (!cancelled) {

--- a/playground/src/pages/TrackerPage.tsx
+++ b/playground/src/pages/TrackerPage.tsx
@@ -1,5 +1,5 @@
 /**
- * TrackerPage — /tracker/:runtimeId
+ * TrackerPage — /run/:runtimeId
  *
  * Runs a workout from a pending runtime stored in the in-memory pendingRuntimes
  * map. On completion the result is persisted to IndexedDB and the user is
@@ -8,8 +8,9 @@
 
 import { useRef, useEffect, useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { reviewPath, playgroundPath, journalEntryPath, workoutPath } from '../lib/routes'
 import { FullscreenTimer } from '@/components/Editor/overlays/FullscreenTimer'
-import { indexedDBService } from '@/services/db/IndexedDBService'
+import { notePersistence } from '@/services/persistence'
 import { pendingRuntimes } from '../runtimeStore'
 
 export function TrackerPage() {
@@ -27,16 +28,16 @@ export function TrackerPage() {
   const handleComplete = useCallback(
     (blockId: string, results: any) => {
       if (!results || !runtimeId || !pending) return
-      indexedDBService.saveResult({
-        id: runtimeId,
-        noteId: pending.noteId,
-        sectionId: blockId,
-        segmentId: blockId,
-        data: results,
-        completedAt: results.endTime || Date.now(),
+      notePersistence.mutateNote(pending.noteId, {
+        workoutResult: {
+          id: runtimeId,
+          sectionId: blockId,
+          data: results,
+          completedAt: results.endTime || Date.now(),
+        },
       }).then(() => {
         if (results.completed) {
-          navigate(`/review/${runtimeId}`, { replace: true })
+          navigate(reviewPath(runtimeId), { replace: true })
         }
       }).catch(() => {})
     },
@@ -46,13 +47,14 @@ export function TrackerPage() {
   const handleClose = useCallback(() => {
     if (!pending) { navigate('/'); return }
     // Go back to the note
+    // Go back to the note
     const parts = pending.noteId.split('/')
     if (parts.length >= 2 && parts[0] === 'playground') {
-      navigate(`/playground/${encodeURIComponent(parts[1])}`, { replace: true })
+      navigate(playgroundPath(parts[1]!), { replace: true })
     } else if (parts.length >= 2 && parts[0] === 'journal') {
-      navigate(`/journal/${encodeURIComponent(parts[1])}`, { replace: true })
+      navigate(journalEntryPath(parts[1]!), { replace: true })
     } else if (parts.length >= 2) {
-      navigate(`/workout/${encodeURIComponent(parts[0])}/${encodeURIComponent(parts[1])}`, { replace: true })
+      navigate(workoutPath(parts[0]!, parts[1]!), { replace: true })
     } else {
       navigate('/', { replace: true })
     }

--- a/playground/src/pages/WorkoutEditorPage.tsx
+++ b/playground/src/pages/WorkoutEditorPage.tsx
@@ -1,5 +1,5 @@
 /**
- * WorkoutEditorPage — /workout/:category/:name
+ * WorkoutEditorPage — /collections/:collection/:workout
  *
  * Wrapper that loads workout content via IndexedDB (or falls back to the
  * bundled MD file). Keeps WodBlock IDs stable across page loads so results
@@ -19,6 +19,7 @@ import { CalendarCard } from '@/components/ui/CalendarCard'
 import { usePlaygroundContent } from '../hooks/usePlaygroundContent'
 import { PlaygroundDBService } from '../services/playgroundDB'
 import { pendingRuntimes } from '../runtimeStore'
+import { runPath } from '../lib/routes'
 import { appendWorkoutToJournal } from '../services/journalWorkout'
 import { PageActions } from './shared/PageActions'
 import { useNotePageNav } from './shared/useNotePageNav'
@@ -58,7 +59,7 @@ export function WorkoutEditorPage({
 
     return {
       label: `${category}-${name}`,
-      path: `/workout/${encodeURIComponent(category)}/${encodeURIComponent(name)}`,
+      path: `/collections/${encodeURIComponent(category)}/${encodeURIComponent(name)}`,
     }
   }, [category, isCollection, name])
 
@@ -70,7 +71,7 @@ export function WorkoutEditorPage({
       // For syntax/inline categories keep the original popup behaviour.
       if (usePopup) {
         pendingRuntimes.set(runtimeId, { block, noteId })
-        navigate(`/tracker/${runtimeId}`)
+        navigate(runPath(runtimeId))
         return
       }
       // Append the wod block to today's journal note and navigate there.
@@ -88,7 +89,7 @@ export function WorkoutEditorPage({
       } catch {
         // IndexedDB unavailable — fall back to the fullscreen tracker route
         pendingRuntimes.set(runtimeId, { block, noteId })
-        navigate(`/tracker/${runtimeId}`)
+        navigate(runPath(runtimeId))
       }
     },
     [usePopup, noteId, name, category, sourceNote, navigate],

--- a/playground/src/services/journalWorkout.test.ts
+++ b/playground/src/services/journalWorkout.test.ts
@@ -29,6 +29,7 @@ mock.module('@/repositories/wod-collections', () => ({
 
     return undefined;
   },
+  getWodCollections: () => [],
 }));
 
 mock.module('./playgroundDB', () => ({
@@ -62,13 +63,13 @@ describe('appendWorkoutToJournal', () => {
       workoutName: 'Event-05',
       category: 'crossfit-games-2021',
       sourceNoteLabel: 'crossfit-games-2021-Event-05',
-      sourceNotePath: '/workout/crossfit-games-2021/Event-05',
+      sourceNotePath: '/collections/crossfit-games-2021/Event-05',
       wodContent: '5 rounds',
       date: new Date('2026-05-05T12:00:00Z'),
     });
 
     expect(savedPages).toHaveLength(1);
-    expect(savedPages[0]?.content).toContain('Source: [crossfit-games-2021-Event-05](/workout/crossfit-games-2021/Event-05)');
+    expect(savedPages[0]?.content).toContain('Source: [crossfit-games-2021-Event-05](/collections/crossfit-games-2021/Event-05)');
     expect(savedPages[0]?.content).toContain('Collection: [crossfit-games-2021](/collections/crossfit-games-2021)');
     expect(savedPages[0]?.content).toContain('## Event-05');
     expect(savedPages[0]?.content).toContain('```wod');

--- a/playground/src/services/journalWorkout.ts
+++ b/playground/src/services/journalWorkout.ts
@@ -65,7 +65,7 @@ export async function appendWorkoutToJournal({
   const collection = getWodCollection(category);
   const siblingLinks = collection?.items
     .filter(item => item.id !== workoutName)
-    .map(item => `[${category}-${item.id}](/workout/${encodeURIComponent(category)}/${encodeURIComponent(item.id)})`) ?? [];
+    .map(item => `[${category}-${item.id}](/collections/${encodeURIComponent(category)}/${encodeURIComponent(item.id)})`) ?? [];
   
   const lines = [
     `\n## ${workoutName}`,

--- a/playground/src/views/homeDocumentationLinks.ts
+++ b/playground/src/views/homeDocumentationLinks.ts
@@ -8,17 +8,17 @@ export const HOME_WORKFLOW_DOC_LINKS = {
   write: {
     id: 'home-doc-write',
     label: 'Statement basics',
-    to: '/getting-started?h=statement',
+    to: '/guide/getting-started?h=statement',
   },
   run: {
     id: 'home-doc-run',
     label: 'Timers and groups',
-    to: '/syntax?h=groups',
+    to: '/guide/syntax?h=groups',
   },
   analyze: {
     id: 'home-doc-analyze',
     label: 'Review workflow',
-    to: '/getting-started?h=review',
+    to: '/guide/getting-started?h=review',
   },
 } as const
 
@@ -26,21 +26,21 @@ export const HOME_SYNTAX_DEEP_LINKS: DocumentationLinkItem[] = [
   {
     id: 'syntax-deep-overview',
     label: 'Syntax overview',
-    to: '/syntax',
+    to: '/guide/syntax',
   },
   {
     id: 'syntax-deep-anatomy',
     label: 'Statement anatomy',
-    to: '/syntax?h=anatomy',
+    to: '/guide/syntax?h=anatomy',
   },
   {
     id: 'syntax-deep-groups',
     label: 'Groups and repeaters',
-    to: '/syntax?h=groups',
+    to: '/guide/syntax?h=groups',
   },
   {
     id: 'syntax-deep-protocols',
     label: 'Protocols',
-    to: '/syntax?h=protocols',
+    to: '/guide/syntax?h=protocols',
   },
 ]


### PR DESCRIPTION
## Summary
- ship the audited canonical playground router contract in code
- add explicit compatibility redirects plus a dedicated not-found page
- include the route inventory and governance ADR from [WOD-490](/WOD/issues/WOD-490)

## Verification
- bun test playground/src/lib/routes.test.tsx playground/src/pages/PlaygroundRedirect.test.tsx playground/src/components/PlaygroundGuidePanel.test.tsx playground/src/nav/panels/__tests__/CollectionsNavPanel.test.tsx playground/src/services/journalWorkout.test.ts --preload ./tests/unit-setup.ts --isolate
- bun x vite build --config playground/vite.config.ts

## Notes
- supersedes the docs-only PR #608 for [WOD-490](/WOD/issues/WOD-490)