### PR TITLE
fix: add PlaygroundRedirect template selection

### DIFF
--- a/markdown/canvas/home/README.md
+++ b/markdown/canvas/home/README.md
@@ -1,7 +1,7 @@
 ---
 search: hidden
 template: canvas
-route: /
+route: /tour
 hidden: true
 ---
 

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -626,7 +626,7 @@ export function App() {
             <CommandProvider>
               <NavProvider tree={navTree}>
                 <Routes>
-                  <Route path={ROUTE_PATTERNS.home} element={<PlaygroundRedirect />} />
+                  <Route path={ROUTE_PATTERNS.home} element={<PlaygroundRedirect template="home" />} />
                   <Route path="/getting-started" element={<GettingStartedRedirect />} />
                   <Route path="/getting-started/*" element={<GettingStartedRedirect />} />
                   <Route path="/syntax" element={<SyntaxRedirect />} />
@@ -640,7 +640,7 @@ export function App() {
                   <Route path={ROUTE_PATTERNS.collectionDetail} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                   <Route path={ROUTE_PATTERNS.collectionWorkout} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                   <Route path={ROUTE_PATTERNS.load} element={<Suspense fallback={<div className="flex-1 flex items-center justify-center text-zinc-400">Loading…</div>}><LoadZipPage /></Suspense>} />
-                  <Route path={ROUTE_PATTERNS.playgroundRoot} element={<PlaygroundRedirect />} />
+                  <Route path={ROUTE_PATTERNS.playgroundRoot} element={<PlaygroundRedirect template="empty" />} />
                   <Route path={ROUTE_PATTERNS.playground} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                   <Route path={ROUTE_PATTERNS.notePlaygroundAlias} element={<NotePlaygroundRedirect />} />
                   <Route path={ROUTE_PATTERNS.note} element={<AppContent searchHandlerRef={searchHandlerRef} />} />

--- a/playground/src/canvas/canvasRoutes.test.ts
+++ b/playground/src/canvas/canvasRoutes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'fs'
+
+import { ROUTE_PATTERNS } from '../lib/routes'
+import { parseCanvasMarkdown } from './parseCanvasMarkdown'
+
+const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8')
+const homeMarkdown = readFileSync(new URL('../../../markdown/canvas/home/README.md', import.meta.url), 'utf8')
+const homePage = parseCanvasMarkdown(homeMarkdown)
+
+describe('home route governance', () => {
+  it('keeps / owned by the playground redirect route', () => {
+    expect(ROUTE_PATTERNS.home).toBe('/')
+    expect(appSource).toMatch(
+      /<Route\s+path=\{ROUTE_PATTERNS\.home\}[\s\S]*?<PlaygroundRedirect template="home"\s*\/>/,
+    )
+  })
+
+  it('moves the editorial home canvas off the root route onto /tour', () => {
+    expect(homePage).not.toBeNull()
+    expect(homePage?.route).toBe('/tour')
+    expect(homePage?.route).not.toBe(ROUTE_PATTERNS.home)
+  })
+})

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -29,6 +29,9 @@ mock.module('../templates/defaultPlaygroundContent', () => ({
   EMPTY_PLAYGROUND_CONTENT: {
     content: '# New playground\n',
   },
+  DEFAULT_PLAYGROUND_CONTENT: {
+    content: '# Playground home\n',
+  },
 }))
 
 const componentModule = import('./PlaygroundRedirect')
@@ -41,13 +44,29 @@ beforeEach(() => {
 })
 
 describe('PlaygroundRedirect', () => {
-  it('creates a fresh playground note and redirects to its canonical route', async () => {
+  it('creates an empty playground note for the /playground entry route by default', async () => {
     const { PlaygroundRedirect } = await componentModule
 
     render(<PlaygroundRedirect />)
 
     await waitFor(() => {
       expect(createPlaygroundPageCalls).toEqual(['# New playground\n'])
+      expect(navigateCalls).toEqual([
+        {
+          to: '/playground/2026-05-19%2015.30',
+          options: { replace: true },
+        },
+      ])
+    })
+  })
+
+  it('creates the rich home playground note when template="home"', async () => {
+    const { PlaygroundRedirect } = await componentModule
+
+    render(<PlaygroundRedirect template="home" />)
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual(['# Playground home\n'])
       expect(navigateCalls).toEqual([
         {
           to: '/playground/2026-05-19%2015.30',

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -3,24 +3,34 @@ import { useNavigate } from 'react-router-dom'
 
 import { playgroundPath } from '../lib/routes'
 import { createPlaygroundPage } from '../services/createPlaygroundPage'
-import { EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
+import { DEFAULT_PLAYGROUND_CONTENT, EMPTY_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
+
+export interface PlaygroundRedirectProps {
+  template?: 'empty' | 'home'
+}
 
 /**
- * Canonical entry route for both `/` and `/playground`.
+ * Canonical entry route for `/` and `/playground`.
  *
  * Always creates a fresh playground note, then redirects to `/playground/:id`.
  */
-export function PlaygroundRedirect() {
+export function PlaygroundRedirect({
+  template = 'empty',
+}: PlaygroundRedirectProps) {
   const navigate = useNavigate()
   const [error, setError] = useState(false)
   const [attempt, setAttempt] = useState(0)
+
+  const templateContent = template === 'home'
+    ? DEFAULT_PLAYGROUND_CONTENT.content
+    : EMPTY_PLAYGROUND_CONTENT.content
 
   useEffect(() => {
     let cancelled = false
 
     ;(async () => {
       try {
-        const id = await createPlaygroundPage(EMPTY_PLAYGROUND_CONTENT.content)
+        const id = await createPlaygroundPage(templateContent)
         if (!cancelled) {
           navigate(playgroundPath(id), { replace: true })
         }
@@ -34,7 +44,7 @@ export function PlaygroundRedirect() {
     return () => {
       cancelled = true
     }
-  }, [navigate, attempt])
+  }, [navigate, attempt, templateContent])
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary
- add a `template` prop to `PlaygroundRedirect` so `/` can seed the rich home template while `/playground` keeps the empty note flow
- move the legacy markdown home canvas off `/` to `/tour` so the redirect route owns the root path cleanly
- add redirect coverage for both templates plus route-governance coverage for the `/tour` move

## Verification
- `bun test ./playground/src/pages/PlaygroundRedirect.test.tsx ./playground/src/canvas/canvasRoutes.test.ts --preload ./tests/unit-setup.ts`
- `bun run test:playground` *(currently fails on unrelated pre-existing dev-branch failures in `paletteDataSources`, `journalWorkout`, `useShowPlaygrounds`, `usePlaygroundContent`, `JournalDateScroll`, `EffortCard`, and markdown block extraction tests)*
