### PR TITLE
Update import paths and section headers for consistency

### DIFF
--- a/markdown/canvas/syntax/complex-full-session.md
+++ b/markdown/canvas/syntax/complex-full-session.md
@@ -8,20 +8,20 @@ order: 6
 # Thursday Session
 
 ```wod
-(Warmup)
+// Warmup
   400m Run
   10 Air Squats
 
-(Strength)
+// Strength
   (5 Sets)
     3 Back Squat 225lb
     *2:00 Rest
 
-(Conditioning)
+// Conditioning
   10:00 AMRAP
     5 Pullups
     10 Pushups
 
-(Cool-down)
+// Cool-down
   5:00 Walk
 ```

--- a/markdown/canvas/syntax/complex-nested-protocols.md
+++ b/markdown/canvas/syntax/complex-nested-protocols.md
@@ -10,7 +10,7 @@ order: 5
   5:00 AMRAP
     5 Pullups
     10 Pushups
-  (Strength)
+  // Strength
     3 Back Squat 225lb
     *2:00 Rest
 ```

--- a/markdown/canvas/syntax/mixed-sections.md
+++ b/markdown/canvas/syntax/mixed-sections.md
@@ -6,15 +6,15 @@ section: groups
 order: 6
 ---
 ```wod
-(Warmup)
+// Warmup
   500m Row
   10 Lunges
 
-(Strength)
+// Strength
   5 Back Squat 225lb
   *2:00 Rest
 
-(Conditioning)
+// Conditioning
   10:00 AMRAP
     5 Pullups
     10 Pushups

--- a/markdown/canvas/syntax/named-groups.md
+++ b/markdown/canvas/syntax/named-groups.md
@@ -6,10 +6,10 @@ section: groups
 order: 5
 ---
 ```wod
-(Warmup)
+// Warmup
   400m Run
   10 Air Squats
 
-(Strength)
+// Strength
   5 Back Squat 225lb
 ```

--- a/src/editor-entry.ts
+++ b/src/editor-entry.ts
@@ -7,8 +7,8 @@
 // Main editor components
 
 // Note editor (single CM6 instance for full document editing)
-export { NoteEditor } from './components/Editor/NoteEditor';
-export type { NoteEditorProps } from './components/Editor/NoteEditor';
+export { NoteEditor } from './components/organisms/editor/NoteEditor';
+export type { NoteEditorProps } from './components/organisms/editor/NoteEditor';
 
 // Exercise management
 export { ExerciseIndexManager } from './components/Editor/ExerciseIndexManager';
@@ -22,8 +22,8 @@ export { LRUCache } from './components/Editor/LRUCache';
 export type { Exercise, Muscle, Force, Level, Mechanic, Equipment, Category } from './exercise';
 
 // UI Components
-export { CommandPalette } from './components/command-palette/CommandPalette';
-export { CommandProvider, useCommandPalette } from './components/command-palette/CommandContext';
-export type { Command } from './components/command-palette/types';
-export { Dialog, DialogContent, DialogHeader, DialogTitle } from './components/headless/Dialog';
-export type { DialogProps } from './components/headless/Dialog';
+export { CommandPalette } from './components/organisms/command-palette/CommandPalette';
+export { CommandProvider, useCommandPalette } from './contexts/CommandContext';
+export type { Command } from './components/organisms/command-palette/types';
+export { Dialog, DialogContent, DialogHeader, DialogTitle } from './components/atoms/Dialog';
+export type { DialogProps } from './components/atoms/Dialog';


### PR DESCRIPTION
This pull request primarily updates the syntax used in markdown workout templates for improved consistency and refactors several import paths in `src/editor-entry.ts` to reflect a more organized component structure. The markdown changes standardize section headers, while the TypeScript changes align imports with a revised folder hierarchy, moving components to more appropriately named directories.

**Markdown Syntax Standardization:**

* Replaced parenthesis-based section headers (e.g., `(Warmup)`) with comment-style headers (e.g., `// Warmup`) in multiple workout markdown files for consistency and clarity. [[1]](diffhunk://#diff-89eedd286f5562fe57ac2b9cfba433d4d5b675510d9e839fb540749c2844df94L11-R25) [[2]](diffhunk://#diff-3c066bbb8e265e249b2ce8778e552bc055a0f64cdeda1be5b422b1b2022100a1L9-R17) [[3]](diffhunk://#diff-2d990a6dd23f0a1bee97c2dca9e3de30ac4c4b574d2d89d05d90392d10f1e73dL9-R13) [[4]](diffhunk://#diff-8f3c289ca8e0c68bbaea231a0c00f35e39883b6343221f5916570b8d7cdd600aL13-R13)

**Component Import Refactoring:**

* Updated imports in `src/editor-entry.ts` to reflect new component locations, moving `NoteEditor` and related types to `components/organisms/editor`, and relocating `CommandPalette` and its types to `components/organisms/command-palette`. [[1]](diffhunk://#diff-d618ce6bf2ffb3a64c9831c2492df25fe0d63e05bd18dff46acc0597d0226a8bL10-R11) [[2]](diffhunk://#diff-d618ce6bf2ffb3a64c9831c2492df25fe0d63e05bd18dff46acc0597d0226a8bL25-R29)
* Changed `CommandProvider` and `useCommandPalette` imports to use the new `contexts/CommandContext` path.
* Updated `Dialog` and related component imports to use the new `components/atoms/Dialog` directory.