### PR TITLE
feat: use split canvas layout in JournalPageShell

### DIFF
--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -110,17 +110,19 @@ export function JournalPageShell({
     }
   };
 
+
+
   return (
-    <div className={cn('relative flex w-full min-h-screen justify-start items-start', className)}>
+    <div className={cn('relative flex flex-col lg:flex-row w-full min-h-screen justify-start items-start', className)}>
       {/* 
-        Note Column — Constrained to 3xl max-width on large screens.
-        Everything inside (Header + Editor) has the background and shadow.
+        Note Column — Main Editor Content (Prose/Code)
+        Uses the content surface class to maintain the "feel".
       */}
       <div className={cn(
-        'flex flex-col flex-1 min-w-0 3xl:max-w-7xl min-h-screen lg:rounded-[2.5rem]',
+        'flex flex-col w-full lg:w-[60%] min-h-screen lg:border-r border-border/50 lg:rounded-br-[2.5rem]',
         PAGE_SHELL_CONTENT_SURFACE_CLASS,
       )}>
-        {/* Sticky header — hidden on mobile (SidebarLayout navbar covers it), sticky on desktop */}
+        {/* Sticky header */}
         <div className="hidden lg:block lg:sticky lg:top-0 lg:z-30 lg:bg-background/80 lg:backdrop-blur-md pt-4 lg:pt-8">
           <div className="flex items-center justify-between px-6 lg:px-10">
             <div className="flex items-center gap-4 truncate">
@@ -142,13 +144,16 @@ export function JournalPageShell({
         </main>
       </div>
 
-      {/* Index Sidebar Column — Outside the Note card, visible on Desktop XL */}
+      {/*
+        Index Sidebar Column — "Sticky Canvas" look
+        On desktop: 40% width, sticky.
+      */}
       {index.length > 0 && (
-        <aside className="hidden 3xl:block w-80 shrink-0 sticky top-0 self-start max-h-screen overflow-y-auto p-10">
+        <aside className="hidden lg:flex flex-col w-[40%] sticky top-0 self-start h-screen overflow-y-auto p-10 bg-muted/5 border-l border-border/30 shadow-inner">
           <div className="font-bold text-[10px] uppercase tracking-[0.2em] text-muted-foreground/60 mb-6">
             On this page
           </div>
-          <nav className="flex flex-col gap-1 border-l border-border/40 ml-1">
+          <nav className="flex flex-col gap-1 border-l border-border/40 ml-1 flex-1">
             {index.map((link) => (
               <div key={link.id} className="flex items-center group -ml-px">
                 <button

--- a/src/panels/page-shells/JournalPageShell.tsx
+++ b/src/panels/page-shells/JournalPageShell.tsx
@@ -149,7 +149,7 @@ export function JournalPageShell({
         On desktop: 40% width, sticky.
       */}
       {index.length > 0 && (
-        <aside className="hidden lg:flex flex-col w-[40%] sticky top-0 self-start h-screen overflow-y-auto p-10 bg-muted/5 border-l border-border/30 shadow-inner">
+        <aside className="hidden lg:flex flex-col w-[40%] sticky top-0 self-start h-screen overflow-y-auto p-10 bg-muted/5 shadow-inner">
           <div className="font-bold text-[10px] uppercase tracking-[0.2em] text-muted-foreground/60 mb-6">
             On this page
           </div>

--- a/src/services/storage/IStorage.ts
+++ b/src/services/storage/IStorage.ts
@@ -59,7 +59,8 @@ export interface IReadWriteStore extends IReadonlyStore {
 }
 
 export interface IStorageTransaction {
-    store(name: StoreName): IReadWriteStore;
+    readonly(store: StoreName): IReadonlyStore;
+    readwrite(store: StoreName): IReadWriteStore;
     done(): Promise<void>;
 }
 

--- a/src/services/storage/IStorage.ts
+++ b/src/services/storage/IStorage.ts
@@ -47,7 +47,6 @@ export interface IReadonlyStore {
 }
 
 /** Read-write per-store view. Returned from {@link IStorage.readwrite}. */
-/** Read-write per-store view. Returned from {@link IStorage.readwrite}. */
 export interface IReadWriteStore extends IReadonlyStore {
     /**
      * Put a value into the store. The key is derived from the value (each
@@ -58,6 +57,13 @@ export interface IReadWriteStore extends IReadonlyStore {
     put(value: StorageValue): Promise<StorageKey>;
     delete(key: StorageKey): Promise<void>;
 }
+
+export interface IStorageTransaction {
+    store(name: StoreName): IReadWriteStore;
+    done(): Promise<void>;
+}
+
+export interface IStorage {
     /** Open the underlying engine. Idempotent; safe to call multiple times. */
     open(): Promise<void>;
 


### PR DESCRIPTION
This PR refactors `JournalPageShell.tsx` to implement a split canvas layout (60% prose/editor, 40% sticky index navigation), updating the UI layout for WorkoutEditor, Journal entries, and Playground notes based on the Stitch reference. It also fixes broken TS definitions in `IStorage.ts` that were causing typecheck errors.

---
*PR created automatically by Jules for task [16376104651878260967](https://jules.google.com/task/16376104651878260967) started by @SergeiGolos*