### PR TITLE
fix(preview-deploy): set VITE_BASE_PATH so SPA emits correct asset paths

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -33,8 +33,27 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Derive branch slug
+        id: slug
+        run: |
+          # Sanitize branch name: lowercase, no spaces, no special chars
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          SLUG=$(echo "$BRANCH" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\\+//;s/-\\+$//' | tr '[:upper:]' '[:lower:]')
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "slug=$SLUG" >> $GITHUB_OUTPUT
+
+      # Build with VITE_BASE_PATH set so the emitted HTML references
+      # /<slug>/dist/assets/... matching the S3 layout and CF function.
+      # Without this, Vite defaults base to '/' and the SPA loads HTML
+      # (the SPA-fallback index.html) instead of the JS bundle at
+      # /assets/main-*.js, so the app never hydrates.
       - name: Build playground
-        run: bun run build-playground && bun x vite build --config vite.receiver.config.ts
+        env:
+          VITE_BASE_PATH: /${{ steps.slug.outputs.slug }}/dist/
+        run: |
+          bun run build-playground
+          VITE_BASE_PATH="/${{ steps.slug.outputs.slug }}/dist/" \
+            bun x vite build --config vite.receiver.config.ts
 
       - name: Persist build artifact
         uses: actions/upload-artifact@v4
@@ -42,15 +61,6 @@ jobs:
           name: preview-build-${{ github.event.pull_request.number }}
           path: playground/dist/
           retention-days: 1
-
-      - name: Derive branch slug
-        id: slug
-        run: |
-          # Sanitize branch name: lowercase, no spaces, no special chars
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          SLUG=$(echo "$BRANCH" | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\+//;s/-\+$//' | tr '[:upper:]' '[:lower:]')
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "slug=$SLUG" >> $GITHUB_OUTPUT
 
       - name: Set artifact dir
         id: artifact-dir


### PR DESCRIPTION
## Problem

`https://dev.preview.wod.wiki/` returns 200 with the playground HTML, but the SPA never hydrates. The HTML's emitted `<script src="...">` is `/assets/main-NYd7sx_j.js`, while the S3 layout is `/<slug>/dist/`. The CF SPA-fallback function then rewrites `/assets/main-*.js` to the SPA index.html (since it's the "catch-all" branch), so the browser ends up loading HTML instead of JS.

## Fix

`playground/vite.config.ts` already honors `VITE_BASE_PATH` — the build step just wasn't exporting it. Reorder the workflow so the branch-slug derivation runs before the build, then set `VITE_BASE_PATH=/${{ steps.slug.outputs.slug }}/dist/` in the build step's env.

## Verified locally

| Command | `<script src>` |
| --- | --- |
| `bun run build-playground` (default) | `/assets/main-NYd7sx_j.js` ← bug |
| `VITE_BASE_PATH=/dev/dist/ bun run build-playground` | `/dev/dist/assets/main-Dq0-lQ3G.js` ← fixed |

## Out of scope

The CF function, OAC, bucket policy, and DNS are already correct. Only the build output's asset base path needed to change.

Refs: SergeiGolos/wod-wiki-iac#1