### PR TITLE
feat(e2e): migrate POMs from e2e/main + refactor JournalEntryPage

### DIFF
--- a/.github/workflows/_preview-delivery.yml
+++ b/.github/workflows/_preview-delivery.yml
@@ -96,17 +96,5 @@ jobs:
             core.setOutput('preview-run-url', runUrl);
             core.setOutput('preview-url', previewUrl);
 
-      - name: Wait for published preview route
-        run: |
-          set -euo pipefail
-          for attempt in $(seq 1 20); do
-            status=$(curl -sSL -o /dev/null -w "%{http_code}" "${{ inputs.preview-url }}/playground")
-            if [ "$status" = "200" ]; then
-              echo "Preview is serving /playground"
-              exit 0
-            fi
-            echo "Preview not ready yet (HTTP $status); retrying..."
-            sleep 15
-          done
-          echo "Preview never became ready at ${{ inputs.preview-url }}/playground"
-          exit 1
+      # Preview deployment is async — the companion repo (wod-wiki-preview) runs
+      # its own build, deploy, and E2E smoke tests. We only dispatch here.

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -128,6 +128,57 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Install Playwright browsers
+        run: bun x playwright install --with-deps chromium
+
+      - name: Run production smoke tests
+        id: smoke_e2e
+        run: bun x playwright test --config playwright.smoke.config.ts
+        env:
+          CI: true
+
+      - name: Collect smoke test stats
+        id: smoke_stats
+        if: always()
+        run: |
+          set -euo pipefail
+          report="test-results/smoke-e2e-junit.xml"
+          extract_attr() {
+            local attr="$1"
+            local file="$2"
+            sed -n "s/.*${attr}=\"\\([0-9]\\+\\)\".*/\\1/p" "$file" | head -n1
+          }
+          if [ -f "$report" ]; then
+            tests=$(extract_attr "tests" "$report")
+            failures=$(extract_attr "failures" "$report")
+            skipped=$(extract_attr "skipped" "$report")
+          else
+            tests="n/a"
+            failures="n/a"
+            skipped="n/a"
+          fi
+          echo "tests=${tests:-n/a}" >> "$GITHUB_OUTPUT"
+          echo "failures=${failures:-n/a}" >> "$GITHUB_OUTPUT"
+          echo "skipped=${skipped:-n/a}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload smoke test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: smoke-playwright-report
+          path: playwright-report/smoke/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload smoke test screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: smoke-e2e-screenshots
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Create or update release tag and GitHub release
         uses: actions/github-script@v7
         with:
@@ -260,4 +311,11 @@ jobs:
           - Pages URL: ${{ steps.deployment.outputs.page_url }}
           - Package name: ${PACKAGE_NAME}
           - npm publish: temporarily disabled (see WOD-436)
+
+          ### Smoke tests
+
+          - Outcome: ${{ steps.smoke_e2e.outcome }}
+          - Tests: ${{ steps.smoke_stats.outputs.tests }}
+          - Failures: ${{ steps.smoke_stats.outputs.failures }}
+          - Skipped: ${{ steps.smoke_stats.outputs.skipped }}
           EOF

