### PR TITLE
feat(hero): HeroSlider widget variations with slice transitions

### DIFF
--- a/src/components/Editor/widgets/HeroSlider.tsx
+++ b/src/components/Editor/widgets/HeroSlider.tsx
@@ -1,0 +1,277 @@
+/**
+ * HeroSlider widget
+ *
+ * A full-width hero section that cycles through slides using a "slice"
+ * transition effect. Each slide is split into vertical strips that stagger
+ * in and out, creating a clean, pleasant easing animation.
+ *
+ * Config JSON shape:
+ *   {
+ *     "intervalMs": 6000,
+ *     "autoPlay": true,
+ *     "slices": 8,
+ *     "slides": [
+ *       {
+ *         "title": "…",
+ *         "subtitle": "…",
+ *         "body": "…",
+ *         "badge": "New",
+ *         "cta": { "label": "Go →", "href": "#" },
+ *         "bgGradient": "from-primary/10 via-background to-secondary/10"
+ *       }
+ *     ]
+ *   }
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import type { WidgetProps } from "./types";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface SlideCta {
+  label: string;
+  href?: string;
+}
+
+interface Slide {
+  title: string;
+  subtitle?: string;
+  body?: string;
+  badge?: string;
+  cta?: SlideCta;
+  bgGradient?: string;
+}
+
+interface HeroSliderConfig {
+  slides: Slide[];
+  intervalMs?: number;
+  autoPlay?: boolean;
+  slices?: number;
+}
+
+// ── Slice transition variants ────────────────────────────────────────
+
+const sliceVariants = {
+  enter: (direction: number) => ({
+    clipPath: direction > 0
+      ? "inset(0 0 0 100%)"
+      : "inset(0 100% 0 0)",
+    opacity: 0,
+  }),
+  center: {
+    clipPath: "inset(0 0% 0 0%)",
+    opacity: 1,
+  },
+  exit: (direction: number) => ({
+    clipPath: direction > 0
+      ? "inset(0 100% 0 0)"
+      : "inset(0 0 0 100%)",
+    opacity: 0,
+  }),
+};
+
+const contentVariants = {
+  enter: { opacity: 0, y: 20 },
+  center: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
+};
+
+// ── Component ────────────────────────────────────────────────────────
+
+export const HeroSlider: React.FC<WidgetProps> = ({ config }) => {
+  const {
+    slides = [],
+    intervalMs = 6000,
+    autoPlay = true,
+    slices = 8,
+  } = config as unknown as HeroSliderConfig;
+
+  const [[index, direction], setIndex] = useState([0, 0]);
+  const [isPaused, setIsPaused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const slideCount = slides.length;
+
+  const paginate = useCallback(
+    (newDirection: number) => {
+      setIndex(([prev]) => {
+        const next = (prev + newDirection + slideCount) % slideCount;
+        return [next, newDirection];
+      });
+    },
+    [slideCount]
+  );
+
+  // Auto-advance
+  useEffect(() => {
+    if (!autoPlay || slideCount <= 1 || isPaused) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+    timerRef.current = setInterval(() => paginate(1), intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [autoPlay, intervalMs, isPaused, paginate, slideCount]);
+
+  if (slideCount === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+        No slides configured
+      </div>
+    );
+  }
+
+  const currentSlide = slides[index];
+  const sliceArray = Array.from({ length: slices }, (_, i) => i);
+  const sliceWidth = 100 / slices;
+
+  return (
+    <div
+      className="relative flex h-full w-full flex-col overflow-hidden"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {/* Background layer with gradient */}
+      <div
+        className={`absolute inset-0 bg-gradient-to-br ${
+          currentSlide.bgGradient || "from-primary/10 via-background to-secondary/10"
+        }`}
+      />
+
+      {/* Slice transition container */}
+      <div className="relative flex-1 overflow-hidden">
+        <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          <motion.div
+            key={index}
+            className="absolute inset-0 flex"
+            custom={direction}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{ duration: 0.01 }} // container switches instantly; slices handle animation
+          >
+            {sliceArray.map((sliceIndex) => (
+              <motion.div
+                key={sliceIndex}
+                className="relative h-full overflow-hidden"
+                style={{ width: `${sliceWidth}%` }}
+                custom={direction}
+                variants={sliceVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{
+                  duration: 0.55,
+                  ease: [0.32, 0.72, 0, 1],
+                  delay: sliceIndex * 0.025,
+                }}
+              >
+                {/* Each slice shows a clipped portion of the slide content */}
+                <div
+                  className="absolute top-0 h-full"
+                  style={{
+                    left: `${-sliceIndex * sliceWidth}%`,
+                    width: `${slices * sliceWidth}%`,
+                  }}
+                >
+                  <div className="flex h-full w-full flex-col justify-center px-6 py-8 sm:px-10 lg:px-16">
+                    <motion.div
+                      variants={contentVariants}
+                      initial="enter"
+                      animate="center"
+                      exit="exit"
+                      transition={{
+                        duration: 0.45,
+                        ease: [0.32, 0.72, 0, 1],
+                        delay: 0.15 + sliceIndex * 0.02,
+                      }}
+                      className="max-w-2xl"
+                    >
+                      {currentSlide.badge && (
+                        <span className="mb-3 inline-block self-start rounded-full bg-primary/20 px-2.5 py-0.5 text-xs font-semibold text-primary">
+                          {currentSlide.badge}
+                        </span>
+                      )}
+
+                      <h2 className="text-2xl font-bold leading-tight tracking-tight text-foreground sm:text-3xl lg:text-4xl">
+                        {currentSlide.title}
+                      </h2>
+
+                      {currentSlide.subtitle && (
+                        <p className="mt-2 text-base font-medium text-muted-foreground sm:text-lg">
+                          {currentSlide.subtitle}
+                        </p>
+                      )}
+
+                      {currentSlide.body && (
+                        <p className="mt-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                          {currentSlide.body}
+                        </p>
+                      )}
+
+                      {currentSlide.cta && (
+                        <a
+                          href={currentSlide.cta.href || "#"}
+                          className="mt-5 inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-opacity hover:opacity-90"
+                        >
+                          {currentSlide.cta.label}
+                        </a>
+                      )}
+                    </motion.div>
+                  </div>
+                </div>
+              </motion.div>
+            ))}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation arrows */}
+      {slideCount > 1 && (
+        <>
+          <button
+            onClick={() => paginate(-1)}
+            className="absolute left-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Previous slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            onClick={() => paginate(1)}
+            className="absolute right-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Next slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </>
+      )}
+
+      {/* Dot indicators */}
+      {slideCount > 1 && (
+        <div className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => paginate(i > index ? 1 : -1)}
+              className={`h-1.5 rounded-full transition-all ${
+                i === index
+                  ? "w-6 bg-primary"
+                  : "w-1.5 bg-primary/30 hover:bg-primary/60"
+              }`}
+              aria-label={`Slide ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Editor/widgets/HeroSliderDiagonal.tsx
+++ b/src/components/Editor/widgets/HeroSliderDiagonal.tsx
@@ -1,0 +1,269 @@
+/**
+ * HeroSliderDiagonal widget
+ *
+ * A full-width hero section that cycles through slides using a diagonal "slice"
+ * transition effect. Slides are split into diagonal strips that sweep in and out
+ * at an angle, creating a more dynamic, modern feel.
+ *
+ * Config JSON shape:
+ *   {
+ *     "intervalMs": 6000,
+ *     "autoPlay": true,
+ *     "slices": 10,
+ *     "angle": -25,
+ *     "slides": [
+ *       {
+ *         "title": "…",
+ *         "subtitle": "…",
+ *         "body": "…",
+ *         "badge": "New",
+ *         "cta": { "label": "Go →", "href": "#" },
+ *         "bgGradient": "from-primary/10 via-background to-secondary/10"
+ *       }
+ *     ]
+ *   }
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import type { WidgetProps } from "./types";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface SlideCta {
+  label: string;
+  href?: string;
+}
+
+interface Slide {
+  title: string;
+  subtitle?: string;
+  body?: string;
+  badge?: string;
+  cta?: SlideCta;
+  bgGradient?: string;
+}
+
+interface HeroSliderDiagonalConfig {
+  slides: Slide[];
+  intervalMs?: number;
+  autoPlay?: boolean;
+  slices?: number;
+  angle?: number;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export const HeroSliderDiagonal: React.FC<WidgetProps> = ({ config }) => {
+  const {
+    slides = [],
+    intervalMs = 6000,
+    autoPlay = true,
+    slices = 10,
+    angle = -25,
+  } = config as unknown as HeroSliderDiagonalConfig;
+
+  const [[index, direction], setIndex] = useState([0, 0]);
+  const [isPaused, setIsPaused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const slideCount = slides.length;
+
+  const paginate = useCallback(
+    (newDirection: number) => {
+      setIndex(([prev]) => {
+        const next = (prev + newDirection + slideCount) % slideCount;
+        return [next, newDirection];
+      });
+    },
+    [slideCount]
+  );
+
+  // Auto-advance
+  useEffect(() => {
+    if (!autoPlay || slideCount <= 1 || isPaused) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+    timerRef.current = setInterval(() => paginate(1), intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [autoPlay, intervalMs, isPaused, paginate, slideCount]);
+
+  if (slideCount === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+        No slides configured
+      </div>
+    );
+  }
+
+  const currentSlide = slides[index];
+  const sliceArray = Array.from({ length: slices }, (_, i) => i);
+  const sliceWidth = 100 / slices;
+
+  return (
+    <div
+      className="relative flex h-full w-full flex-col overflow-hidden"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {/* Background layer with gradient */}
+      <div
+        className={`absolute inset-0 bg-gradient-to-br ${
+          currentSlide.bgGradient || "from-primary/10 via-background to-secondary/10"
+        }`}
+      />
+
+      {/* Diagonal slice transition container */}
+      <div className="relative flex-1 overflow-hidden">
+        <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          <motion.div
+            key={index}
+            className="absolute inset-0 flex"
+            custom={direction}
+          >
+            {sliceArray.map((sliceIndex) => {
+              const isEven = sliceIndex % 2 === 0;
+              const staggerDelay = sliceIndex * 0.03;
+              const yOffset = direction > 0 ? (isEven ? -40 : 40) : (isEven ? 40 : -40);
+
+              return (
+                <motion.div
+                  key={sliceIndex}
+                  className="relative h-full overflow-hidden"
+                  style={{
+                    width: `${sliceWidth}%`,
+                    transform: `skewX(${angle}deg)`,
+                    transformOrigin: "center center",
+                  }}
+                  initial={{
+                    x: direction > 0 ? 300 : -300,
+                    opacity: 0,
+                    scaleY: 0.8,
+                  }}
+                  animate={{
+                    x: 0,
+                    opacity: 1,
+                    scaleY: 1,
+                  }}
+                  exit={{
+                    x: direction > 0 ? -300 : 300,
+                    opacity: 0,
+                    scaleY: 0.8,
+                  }}
+                  transition={{
+                    duration: 0.6,
+                    ease: [0.32, 0.72, 0, 1],
+                    delay: staggerDelay,
+                  }}
+                >
+                  {/* Each slice shows a clipped portion of the slide content */}
+                  <div
+                    className="absolute top-0 h-full"
+                    style={{
+                      left: `${-sliceIndex * sliceWidth}%`,
+                      width: `${slices * sliceWidth}%`,
+                      transform: `skewX(${-angle}deg)`, // counter-skew content
+                    }}
+                  >
+                    <div className="flex h-full w-full flex-col justify-center px-6 py-8 sm:px-10 lg:px-16">
+                      <motion.div
+                        initial={{ opacity: 0, y: yOffset }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -yOffset }}
+                        transition={{
+                          duration: 0.5,
+                          ease: [0.32, 0.72, 0, 1],
+                          delay: 0.2 + staggerDelay,
+                        }}
+                        className="max-w-2xl"
+                      >
+                        {currentSlide.badge && (
+                          <span className="mb-3 inline-block self-start rounded-full bg-primary/20 px-2.5 py-0.5 text-xs font-semibold text-primary">
+                            {currentSlide.badge}
+                          </span>
+                        )}
+
+                        <h2 className="text-2xl font-bold leading-tight tracking-tight text-foreground sm:text-3xl lg:text-4xl">
+                          {currentSlide.title}
+                        </h2>
+
+                        {currentSlide.subtitle && (
+                          <p className="mt-2 text-base font-medium text-muted-foreground sm:text-lg">
+                            {currentSlide.subtitle}
+                          </p>
+                        )}
+
+                        {currentSlide.body && (
+                          <p className="mt-3 text-sm leading-relaxed text-muted-foreground sm:text-base">
+                            {currentSlide.body}
+                          </p>
+                        )}
+
+                        {currentSlide.cta && (
+                          <a
+                            href={currentSlide.cta.href || "#"}
+                            className="mt-5 inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-opacity hover:opacity-90"
+                          >
+                            {currentSlide.cta.label}
+                          </a>
+                        )}
+                      </motion.div>
+                    </div>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation arrows */}
+      {slideCount > 1 && (
+        <>
+          <button
+            onClick={() => paginate(-1)}
+            className="absolute left-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Previous slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            onClick={() => paginate(1)}
+            className="absolute right-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Next slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </>
+      )}
+
+      {/* Dot indicators */}
+      {slideCount > 1 && (
+        <div className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => paginate(i > index ? 1 : -1)}
+              className={`h-1.5 rounded-full transition-all ${
+                i === index
+                  ? "w-6 bg-primary"
+                  : "w-1.5 bg-primary/30 hover:bg-primary/60"
+              }`}
+              aria-label={`Slide ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Editor/widgets/HeroSliderFade.tsx
+++ b/src/components/Editor/widgets/HeroSliderFade.tsx
@@ -1,0 +1,234 @@
+/**
+ * HeroSliderFade widget
+ *
+ * A full-width hero section that cycles through slides using a soft cross-fade
+ * with a subtle scale and blur transition. Clean, minimal, and elegant.
+ *
+ * Config JSON shape:
+ *   {
+ *     "intervalMs": 6000,
+ *     "autoPlay": true,
+ *     "slides": [
+ *       {
+ *         "title": "…",
+ *         "subtitle": "…",
+ *         "body": "…",
+ *         "badge": "New",
+ *         "cta": { "label": "Go →", "href": "#" },
+ *         "bgGradient": "from-primary/10 via-background to-secondary/10"
+ *       }
+ *     ]
+ *   }
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import type { WidgetProps } from "./types";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+interface SlideCta {
+  label: string;
+  href?: string;
+}
+
+interface Slide {
+  title: string;
+  subtitle?: string;
+  body?: string;
+  badge?: string;
+  cta?: SlideCta;
+  bgGradient?: string;
+}
+
+interface HeroSliderFadeConfig {
+  slides: Slide[];
+  intervalMs?: number;
+  autoPlay?: boolean;
+}
+
+// ── Component ────────────────────────────────────────────────────────
+
+export const HeroSliderFade: React.FC<WidgetProps> = ({ config }) => {
+  const {
+    slides = [],
+    intervalMs = 6000,
+    autoPlay = true,
+  } = config as unknown as HeroSliderFadeConfig;
+
+  const [[index, direction], setIndex] = useState([0, 0]);
+  const [isPaused, setIsPaused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const slideCount = slides.length;
+
+  const paginate = useCallback(
+    (newDirection: number) => {
+      setIndex(([prev]) => {
+        const next = (prev + newDirection + slideCount) % slideCount;
+        return [next, newDirection];
+      });
+    },
+    [slideCount]
+  );
+
+  // Auto-advance
+  useEffect(() => {
+    if (!autoPlay || slideCount <= 1 || isPaused) {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+      return;
+    }
+    timerRef.current = setInterval(() => paginate(1), intervalMs);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [autoPlay, intervalMs, isPaused, paginate, slideCount]);
+
+  if (slideCount === 0) {
+    return (
+      <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+        No slides configured
+      </div>
+    );
+  }
+
+  const currentSlide = slides[index];
+
+  return (
+    <div
+      className="relative flex h-full w-full flex-col overflow-hidden"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      {/* Background layer with gradient */}
+      <AnimatePresence initial={false} mode="popLayout">
+        <motion.div
+          key={`bg-${index}`}
+          className={`absolute inset-0 bg-gradient-to-br ${
+            currentSlide.bgGradient || "from-primary/10 via-background to-secondary/10"
+          }`}
+          initial={{ opacity: 0, scale: 1.05 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.98 }}
+          transition={{ duration: 0.8, ease: [0.32, 0.72, 0, 1] }}
+        />
+      </AnimatePresence>
+
+      {/* Content layer */}
+      <div className="relative flex-1">
+        <AnimatePresence initial={false} custom={direction} mode="popLayout">
+          <motion.div
+            key={index}
+            className="absolute inset-0 flex flex-col justify-center px-6 py-8 sm:px-10 lg:px-16"
+            custom={direction}
+            initial={{ opacity: 0, y: 30, filter: "blur(8px)" }}
+            animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+            exit={{ opacity: 0, y: -30, filter: "blur(8px)" }}
+            transition={{ duration: 0.6, ease: [0.32, 0.72, 0, 1] }}
+          >
+            <div className="max-w-2xl">
+              {currentSlide.badge && (
+                <motion.span
+                  initial={{ opacity: 0, x: -10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: 0.2, duration: 0.4 }}
+                  className="mb-3 inline-block self-start rounded-full bg-primary/20 px-2.5 py-0.5 text-xs font-semibold text-primary"
+                >
+                  {currentSlide.badge}
+                </motion.span>
+              )}
+
+              <motion.h2
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.1, duration: 0.5 }}
+                className="text-2xl font-bold leading-tight tracking-tight text-foreground sm:text-3xl lg:text-4xl"
+              >
+                {currentSlide.title}
+              </motion.h2>
+
+              {currentSlide.subtitle && (
+                <motion.p
+                  initial={{ opacity: 0, y: 15 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.2, duration: 0.5 }}
+                  className="mt-2 text-base font-medium text-muted-foreground sm:text-lg"
+                >
+                  {currentSlide.subtitle}
+                </motion.p>
+              )}
+
+              {currentSlide.body && (
+                <motion.p
+                  initial={{ opacity: 0, y: 15 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.3, duration: 0.5 }}
+                  className="mt-3 text-sm leading-relaxed text-muted-foreground sm:text-base"
+                >
+                  {currentSlide.body}
+                </motion.p>
+              )}
+
+              {currentSlide.cta && (
+                <motion.a
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.4, duration: 0.4 }}
+                  href={currentSlide.cta.href || "#"}
+                  className="mt-5 inline-block rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition-opacity hover:opacity-90"
+                >
+                  {currentSlide.cta.label}
+                </motion.a>
+              )}
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Navigation arrows */}
+      {slideCount > 1 && (
+        <>
+          <button
+            onClick={() => paginate(-1)}
+            className="absolute left-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Previous slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            onClick={() => paginate(1)}
+            className="absolute right-3 top-1/2 z-10 flex size-8 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-background"
+            aria-label="Next slide"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        </>
+      )}
+
+      {/* Dot indicators */}
+      {slideCount > 1 && (
+        <div className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 gap-2">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => paginate(i > index ? 1 : -1)}
+              className={`h-1.5 rounded-full transition-all ${
+                i === index
+                  ? "w-6 bg-primary"
+                  : "w-1.5 bg-primary/30 hover:bg-primary/60"
+              }`}
+              aria-label={`Slide ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/stories/catalog/organisms/HeroSlider.stories.tsx
+++ b/stories/catalog/organisms/HeroSlider.stories.tsx
@@ -1,0 +1,184 @@
+/**
+ * Catalog / Organisms / HeroSlider
+ *
+ * Hero slider widget variations with slice-based transitions.
+ * Three transition styles: vertical slice, diagonal slice, and fade/blur.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react";
+import { HeroSlider } from "@/components/Editor/widgets/HeroSlider";
+import { HeroSliderDiagonal } from "@/components/Editor/widgets/HeroSliderDiagonal";
+import { HeroSliderFade } from "@/components/Editor/widgets/HeroSliderFade";
+
+// ── Shared demo slides ───────────────────────────────────────────────
+
+const DEMO_SLIDES = [
+  {
+    title: "The workout studio built for fitness enthusiasts.",
+    subtitle: "Plan with Markdown, execute with a precision timer, and evolve with performance insights.",
+    badge: "Workout Studio",
+    cta: { label: "Start Planning", href: "#" },
+    bgGradient: "from-emerald-500/10 via-background to-teal-500/5",
+  },
+  {
+    title: "Write workouts in Markdown",
+    subtitle: "Draft, format, and share workouts as fast as you can type — no forms, no friction.",
+    badge: "Plan",
+    cta: { label: "Try the Editor", href: "#" },
+    bgGradient: "from-blue-500/10 via-background to-indigo-500/5",
+  },
+  {
+    title: "Integrated timer keeps pace",
+    subtitle: "Your scripted workout comes to life. Hit Start and let the app keep the pace while you focus on the work.",
+    badge: "Execute",
+    cta: { label: "See Timer Demo", href: "#" },
+    bgGradient: "from-amber-500/10 via-background to-orange-500/5",
+  },
+  {
+    title: "Data-driven performance insights",
+    subtitle: "Every lap tracked becomes insight. Analyse trends, visualise progress, and make informed adjustments.",
+    badge: "Evolve",
+    cta: { label: "View Insights", href: "#" },
+    bgGradient: "from-violet-500/10 via-background to-purple-500/5",
+  },
+];
+
+const SINGLE_SLIDE = [DEMO_SLIDES[0]];
+
+// ── Story wrappers ───────────────────────────────────────────────────
+
+interface SliderStoryProps {
+  Component: React.ComponentType<any>;
+  config: Record<string, unknown>;
+}
+
+const SliderStoryWrapper: React.FC<SliderStoryProps> = ({ Component, config }) => (
+  <div className="h-[420px] w-full rounded-2xl border border-border/40 overflow-hidden shadow-sm">
+    <Component config={config} rawContent="" sectionId="storybook-demo" />
+  </div>
+);
+
+// ── Meta for HeroSlider (vertical slice) ─────────────────────────────
+
+const metaSlider: Meta<typeof HeroSlider> = {
+  title: "catalog/organisms/HeroSlider",
+  component: HeroSlider,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Hero slider with vertical slice transitions. Each slide is split into vertical strips that stagger in and out with a smooth easing curve.",
+      },
+    },
+  },
+};
+
+export default metaSlider;
+
+type Story = StoryObj<typeof metaSlider>;
+
+// ── HeroSlider stories ───────────────────────────────────────────────
+
+export const VerticalSlice: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSlider}
+      config={{ slides: DEMO_SLIDES, intervalMs: 5000, slices: 8 }}
+    />
+  ),
+};
+
+export const VerticalSliceSlow: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSlider}
+      config={{ slides: DEMO_SLIDES, intervalMs: 8000, slices: 12 }}
+    />
+  ),
+};
+
+export const VerticalSliceSingle: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSlider}
+      config={{ slides: SINGLE_SLIDE, slices: 8 }}
+    />
+  ),
+};
+
+// ── HeroSliderDiagonal stories ───────────────────────────────────────
+
+export const DiagonalSlice: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSliderDiagonal}
+      config={{ slides: DEMO_SLIDES, intervalMs: 5000, slices: 10, angle: -25 }}
+    />
+  ),
+};
+
+export const DiagonalSliceSteep: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSliderDiagonal}
+      config={{ slides: DEMO_SLIDES, intervalMs: 6000, slices: 12, angle: -45 }}
+    />
+  ),
+};
+
+// ── HeroSliderFade stories ───────────────────────────────────────────
+
+export const FadeBlur: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSliderFade}
+      config={{ slides: DEMO_SLIDES, intervalMs: 5000 }}
+    />
+  ),
+};
+
+export const FadeBlurSlow: Story = {
+  render: () => (
+    <SliderStoryWrapper
+      Component={HeroSliderFade}
+      config={{ slides: DEMO_SLIDES, intervalMs: 8000 }}
+    />
+  ),
+};
+
+// ── Comparison view ──────────────────────────────────────────────────
+
+export const AllVariations: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Vertical Slice
+        </h3>
+        <SliderStoryWrapper
+          Component={HeroSlider}
+          config={{ slides: DEMO_SLIDES, intervalMs: 6000, slices: 8 }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Diagonal Slice
+        </h3>
+        <SliderStoryWrapper
+          Component={HeroSliderDiagonal}
+          config={{ slides: DEMO_SLIDES, intervalMs: 6000, slices: 10, angle: -25 }}
+        />
+      </div>
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Fade + Blur
+        </h3>
+        <SliderStoryWrapper
+          Component={HeroSliderFade}
+          config={{ slides: DEMO_SLIDES, intervalMs: 6000 }}
+        />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

Three hero slider widget variations to replace the static landing page hero.

## Variations

| Variant | Transition |
|---------|-----------|
| HeroSlider | Vertical slice (clipPath stagger) |
| HeroSliderDiagonal | Diagonal slice (skewX wave) |
| HeroSliderFade | Fade + blur + scale |

## Demo

- 4 slides: Hero → Plan → Execute → Evolve
- Auto-advance with pause on hover
- Arrow + dot navigation
- Storybook stories for review

## Tickets

- WOD-595 (implementation)
- WOD-596 (preview deploy)
- WOD-597 (post-review integration)

## Checklist

- [x] TypeScript compiles clean
- [x] Storybook stories render
- [x] 60fps transitions on desktop
