### PR TITLE
WOD-610: increase WOD action button touch targets on mobile

### DIFF
--- a/src/components/Editor/extensions/preview-decorations.ts
+++ b/src/components/Editor/extensions/preview-decorations.ts
@@ -158,6 +158,13 @@ const wodBlockBaseTheme = EditorView.baseTheme({
   "&dark .cm-wod-inner": {
     backgroundColor: "rgba(96, 165, 250, 0.06)",
   },
+
+  "@media (max-width: 639px)": {
+    ".cm-wod-fence-open": {
+      lineHeight: "30px",
+      paddingTop: "6px",
+    },
+  },
 });
 
 // ── Public export ────────────────────────────────────────────────────

--- a/src/components/Editor/overlays/InlineCommandBar.tsx
+++ b/src/components/Editor/overlays/InlineCommandBar.tsx
@@ -118,10 +118,11 @@ const CommandPill: React.FC<{
       <Button
         variant={cmd.primary ? "default" : "secondary"}
         className={cn(
-          "h-auto px-2 py-0.5 text-[10px] font-medium rounded-sm shadow-sm gap-1",
+          "h-11 w-11 rounded-full p-0 text-[10px] font-medium shadow-sm gap-0 sm:h-auto sm:w-auto sm:gap-1 sm:rounded-sm sm:px-2 sm:py-0.5",
           !cmd.primary && "border border-border/50",
         )}
         title={cmd.label}
+        aria-label={cmd.label}
         data-testid={cmd.id === 'run' ? TEST_IDS.EDITOR_START_WORKOUT : undefined}
         onClick={(e) => {
           stopEvent(e);
@@ -130,8 +131,8 @@ const CommandPill: React.FC<{
         onMouseDown={stopEvent}
         onPointerDown={stopEvent}
       >
-        <span className="flex items-center size-3">{cmd.icon}</span>
-        <span className="hidden sm:inline">{cmd.label}</span>
+        <span className="flex items-center justify-center size-4 sm:size-3">{cmd.icon}</span>
+        <span className="sr-only sm:not-sr-only sm:inline">{cmd.label}</span>
       </Button>
     );
   }
@@ -148,8 +149,8 @@ const CommandPill: React.FC<{
         secondary={secondaryActivation}
         size="xs"
         variant={cmd.primary ? "primary" : "default"}
-        className="rounded-sm"
-        labelClassName="hidden sm:inline"
+        className="rounded-full sm:rounded-sm"
+        labelClassName="sr-only sm:not-sr-only sm:inline"
       />
     </div>
   );
@@ -236,7 +237,7 @@ export const InlineCommandBar: React.FC<InlineCommandBarProps> = ({
         return (
           <div
             key={rect.sectionId}
-            className="absolute right-1 z-10 flex items-center gap-1 pointer-events-auto"
+            className="absolute right-1 z-10 flex items-center gap-1 pointer-events-auto -translate-y-1 sm:translate-y-0"
             style={{
               // rect.top is document-space; subtract scrollTop to get the correct
               // position relative to .cm-note-editor as the editor scrolls.

--- a/src/components/Editor/overlays/WodCompanion.tsx
+++ b/src/components/Editor/overlays/WodCompanion.tsx
@@ -245,16 +245,17 @@ const CommandPill: React.FC<{
       <Button
         variant={cmd.primary ? "default" : "secondary"}
         className={cn(
-          "h-auto px-2 py-0.5 text-[10px] font-medium rounded-sm shadow-sm gap-1",
+          "h-11 w-11 rounded-full p-0 text-[10px] font-medium shadow-sm gap-0 sm:h-auto sm:w-auto sm:gap-1 sm:rounded-sm sm:px-2 sm:py-0.5",
           !cmd.primary && "border border-border/50",
         )}
         title={cmd.label}
+        aria-label={cmd.label}
         onClick={(e) => { stopEvent(e); cmd.onClick(block); }}
         onMouseDown={stopEvent}
         onPointerDown={stopEvent}
       >
-        <span className="flex items-center size-3">{cmd.icon}</span>
-        <span className="hidden sm:inline">{cmd.label}</span>
+        <span className="flex items-center justify-center size-4 sm:size-3">{cmd.icon}</span>
+        <span className="sr-only sm:not-sr-only sm:inline">{cmd.label}</span>
       </Button>
     );
   }
@@ -266,8 +267,8 @@ const CommandPill: React.FC<{
         secondary={secondaryActivation}
         size="xs"
         variant={cmd.primary ? "primary" : "default"}
-        className="rounded-sm"
-        labelClassName="hidden sm:inline"
+        className="rounded-full sm:rounded-sm"
+        labelClassName="sr-only sm:not-sr-only sm:inline"
       />
     </div>
   );
@@ -290,7 +291,7 @@ const CommandButtons: React.FC<{
 
   if (compact) {
     return (
-      <div className="flex flex-row items-center gap-1 p-1.5">
+      <div className="flex flex-row items-center gap-1 p-0 sm:p-1.5">
         {commands.map((cmd) => (
           <CommandPill key={cmd.id} cmd={cmd} block={block} />
         ))}
@@ -411,7 +412,8 @@ export const WodCompanion: React.FC<WodCompanionProps> = ({
   //  1. STRIP — always visible, sticky to top of viewport within section bounds
   //  2. CARD  — compact metric panel, shown on hover/active, positioned below strip
 
-  const STRIP_H = 28;
+  const isMobileViewport = typeof window !== "undefined" && window.matchMedia("(max-width: 639px)").matches;
+  const STRIP_H = isMobileViewport ? 44 : 28;
   const CARD_H  = 200;
 
   // Card top: centered on the active line, but clamped to stay within the slot

--- a/src/components/ui/ButtonGroup.tsx
+++ b/src/components/ui/ButtonGroup.tsx
@@ -59,8 +59,22 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
   const SecondaryIcon = secondary.icon;
   const isPrimary = variant === 'primary';
 
-  const padding = size === 'xs' ? 'px-2 py-0.5' : size === 'sm' ? 'px-2.5 py-1.5' : 'px-3 py-2';
-  const iconPadding = size === 'xs' ? 'px-1.5 py-0.5' : size === 'sm' ? 'px-2 py-1.5' : 'px-2.5 py-2';
+  const padding = size === 'xs'
+    ? 'h-11 min-w-11 justify-center px-0 sm:h-auto sm:min-w-0 sm:px-2 sm:py-0.5 sm:justify-start'
+    : size === 'sm'
+      ? 'px-2.5 py-1.5'
+      : 'px-3 py-2';
+  const iconPadding = size === 'xs'
+    ? 'h-11 w-11 px-0 sm:h-auto sm:w-auto sm:px-1.5 sm:py-0.5'
+    : size === 'sm'
+      ? 'px-2 py-1.5'
+      : 'px-2.5 py-2';
+  const primaryPadding = size === 'xs'
+    ? 'h-11 min-w-11 justify-center px-0 sm:h-auto sm:min-w-0 sm:pl-5 sm:pr-4 sm:py-2 sm:justify-start'
+    : 'pl-5 pr-4 py-2';
+  const primaryIconPadding = size === 'xs'
+    ? 'h-11 w-11 px-0 sm:h-auto sm:w-auto sm:px-3 sm:py-2'
+    : 'px-3 py-2';
   const textSize = size === 'xs' ? 'text-[10px]' : size === 'sm' ? 'text-[11px]' : 'text-xs';
 
   return (
@@ -78,38 +92,41 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = ({
       <button
         type="button"
         title={primary.label}
+        aria-label={primary.label}
         onClick={() => fireAction(primary, onAction)}
         className={cn(
           'flex items-center gap-2 transition-colors active:scale-95',
+          size === 'xs' && 'gap-0 sm:gap-2',
           isPrimary
-            ? 'bg-primary text-primary-foreground hover:bg-primary/90 font-black uppercase tracking-widest pl-5 pr-4 py-2'
+            ? cn('bg-primary text-primary-foreground hover:bg-primary/90 font-black uppercase tracking-widest', primaryPadding)
             : cn('hover:bg-accent hover:text-accent-foreground text-muted-foreground font-medium', padding),
         )}
       >
-        {PrimaryIcon && <PrimaryIcon className={cn('shrink-0', isPrimary ? 'size-3 fill-current' : 'h-4 w-4')} />}
+        {PrimaryIcon && <PrimaryIcon className={cn('shrink-0', isPrimary ? 'size-4 fill-current sm:size-3' : 'size-4 sm:h-4 sm:w-4')} />}
         <span className={labelClassName}>{primary.label}</span>
       </button>
 
       {/* Divider */}
       <div className={cn(
         'self-stretch',
-        isPrimary ? 'w-px bg-primary-foreground/20 my-1' : 'w-px bg-border/60',
+        isPrimary ? 'w-px bg-primary-foreground/20 my-2 sm:my-1' : 'w-px bg-border/60',
       )} />
 
       {/* Secondary */}
       <button
         type="button"
         title={secondary.label}
+        aria-label={secondary.label}
         onClick={() => fireAction(secondary, onAction)}
         className={cn(
           'flex items-center justify-center transition-colors active:scale-95',
           isPrimary
-            ? 'bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-2'
+            ? cn('bg-primary text-primary-foreground hover:bg-primary/90', primaryIconPadding)
             : cn('hover:bg-accent hover:text-accent-foreground text-muted-foreground', iconPadding),
         )}
       >
         {SecondaryIcon
-          ? <SecondaryIcon className={cn('shrink-0', isPrimary ? 'size-3.5' : 'h-4 w-4')} />
+          ? <SecondaryIcon className={cn('shrink-0', isPrimary ? 'size-4 sm:size-3.5' : 'size-4 sm:h-4 sm:w-4')} />
           : <span className="sr-only">{secondary.label}</span>
         }
       </button>


### PR DESCRIPTION
## Summary
- increase WOD inline and overlay action buttons to 44x44 touch targets below the `sm` breakpoint
- keep desktop pills compact with visible labels while switching mobile actions to icon-only accessible controls
- raise the mobile opening fence line height modestly so the larger buttons sit cleanly without changing desktop line height

## Verification
- `bun run build:app`
- Chrome/Playwright mobile emulation against a temporary NoteEditor harness using the real edited components: Run/Share/Copy Link all measured 44x44 on iPhone 12 viewport in inline and overlay modes
- Desktop visual check in the same harness confirmed labeled compact pills remain unchanged in both inline and overlay modes
- `bun x tsc --noEmit --pretty false` *(fails on pre-existing `baseUrl` deprecation in `tsconfig.json`, unrelated to this change)*

Closes WOD-610