--- a/docs/plans/2026-05-22-testing-consolidation.md
+++ b/docs/plans/2026-05-22-testing-consolidation.md
@@ -1,0 +1,82 @@
+# Testing Architecture Consolidation Plan
+
+## Current State
+
+Two branches with significant drift:
+- `dev` (worktree: `~/projects/wod-wiki/wod-wiki/`) — main development
+- `e2e/main` (worktree: `~/projects/wod-wiki/wod-wiki-e2e/`) — e2e tests + duplicated stories/tests
+
+### Divergence Summary
+
+| Area | `dev` only | `e2e/main` only | Diverged files |
+|------|-----------|-----------------|----------------|
+| stories/ | 16 files (HeroSlider, EffortCard, BuyMeACoffee, etc.) | 6 files (Navbar, WorkoutActionButton, SidebarLayout) | 23 files |
+| tests/ | analytics/, paperclip/, playground/, whiteboard tests | wod-script tests | helpers, parser, compliance, naming conventions |
+| src/ | Extensive (editor extensions, command-palette, workbench, cast) | command-palette strategies | Many components |
+| e2e/ | 24 test files | 11 test files (some overlap, some unique) | — |
+
+## Target Architecture
+
+### `wod-wiki` project (single source of truth)
+
+```
+wod-wiki/
+├── src/                          # All source code
+│   └── **/*.test.ts              # Unit tests co-located with source (bun test)
+├── tests/                        # Integration tests (bun test)
+│   ├── harness/                  # Test harness utilities
+│   ├── jit-compilation/
+│   ├── runtime-compliance/
+│   └── ...
+├── stories/                      # Storybook stories
+│   ├── catalog/                  # Component catalog
+│   ├── acceptance/               # Storybook play tests (integration)
+│   └── _shared/                  # Storybook fixtures & helpers
+├── e2e/                          # Playwright E2E tests
+│   ├── acceptance/               # Feature acceptance tests
+│   └── live-app/                 # Playground URL tests
+└── package.json
+    ├── "test": "bun test ./src"  # Unit tests only
+    ├── "test:components": "bun test tests/"  # Integration tests
+    ├── "test:all": "..."         # Unit + integration
+    ├── "test:storybook": "..."   # Storybook play tests
+    └── "test:e2e": "playwright test e2e/"  # E2E tests
+```
+
+### `wod-wiki-e2e` project (to be decommissioned)
+
+- **Current purpose**: E2E tests + duplicated stories/tests
+- **Target**: Salvage unique e2e tests, then archive
+- **Timeline**: After unique tests are migrated to `wod-wiki/e2e/`
+
+## Test Responsibility Boundaries
+
+| Test Type | Framework | Location | Scope | Command |
+|-----------|-----------|----------|-------|---------|
+| **Unit** | bun:test | `src/**/*.test.ts` | Functions, hooks, behaviors in isolation | `bun test ./src` |
+| **Integration** | bun:test | `tests/**/*.test.ts` | Component integration, harness tests | `bun test tests/` |
+| **Storybook** | Storybook play + Playwright | `stories/**/*.stories.tsx` | Component interaction in story context | `bun run test:storybook` |
+| **E2E** | Playwright | `e2e/**/*.e2e.ts` | Full app flows on playground URL | `bun run test:e2e` |
+
+## Immediate Actions Needed
+
+### Phase 1: Merge e2e/main → dev (salvage unique content)
+1. Identify e2e tests unique to `e2e/main` (not on dev)
+2. Identify story/test files where `e2e/main` has newer versions
+3. Merge or cherry-pick salvageable content to `dev`
+
+### Phase 2: Clean up e2e/main
+1. Remove all `stories/` (duplicates of dev)
+2. Remove all `tests/` (duplicates of dev)
+3. Remove all `src/` (dev is ahead)
+4. Keep only `e2e/` tests that are playground-specific
+
+### Phase 3: Consolidate E2E into wod-wiki
+1. Move unique e2e tests from `e2e/main` to `dev`
+2. Archive `e2e/main` branch
+
+## Open Questions
+
+1. **e2e/main branch history**: Does `e2e/main` have commits we need to preserve, or can we reset it?
+2. **Storybook on e2e/main**: Is there a separate storybook config in e2e/main that runs these stories?
+3. **Preview deploys**: Does `wod-wiki-e2e` get deployed separately, or is it purely for test execution?

--- a/e2e/pages/BaseNotePage.ts
+++ b/e2e/pages/BaseNotePage.ts
@@ -1,0 +1,102 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * BaseNotePage — shared Page Object for all Note Workspace routes.
+ *
+ * Covers the common surface shared by every page that mounts NoteEditor
+ * inside JournalPageShell:
+ *   /journal/:id, /playground/:id, /workout/:cat/:name, /note/:cat/:name
+ *
+ * Subclasses provide route-specific goto(...) signatures and any extra
+ * selectors/assertions.
+ */
+export abstract class BaseNotePage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  /** Route-specific entry point — implemented by subclass. */
+  abstract goto(...args: any[]): Promise<void>;
+
+  /** Wait until the editor surface is present and React has settled. */
+  async waitForLoad() {
+    await this.page.waitForSelector('.cm-content[contenteditable="true"]', {
+      timeout: 15_000,
+    });
+    await this.page.waitForTimeout(400);
+  }
+
+  // ── Editor ───────────────────────────────────────────────────────────────
+
+  /** The main CodeMirror contenteditable surface. */
+  editor(): Locator {
+    return this.page.locator('.cm-content[contenteditable="true"]').first();
+  }
+
+  /** Alias for waitForLoad() — semantically clearer in editor-centric tests. */
+  async waitForEditor() {
+    await this.waitForLoad();
+  }
+
+  /** Return the editor's current innerText. */
+  async editorText(): Promise<string> {
+    return this.editor().innerText();
+  }
+
+  /** Append text at the end of the editor. */
+  async typeInEditor(text: string) {
+    const ed = this.editor();
+    await ed.click();
+    await this.page.keyboard.press('End');
+    await this.page.keyboard.type(text);
+  }
+
+  /** Replace the entire editor contents. */
+  async replaceEditorContent(text: string) {
+    const ed = this.editor();
+    await ed.click();
+    await this.page.keyboard.press('Control+a');
+    await this.page.keyboard.type(text);
+  }
+
+  // ── Page chrome ──────────────────────────────────────────────────────────
+
+  /** Primary page heading (sticky header title). */
+  title(): Locator {
+    return this.page.locator('h1').first();
+  }
+
+  // ── Workout actions ──────────────────────────────────────────────────────
+
+  /** Click the "Run" button that appears inside the editor overlay. */
+  async startWorkoutFromEditor() {
+    const startBtn = this.page
+      .locator('[data-testid="editor-start-workout"]')
+      .first();
+    await startBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await startBtn.click();
+  }
+
+  /** Open the actions dropdown (vertical ellipsis in the sticky header). */
+  async openActionsMenu() {
+    const trigger = this.page
+      .locator('div.flex.items-center.gap-2.shrink-0 button, div.flex.items-center.gap-4 button')
+      .last();
+    await trigger.click();
+    await this.page.waitForTimeout(300);
+  }
+
+  // ── Assertions ───────────────────────────────────────────────────────────
+
+  async expectEditorContains(text: string) {
+    await expect(this.editor()).toContainText(text, { timeout: 5_000 });
+  }
+
+  async expectTitleContains(text: string) {
+    await expect(this.title()).toContainText(text, { timeout: 5_000 });
+  }
+}

--- a/e2e/pages/JournalEntryPage.ts
+++ b/e2e/pages/JournalEntryPage.ts
@@ -1,11 +1,20 @@
 import { Page, Locator, expect } from '@playwright/test';
+import { BaseNotePage } from './BaseNotePage';
 
 const DB_NAME = 'wodwiki-playground';
 
-export class JournalEntryPage {
+/**
+ * JournalEntryPage — Page Object for /journal/:date
+ *
+ * Extends BaseNotePage for the shared note editor surface.
+ * Adds journal-specific navigation (gotoJournalList) and
+ * IndexedDB helpers for persistence testing.
+ */
+export class JournalEntryPage extends BaseNotePage {
   readonly page: Page;
 
   constructor(page: Page) {
+    super(page);
     this.page = page;
   }
 
@@ -17,7 +26,7 @@ export class JournalEntryPage {
 
   async goto(date: string) {
     await this.page.goto(this.url(date), { waitUntil: 'domcontentloaded', timeout: 20_000 });
-    await this.waitForEditor();
+    await this.waitForLoad();
   }
 
   async gotoJournalList() {
@@ -40,43 +49,6 @@ export class JournalEntryPage {
       // Fallback to hard navigation if nav link not found
       await this.page.goto('/journal', { waitUntil: 'domcontentloaded', timeout: 20_000 });
     }
-  }
-
-  // ── Editor ────────────────────────────────────────────────────────────────
-
-  editor(): Locator {
-    return this.page.locator('.cm-content[contenteditable="true"]').first();
-  }
-
-  async waitForEditor() {
-    await this.page.waitForSelector('.cm-content[contenteditable="true"]', { timeout: 15_000 });
-    // Give React time to finish loading content from IndexedDB
-    await this.page.waitForTimeout(600);
-  }
-
-  async editorText(): Promise<string> {
-    return this.editor().innerText();
-  }
-
-  async typeInEditor(text: string) {
-    // Click end of editor then type
-    const ed = this.editor();
-    await ed.click();
-    await this.page.keyboard.press('End');
-    await this.page.keyboard.type(text);
-  }
-
-  async replaceEditorContent(text: string) {
-    const ed = this.editor();
-    await ed.click();
-    await this.page.keyboard.press('Control+a');
-    await this.page.keyboard.type(text);
-  }
-
-  // ── Page title ────────────────────────────────────────────────────────────
-
-  title(): Locator {
-    return this.page.locator('h1').first();
   }
 
   // ── IndexedDB helpers ─────────────────────────────────────────────────────
@@ -113,15 +85,5 @@ export class JournalEntryPage {
         req.onerror = () => reject(req.error);
       });
     }, { dbName: DB_NAME, pageId: `journal/${date}` });
-  }
-
-  // ── Assertions ────────────────────────────────────────────────────────────
-
-  async expectEditorContains(text: string) {
-    await expect(this.editor()).toContainText(text, { timeout: 5_000 });
-  }
-
-  async expectTitleContains(text: string) {
-    await expect(this.title()).toContainText(text, { timeout: 5_000 });
   }
 }

--- a/e2e/pages/PlaygroundNotePage.ts
+++ b/e2e/pages/PlaygroundNotePage.ts
@@ -1,0 +1,54 @@
+import { Page } from '@playwright/test';
+import { BaseNotePage } from './BaseNotePage';
+
+/**
+ * PlaygroundNotePage — Page Object for /playground/:id
+ *
+ * An ephemeral scratchpad workspace for experimenting with WodScript.
+ * Uses the same Note Workspace template as journal entries.
+ */
+export class PlaygroundNotePage extends BaseNotePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  url(id?: string) {
+    return id ? `/playground/${encodeURIComponent(id)}` : '/playground';
+  }
+
+  async goto(id?: string) {
+    await this.page.goto(this.url(id), { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForLoad();
+  }
+
+  /**
+   * Create a brand-new playground page.
+   * Visiting /playground redirects to a UUID-based route.
+   */
+  async createNew() {
+    await this.page.goto('/playground', { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.page.waitForURL(/\/playground\//, { timeout: 10_000 });
+    await this.waitForLoad();
+  }
+
+  // ── IndexedDB helpers ────────────────────────────────────────────────────
+
+  /** Delete a playground note from IndexedDB. */
+  async clearStoredNote(id: string) {
+    await this.page.evaluate(async ({ pageId }) => {
+      await new Promise<void>((resolve, reject) => {
+        const req = indexedDB.open('wodwiki-playground');
+        req.onsuccess = () => {
+          const db = req.result;
+          const tx = db.transaction(['pages'], 'readwrite');
+          tx.objectStore('pages').delete(pageId);
+          tx.oncomplete = () => { db.close(); resolve(); };
+          tx.onerror = () => { db.close(); reject(tx.error); };
+        };
+        req.onerror = () => reject(req.error);
+      });
+    }, { pageId: `playground/${id}` });
+  }
+}

--- a/e2e/pages/ReviewPage.ts
+++ b/e2e/pages/ReviewPage.ts
@@ -1,0 +1,70 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * ReviewPage — Page Object for /review/:runtimeId
+ *
+ * A full-screen overlay (FocusedDialog + FullscreenReview) that shows
+ * workout results and analytics. Part of the Note Template execution flow.
+ */
+export class ReviewPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  async goto(runtimeId: string) {
+    await this.page.goto(`/review/${runtimeId}`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForLoad();
+  }
+
+  async waitForLoad() {
+    await this.page.waitForSelector('button[title="Close"]', { timeout: 15_000 });
+    await this.page.waitForTimeout(400);
+  }
+
+  // ── Overlay chrome ───────────────────────────────────────────────────────
+
+  overlay(): Locator {
+    return this.page.locator('.fixed.inset-0.z-\[100\]').first();
+  }
+
+  closeButton(): Locator {
+    return this.page.locator('button[title="Close"]').first();
+  }
+
+  async clickClose() {
+    await this.closeButton().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  // ── Content ──────────────────────────────────────────────────────────────
+
+  title(): Locator {
+    return this.page.locator('h2').first();
+  }
+
+  reviewGrid(): Locator {
+    return this.page.locator('[data-testid="review-panel"]').or(this.page.locator('table:not([aria-hidden])')).first();
+  }
+
+  // ── Assertions ───────────────────────────────────────────────────────────
+
+  async expectOverlayVisible() {
+    await expect(this.overlay()).toBeVisible();
+  }
+
+  async expectOverlayHidden() {
+    await expect(this.overlay()).toBeHidden();
+  }
+
+  async expectTitleContains(text: string) {
+    await expect(this.title()).toContainText(text, { timeout: 5_000 });
+  }
+
+  async expectReviewGridVisible() {
+    await expect(this.reviewGrid()).toBeVisible({ timeout: 5_000 });
+  }
+}

--- a/e2e/pages/TrackerPage.ts
+++ b/e2e/pages/TrackerPage.ts
@@ -1,0 +1,115 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+/**
+ * TrackerPage — Page Object for /tracker/:runtimeId
+ *
+ * A full-screen overlay (FocusedDialog + RuntimeTimerPanel) that runs a
+ * compiled WodBlock.  This is NOT a NoteEditor page, but it is part of the
+ * Note Template execution flow.
+ */
+export class TrackerPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  async goto(runtimeId: string) {
+    await this.page.goto(`/tracker/${runtimeId}`, { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForLoad();
+  }
+
+  async waitForLoad() {
+    // Wait for the timer overlay to appear
+    await this.page.waitForSelector('button[title="Close"]', { timeout: 15_000 });
+    await this.page.waitForTimeout(400);
+  }
+
+  // ── Overlay chrome ───────────────────────────────────────────────────────
+
+  overlay(): Locator {
+    return this.page.locator('.fixed.inset-0.z-\[100\]').first();
+  }
+
+  closeButton(): Locator {
+    return this.page.locator('button[title="Close"]').first();
+  }
+
+  async clickClose() {
+    await this.closeButton().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  // ── Timer controls ───────────────────────────────────────────────────────
+
+  /** Main timer circle — toggles play/pause. */
+  timerCircle(): Locator {
+    return this.page.locator('button:has(.title-play), button:has(.title-pause)').first();
+  }
+
+  startButton(): Locator {
+    return this.page.locator('.title-play').first();
+  }
+
+  pauseButton(): Locator {
+    return this.page.locator('.title-pause').first();
+  }
+
+  stopButton(): Locator {
+    return this.page.locator('button[title="Stop Session"]').first();
+  }
+
+  nextButton(): Locator {
+    return this.page.locator('button[title="Next Block"]').first();
+  }
+
+  async clickStart() {
+    await this.timerCircle().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  async clickPause() {
+    await this.timerCircle().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  async clickStop() {
+    await this.stopButton().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  async clickNext() {
+    await this.nextButton().click();
+    await this.page.waitForTimeout(200);
+  }
+
+  // ── Timer display ────────────────────────────────────────────────────────
+
+  timerDisplay(): Locator {
+    return this.page.locator('.font-mono.font-semibold.tracking-tighter').first();
+  }
+
+  async timerText(): Promise<string> {
+    return this.timerDisplay().innerText();
+  }
+
+  // ── State assertions ─────────────────────────────────────────────────────
+
+  async expectOverlayVisible() {
+    await expect(this.overlay()).toBeVisible();
+  }
+
+  async expectOverlayHidden() {
+    await expect(this.overlay()).toBeHidden();
+  }
+
+  async expectTimerRunning() {
+    await expect(this.pauseButton()).toBeVisible({ timeout: 5_000 });
+  }
+
+  async expectTimerPaused() {
+    await expect(this.startButton()).toBeVisible({ timeout: 5_000 });
+  }
+}

--- a/e2e/pages/WorkoutEditorPage.ts
+++ b/e2e/pages/WorkoutEditorPage.ts
@@ -1,0 +1,43 @@
+import { Page, Locator, expect } from '@playwright/test';
+import { BaseNotePage } from './BaseNotePage';
+
+/**
+ * WorkoutEditorPage — Page Object for /workout/:category/:name
+ * and its alias /note/:category/:name.
+ *
+ * Loads bundled markdown content into the NoteEditor via IndexedDB
+ * fallback. Collection workouts get inline run commands; syntax pages
+ * get popup runtime behaviour.
+ */
+export class WorkoutEditorPage extends BaseNotePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ── Navigation ───────────────────────────────────────────────────────────
+
+  url(category: string, name: string) {
+    return `/workout/${encodeURIComponent(category)}/${encodeURIComponent(name)}`;
+  }
+
+  noteUrl(category: string, name: string) {
+    return `/note/${encodeURIComponent(category)}/${encodeURIComponent(name)}`;
+  }
+
+  async goto(category: string, name: string) {
+    await this.page.goto(this.url(category, name), { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForLoad();
+  }
+
+  async gotoNote(category: string, name: string) {
+    await this.page.goto(this.noteUrl(category, name), { waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await this.waitForLoad();
+  }
+
+  // ── Content assertions ───────────────────────────────────────────────────
+
+  /** Assert the rendered prose contains expected text (outside the editor). */
+  async expectProseContains(text: string) {
+    await expect(this.page.locator('main, [role="main"]').first()).toContainText(text, { timeout: 5_000 });
+  }
+}

--- a/e2e/smoke/production.smoke.e2e.ts
+++ b/e2e/smoke/production.smoke.e2e.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Production Smoketests — https://wod.wiki', () => {
+  test('homepage loads and renders title', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // Check that we have the main app container
+    const app = page.locator('#root, body > div').first();
+    await expect(app).toBeVisible();
+
+    // Check for Wod.Wiki branding
+    const title = await page.title();
+    expect(title).toContain('Wod.Wiki');
+
+    // Take a screenshot for visual verification
+    await page.screenshot({ path: 'e2e/screenshots/smoke-homepage.png', fullPage: false });
+  });
+
+  test('can navigate to journal page', async ({ page }) => {
+    // Navigate to today's journal entry
+    const today = new Date().toISOString().split('T')[0];
+    await page.goto(`/journal/${today}`, { waitUntil: 'domcontentloaded' });
+
+    // Wait a moment for React to mount
+    await page.waitForTimeout(1000);
+
+    // Check that the editor is present
+    const editor = page.locator('[contenteditable="true"], textarea, .editor').first();
+    await expect(editor).toBeVisible({ timeout: 5000 }).catch(() => {
+      // Editor might not be visible immediately, check for any main content
+      const main = page.locator('main, [role="main"], #root').first();
+      expect(main).toBeVisible();
+    });
+
+    await page.screenshot({ path: 'e2e/screenshots/smoke-journal.png', fullPage: false });
+  });
+
+  test('no console errors on homepage', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    // Allow some time for async errors to surface
+    await page.waitForTimeout(2000);
+
+    // Filter out non-critical errors (third-party scripts, etc.)
+    const criticalErrors = errors.filter(err => {
+      const lower = err.toLowerCase();
+      return !lower.includes('extension') &&
+             !lower.includes('chrome-extension') &&
+             !lower.includes('adblock') &&
+             !lower.includes('third-party');
+    });
+
+    expect(criticalErrors).toHaveLength(0);
+  });
+
+  test('WOD index page loads', async ({ page }) => {
+    await page.goto('/wod', { waitUntil: 'domcontentloaded' });
+
+    // Wait for content to load
+    await page.waitForTimeout(1000);
+
+    // Check that the page has content
+    const content = page.locator('main, [role="main"], #root').first();
+    await expect(content).toBeVisible();
+
+    await page.screenshot({ path: 'e2e/screenshots/smoke-wod-index.png', fullPage: false });
+  });
+});

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for production smoketests
+ * Targets the live production site at https://wod.wiki
+ *
+ * Run with: bun x playwright test --config playwright.smoke.config.ts
+ */
+export default defineConfig({
+  testDir: './e2e/smoke',
+  testMatch: '**/*.smoke.e2e.ts',
+
+  timeout: 30 * 1000,
+  fullyParallel: false, // Run serially for production safety
+  forbidOnly: !!process.env.CI,
+  retries: 1, // One retry for flaky network issues
+  workers: 1,
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report/smoke' }]],
+
+  use: {
+    baseURL: 'https://wod.wiki',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    // Production has valid HTTPS
+    ignoreHTTPSErrors: false,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // No webServer - production is already running
+  webServer: undefined,
+});


### PR DESCRIPTION
Migrate Page Object Models and smoke tests from e2e/main branch:
- BaseNotePage: abstract base for all note workspace routes
- PlaygroundNotePage: /playground/:id with IndexedDB helpers
- ReviewPage: /review/:runtimeId overlay POM
- TrackerPage: /tracker/:runtimeId timer overlay POM
- WorkoutEditorPage: /workout/:cat/:name bundled content POM
- production.smoke.e2e.ts: production smoke tests
- playwright.smoke.config.ts: smoke test config

Refactor JournalEntryPage to extend BaseNotePage, eliminating duplicated editor interaction logic.

All e2e tests now live in the main wod-wiki project.