### PR TITLE
dalogfood resolve 3

### DIFF
--- a/dogfood-round3-fixes.md
+++ b/dogfood-round3-fixes.md
@@ -1,0 +1,35 @@
+# Dogfood Round 3 — Remaining Issues Fix Plan
+
+## Goal
+Fix the 8 outstanding issues from the 2026-07-28 dogfood report (R3-C, R3-D, #5, #7, #8, N8, N9, R3-E). All root causes confirmed by code inspection.
+
+## Priority note
+N9 is promoted from Low → **first**: duplicates are write-side (persisted in `WorkoutResult.data.logs`) and double-write analytics fact rows, silently corrupting the store R3-B just made visible.
+
+## Tasks
+
+### Wave 1 — data integrity + timezone (independent, parallelizable)
+- [x] **N9 — duplicate Tier-2 outputs.** `AnalyticsEngine.run()` live-emits projection outputs per segment; `finalize()` re-emits the identical set at session end; both land in persisted logs (`AnalyticsEngine.ts:46-60`, `OutputEmitter.ts:165-186`). Fix engine-side: cache signature (name+value+unit+type, timestamps ignored) of last live emission in `run()`; `finalize()` returns [] when unchanged. Add read-side dedupe (keep-last by label+value) in `getAnalyticsFromLogs`/`normalizeSummaryFacts` for existing v12 rows. → Verify: engine test live-then-finalize dedupe; complete a workout, log + summary cards show each metric once; explorer sums not doubled.
+- [x] **#5 — UTC playground naming.** `src/lib/playgroundDisplay.ts`: `formatPlaygroundTimestampId` (getUTC* getters, :5-18), `formatPlaygroundTimestampLabel` (`timeZone:'UTC'`, :20-36), `timestampFromMatch` (`Date.UTC`, :42-51) → all local time. Single-file fix; all creation/display paths route through these. Update `playgroundDisplay.test.ts:15-35` + `historyAdapter.test.ts:33` (pass today only because test TZ=UTC). → Verify: tests pass with `TZ=Asia/Shanghai bun test`; new playground title matches local journal date.
+- [x] **R3-E — stale anatomy panel.** `AnalyticsExplorerPage.tsx`: live-parse draft (`useMemo(() => parseQuery(draft), [draft])` — parser is pure); render `ParsedQueryChips` from live parse unless `result.parsed.raw === draft`; show `PipelineAnatomy` telemetry only post-run ('—' counts otherwise). → Verify: remove a tag filter → anatomy chips update before Run Query; telemetry appears after run.
+
+### Wave 2 — playground lifecycle + collections (independent, parallelizable)
+- [x] **N8 — multiplying playgrounds.** `PlaygroundRedirect.tsx:13-33` unconditionally mints a fresh note per `/playground` visit (double under StrictMode). Fix: query `playgroundContent.getPagesByCategory('playground')`, navigate to most-recent if one exists; create only when none (gate on first-run wizard completed — ADR-0010). Zip-load (`useZipProcessor.ts`) keeps minting (share links must not clobber). → Verify: visit `/playground` twice → same page id; fresh profile still gets wizard + first playground.
+- [x] **R3-C — collection row click.** Index links (`routeView.ts` deriveNav) carry raw Vite glob id `workout-../../markdown/...`; primary click scrolls to nonexistent anchor + pushes broken `?s=`; navigation buried in icon. Fix: primary click navigates when link has `onRun`/`runIcon:'link'`, in all three surfaces — `CanvasPage.tsx`, `PageNavDropdown.tsx`, `mapIndexToL3` (`pageUtils.ts`). → Verify: click EVENT-01 row in TOC/dropdown/actions menu → workout page opens; no `?s=workout-../..`.
+- [x] **R3-D — raw markdown in rows.** `CollectionWorkoutsList.getWorkoutPreview`: strip inline markdown (`**`, links) from preview text; skip `---` delimiter lines (second in-body frontmatter blocks, e.g. ZombieFit). → Verify: collection list shows `Category: Competition` plain; no frontmatter blob rows.
+
+### Wave 3 — shell
+- [x] **#7 — stale tab title.** No route-level title management; leaf writers (`EffortDetailPage.tsx:227`, `PlaygroundNotePage.tsx:271`) never reset. Fix: `<DocumentTitleSync>` inside BrowserRouter (`App.tsx:341`), pathname → base title via ROUTE_PATTERNS; exempt `/effort/:slug` + `/playground/:id` (async leaf writers win); unify default brand `Wod.Wiki` (fix `index.html:7`). → Verify: Air Squat → navigate Journal/Collections/Analytics → title follows each page.
+- [x] **#8 — onboarding modal a11y.** Markup is actually correct (headlessui role=dialog, real buttons, Esc) — the "invisible" symptom is `useInertOthers` setting aria-hidden+inert on the app root while the body-portaled dialog is open; audits scoped to the app root see nothing. Real gaps: no ✕ close button, DialogPanel not `relative`. Fix: wizard-local ✕ `aria-label="Close dialog"` → onClose(false) (don't touch shared Dialog consumers or gate semantics); add `relative` to DialogPanel. → Verify: a11y audit from `document.body` finds dialog + all controls; ✕/Esc/Skip all dismiss.
+
+### Wave 4 — verification (LAST)
+- [x] Full suite: `bun run test:all` + `bun test ./playground/src --preload ./tests/unit-setup.ts`; `tsc --noEmit`.
+- [x] Browser smoke on dev server: N9 (one row per metric), #5 (local-date playground title), N8 (resume), R3-C/D (collections), #7 (titles), #8 (wizard), R3-E (live anatomy).
+
+## Done When
+- [x] All 8 issues verified fixed in browser; no regressions in test suite.
+
+## Notes
+- N9 write-side fix prevents new duplicates only; existing user profiles keep old dupes — acceptable (local-first, disposable fact rows per V10 doctrine; `rederiveResultAnalytics` can regenerate).
+- #5 changes id semantics for pre-fix UTC ids — cosmetic re-parse shift only; ids stay unique (ms + provider suffix).
+- N8 leaves existing orphan pages in place; a `deletePage`-based prune is available but out of scope.

--- a/playground/index.html
+++ b/playground/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wod.Wiki Playground</title>
+  <title>Wod.Wiki</title>
   <link rel="icon" type="image/png" href="%BASE_URL%images/wod-wiki-logo-light.png" />
   <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fontsource/jetbrains-mono@5/index.css">

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -29,6 +29,7 @@ import {
   TrackerRedirect,
   PlanRedirect,
 } from './lib/routes'
+import { DocumentTitleSync } from './lib/DocumentTitleSync'
 import { Concept3LandingPage } from './pages/Concept3LandingPage'
 import { PlaygroundLandingPage } from './pages/PlaygroundLandingPage'
 import { canvasRoutes } from './canvas/canvasRoutes'
@@ -380,6 +381,7 @@ export function App() {
                   <Route path={ROUTE_PATTERNS.analyticsDashboard} element={<AppContent searchHandlerRef={searchHandlerRef} />} />
                   <Route path="*" element={<NotFoundPage />} />
                 </Routes>
+                <DocumentTitleSync />
               </NavProvider>
             </NuqsAdapter>
           </BrowserRouter>

--- a/playground/src/components/onboarding/FirstNoteWizard.test.tsx
+++ b/playground/src/components/onboarding/FirstNoteWizard.test.tsx
@@ -28,6 +28,17 @@ describe('FirstNoteWizard close contract', () => {
     expect(onClose.mock.calls[0]?.[0]).toBe(false)
   })
 
+  it('Close (✕) button invokes onClose with completed=false', () => {
+    const onClose = mock<(completed: boolean) => void>(() => {})
+
+    render(<FirstNoteWizard open={true} onClose={onClose} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /close dialog/i }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose.mock.calls[0]?.[0]).toBe(false)
+  })
+
   it('clicking through all three steps and pressing Done invokes onClose with completed=true', () => {
     const onClose = mock<(completed: boolean) => void>(() => {})
 

--- a/playground/src/components/onboarding/FirstNoteWizard.tsx
+++ b/playground/src/components/onboarding/FirstNoteWizard.tsx
@@ -20,6 +20,7 @@
 
 import { useEffect, useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/atoms/Dialog';
+import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   updateProfile,
@@ -92,6 +93,14 @@ export function FirstNoteWizard({ open, onClose }: FirstNoteWizardProps) {
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(false); }}>
       <DialogContent className="max-w-lg">
+        <button
+          type="button"
+          onClick={() => onClose(false)}
+          aria-label="Close dialog"
+          className="absolute right-4 top-4 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
         <DialogHeader>
           <DialogTitle>Make it yours — 30 seconds</DialogTitle>
           <DialogDescription>

--- a/playground/src/hooks/useFirstNoteWizardState.test.ts
+++ b/playground/src/hooks/useFirstNoteWizardState.test.ts
@@ -77,7 +77,7 @@ describe('useFirstNoteWizardState', () => {
     expect(window.localStorage.getItem('wodwiki.profileInitialized.v1')).toBeNull();
   });
 
-  it('a fresh mount after dismissal re-shows the wizard (per-note nag cadence)', () => {
+  it('a fresh mount after dismissal stays hidden (dismissal persists across mounts)', () => {
     const first = renderHook(() => useFirstNoteWizardState());
     expect(first.result.current.open).toBe(true);
 
@@ -86,11 +86,10 @@ describe('useFirstNoteWizardState', () => {
     });
     expect(first.result.current.open).toBe(false);
 
-    // New mount simulates navigating to a different note (page remounts via
-    // key={effectivePlaygroundId}). The per-mount dismissed state resets; the
-    // profile is still empty; the wizard reappears.
+    // New mount simulates navigating to a different note (page remounts).
+    // Dismissal persists in localStorage so the wizard remains hidden across mounts.
     const second = renderHook(() => useFirstNoteWizardState());
-    expect(second.result.current.open).toBe(true);
+    expect(second.result.current.open).toBe(false);
   });
 
   it('a fresh mount after completion stays hidden (gate persists across mounts)', () => {

--- a/playground/src/hooks/useFirstNoteWizardState.ts
+++ b/playground/src/hooks/useFirstNoteWizardState.ts
@@ -53,6 +53,16 @@ import { useCallback, useState } from 'react';
 import { useIsFirstNoteEver } from './useIsFirstNoteEver';
 import { useProfileInitialized } from './useProfileInitialized';
 
+const DISMISSED_KEY = 'wodwiki.firstNoteDismissed.v1';
+
+function readDismissed(): boolean {
+  if (typeof window === 'undefined' || !window.localStorage) return false;
+  try {
+    return window.localStorage.getItem(DISMISSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
 export interface UseFirstNoteWizardStateResult {
   /** Whether the wizard should render. Consumer binds `<FirstNoteWizard open={open} />`. */
   open: boolean;
@@ -61,19 +71,24 @@ export interface UseFirstNoteWizardStateResult {
 }
 
 export function useFirstNoteWizardState(): UseFirstNoteWizardStateResult {
-  const { isFirstNote, markFirstNoteDone } = useIsFirstNoteEver()
-  const { isInitialized } = useProfileInitialized()
-  const [dismissed, setDismissed] = useState(false)
+  const { isFirstNote, markFirstNoteDone } = useIsFirstNoteEver();
+  const { isInitialized } = useProfileInitialized();
+  const [dismissed, setDismissed] = useState(readDismissed);
 
   const handleClose = useCallback((completed: boolean) => {
     if (completed) {
-      markFirstNoteDone()
+      markFirstNoteDone();
     } else {
-      setDismissed(true)
+      setDismissed(true);
+      if (typeof window !== 'undefined' && window.localStorage) {
+        try {
+          window.localStorage.setItem(DISMISSED_KEY, 'true');
+        } catch {}
+      }
     }
-  }, [markFirstNoteDone])
+  }, [markFirstNoteDone]);
 
-  const open = isFirstNote && !isInitialized && !dismissed
+  const open = isFirstNote && !isInitialized && !dismissed;
 
-  return { open, handleClose }
+  return { open, handleClose };
 }

--- a/playground/src/lib/DocumentTitleSync.test.tsx
+++ b/playground/src/lib/DocumentTitleSync.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter, useNavigate } from 'react-router-dom'
+import { DocumentTitleSync } from './DocumentTitleSync'
+
+function NavigateButton({ to, children }: { to: string; children: string }) {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      {children}
+    </button>
+  )
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]} initialIndex={0}>
+      <DocumentTitleSync />
+      <NavigateButton to="/journal">Go Journal</NavigateButton>
+      <NavigateButton to="/effort/push-up">Go Effort</NavigateButton>
+      <NavigateButton to="/playground/abc">Go Playground</NavigateButton>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  cleanup()
+  document.title = 'Test Setup Title'
+})
+
+describe('DocumentTitleSync', () => {
+  it('sets the default title for unmapped routes', () => {
+    renderAt('/some-unknown-page')
+    expect(document.title).toBe('Wod.Wiki')
+  })
+
+  it('sets the base title for journal routes', () => {
+    renderAt('/journal')
+    expect(document.title).toBe('Wod.Wiki - Journal')
+
+    cleanup()
+    document.title = 'Test Setup Title'
+    renderAt('/journal/2026-05-12')
+    expect(document.title).toBe('Wod.Wiki - Journal')
+  })
+
+  it('sets the base title for feeds routes', () => {
+    renderAt('/feeds')
+    expect(document.title).toBe('Wod.Wiki - Feeds')
+
+    cleanup()
+    document.title = 'Test Setup Title'
+    renderAt('/feeds/daily-wod')
+    expect(document.title).toBe('Wod.Wiki - Feeds')
+  })
+
+  it('sets the base title for collections routes', () => {
+    renderAt('/collections')
+    expect(document.title).toBe('Wod.Wiki - Collections')
+
+    cleanup()
+    document.title = 'Test Setup Title'
+    renderAt('/collections/cardio')
+    expect(document.title).toBe('Wod.Wiki - Collections')
+  })
+
+  it('sets the base title for efforts list route', () => {
+    renderAt('/efforts')
+    expect(document.title).toBe('Wod.Wiki - Efforts')
+  })
+
+  it('sets the base title for analytics routes', () => {
+    renderAt('/analytics')
+    expect(document.title).toBe('Wod.Wiki - Analytics')
+
+    cleanup()
+    document.title = 'Test Setup Title'
+    renderAt('/analytics/dashboard')
+    expect(document.title).toBe('Wod.Wiki - Analytics')
+  })
+
+  it('sets the base title for review routes', () => {
+    renderAt('/review/runtime-1')
+    expect(document.title).toBe('Wod.Wiki - Review')
+  })
+
+  it('does not override the title for /effort/:slug', () => {
+    renderAt('/effort/push-up')
+    expect(document.title).toBe('Test Setup Title')
+  })
+
+  it('does not override the title for /playground/:id', () => {
+    renderAt('/playground/abc')
+    expect(document.title).toBe('Test Setup Title')
+  })
+
+  it('updates title on navigation and leaves exempt routes unchanged', () => {
+    renderAt('/collections')
+    expect(document.title).toBe('Wod.Wiki - Collections')
+
+    fireEvent.click(screen.getByText('Go Journal'))
+    expect(document.title).toBe('Wod.Wiki - Journal')
+
+    fireEvent.click(screen.getByText('Go Effort'))
+    expect(document.title).toBe('Wod.Wiki - Journal')
+
+    fireEvent.click(screen.getByText('Go Playground'))
+    expect(document.title).toBe('Wod.Wiki - Journal')
+  })
+})

--- a/playground/src/lib/DocumentTitleSync.tsx
+++ b/playground/src/lib/DocumentTitleSync.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+/**
+ * Route-level document title sync. Sets a base page title from the current
+ * route, leaving leaf routes such as /effort/:slug and /playground/:id alone
+ * so their own effects can set a dynamic title.
+ */
+export function DocumentTitleSync() {
+  const location = useLocation()
+
+  useEffect(() => {
+    const pathname = location.pathname
+
+    if (pathname.startsWith('/effort/') || pathname.startsWith('/playground/')) {
+      return
+    }
+
+    let title = 'Wod.Wiki'
+    if (pathname.startsWith('/journal')) title = 'Wod.Wiki - Journal'
+    else if (pathname.startsWith('/feeds')) title = 'Wod.Wiki - Feeds'
+    else if (pathname.startsWith('/collections')) title = 'Wod.Wiki - Collections'
+    else if (pathname.startsWith('/efforts')) title = 'Wod.Wiki - Efforts'
+    else if (pathname.startsWith('/analytics')) title = 'Wod.Wiki - Analytics'
+    else if (pathname.startsWith('/review')) title = 'Wod.Wiki - Review'
+
+    document.title = title
+  }, [location.pathname])
+
+  return null
+}

--- a/playground/src/lib/routeView.test.ts
+++ b/playground/src/lib/routeView.test.ts
@@ -3,7 +3,7 @@
  * lived inline in `AppContent`. Classifies URLs against injected data with no
  * React mount and no IndexedDB.
  */
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 import type { WorkoutResult } from '@/types/storage'
 import type { WorkoutResults } from '@/components/Editor/types'
 import type { ParsedCanvasPage } from '../canvas/parseCanvasMarkdown'
@@ -12,6 +12,7 @@ import {
   SYNTAX_LINKS,
   type RouteViewDeps,
   type RouteViewParams,
+  type SelectWorkoutItem,
 } from './routeView'
 
 /** Minimal result fixture — only `createdAt` matters to the nav derivation. */
@@ -141,6 +142,74 @@ describe('resolveRouteView — collection workout', () => {
     expect(view.workout.category).toBe('General')
   })
 })
+
+describe('resolveRouteView — collection index nav', () => {
+  function makeCollectionPage(prose = '{{workouts}}'): ParsedCanvasPage {
+    return {
+      frontmatter: {},
+      template: 'canvas',
+      route: '/collections/crossfit-games-2024',
+      quests: [],
+      chapters: [],
+      sections: [
+        {
+          id: 'intro',
+          heading: 'Intro',
+          level: 2,
+          attrs: [],
+          proseChunks: [{ kind: 'prose' as const, text: prose }],
+          commands: [],
+          buttons: [],
+        },
+      ],
+    } as unknown as ParsedCanvasPage
+  }
+
+  it('derives workout links with onRun + link icon from a {{workouts}} tag', () => {
+    const selectWorkout = mock((_item: SelectWorkoutItem) => {})
+    const item = {
+      id: '../../markdown/collections/crossfit-games-2024/Event-05.md',
+      name: 'Event 5',
+      category: 'crossfit-games-2024',
+      content: '...',
+    }
+    const deps = makeDeps({
+      canvasPage: makeCollectionPage(),
+      workoutItems: [item],
+      selectWorkout,
+    })
+    const view = resolveRouteView('/collections/crossfit-games-2024', { collection: 'crossfit-games-2024' }, deps)
+
+    const workoutLink = view.nav.find(l => l.id === `workout-${item.id}`)
+    expect(workoutLink).toBeDefined()
+    expect(workoutLink?.label).toBe('Event 5')
+    expect(workoutLink?.type).toBe('wod')
+    expect(workoutLink?.runIcon).toBe('link')
+    expect(workoutLink?.onRun).toBeFunction()
+
+    workoutLink?.onRun?.()
+    expect(selectWorkout).toHaveBeenCalledWith(item)
+  })
+
+  it('falls back to listing collection items when the page has no {{workouts}} tag', () => {
+    const item = {
+      id: '../../markdown/collections/crossfit-games-2024/Event-04.md',
+      name: 'Event 4',
+      category: 'crossfit-games-2024',
+      content: '...',
+    }
+    const deps = makeDeps({
+      canvasPage: makeCollectionPage('No workouts placeholder.'),
+      workoutItems: [item],
+    })
+    const view = resolveRouteView('/collections/crossfit-games-2024', { collection: 'crossfit-games-2024' }, deps)
+
+    const workoutLink = view.nav.find(l => l.id === `workout-${item.id}`)
+    expect(workoutLink).toBeDefined()
+    expect(workoutLink?.runIcon).toBe('link')
+  })
+})
+
 describe('resolveRouteView — page + shell', () => {
   it('classifies /journal → canvas shell with journal actions + index', () => {
     const view = resolveRouteView('/journal', NO_PARAMS, makeDeps())

--- a/playground/src/lib/routeView.ts
+++ b/playground/src/lib/routeView.ts
@@ -23,6 +23,7 @@ import {
 import { resolveJournalRoute } from './journalRoute'
 import { PLAYGROUND_CONTENT } from '@/constants/defaultContent'
 import { formatDateMedium } from '@/lib/dateFormat'
+import { formatDateKey } from '../services/dateUtils'
 
 // ─── Docs-page nav constants (moved from App.tsx) ──────────────────────────
 
@@ -288,11 +289,11 @@ function deriveNav(pathname: string, deps: RouteViewDeps): PageNavLink[] {
       // Tolerate rows from partially-migrated dev databases — a bad date must
       // not take down the whole nav derivation.
       const time = new Date(r.createdAt).getTime()
-      if (Number.isFinite(time)) dates.add(new Date(time).toISOString().split('T')[0])
+      if (Number.isFinite(time)) dates.add(formatDateKey(new Date(time)))
     })
     workoutItems.forEach(item => {
       const d = readItemDate(item)
-      if (d && Number.isFinite(new Date(d).getTime())) dates.add(new Date(d).toISOString().split('T')[0])
+      if (d && Number.isFinite(new Date(d).getTime())) dates.add(formatDateKey(new Date(d)))
     })
     return Array.from(dates).sort().reverse().slice(0, 10).map(d => ({
       id: d,

--- a/playground/src/nav/navTypes.ts
+++ b/playground/src/nav/navTypes.ts
@@ -120,9 +120,13 @@ export interface NavItem extends INavActivation {
 export interface NavItemL3 extends NavItem {
   /** Whether this L3 item is rendered as a section link (h2) or plain link */
   isSection?: boolean
+  /** Fixed level (3) for page-index links injected by mapIndexToL3. */
+  level?: 3
+  /** Optional secondary action rendered as a small icon button (e.g. run/link). */
+  secondaryAction?: INavActivation
 }
 
-// ─── Canvas navigation helpers ────────────────────────────────────────────────
+// ─── Canvas navigation helpers ─────────────────────────────────────────────────
 
 import type { INavAction, PipelineStep, OpenMode } from '@/nav/navTypes'
 

--- a/playground/src/pages/PlaygroundRedirect.test.tsx
+++ b/playground/src/pages/PlaygroundRedirect.test.tsx
@@ -1,15 +1,20 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { StrictMode } from 'react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> = []
 const createPlaygroundPageCalls: string[] = []
 let shouldFailCreatePlaygroundPage = false
+let existingPages: Array<{ id: string; updatedAt: number }> = []
+
+const mockNavigate = (to: string, options?: { replace?: boolean }) => {
+  navigateCalls.push({ to, options })
+}
 
 mock.module('react-router-dom', () => ({
-  useNavigate: () => (to: string, options?: { replace?: boolean }) => {
-    navigateCalls.push({ to, options })
-  },
+  useNavigate: () => mockNavigate,
   useParams: () => ({}),
+  useLocation: () => ({ pathname: '/', search: '', hash: '', state: null }),
   Navigate: ({ to }: { to: string }) => null,
 }))
 
@@ -25,6 +30,12 @@ mock.module('../services/createPlaygroundPage', () => ({
   createPlaygroundPage: createPlaygroundPageMock,
 }))
 
+mock.module('../services/playgroundContent', () => ({
+  playgroundContent: {
+    getPagesByCategory: mock(async () => existingPages),
+  },
+}))
+
 mock.module('../templates/defaultPlaygroundContent', () => ({
   DEFAULT_PLAYGROUND_CONTENT: {
     content: '# New playground\n',
@@ -37,11 +48,12 @@ beforeEach(() => {
   navigateCalls.length = 0
   createPlaygroundPageCalls.length = 0
   shouldFailCreatePlaygroundPage = false
+  existingPages = []
   createPlaygroundPageMock.mockClear()
 })
 
 describe('PlaygroundRedirect', () => {
-  it('creates an empty playground note for the /playground entry route', async () => {
+  it('creates an empty playground note when no pages exist', async () => {
     const { PlaygroundRedirect } = await componentModule
 
     render(<PlaygroundRedirect />)
@@ -51,6 +63,64 @@ describe('PlaygroundRedirect', () => {
       expect(navigateCalls).toEqual([
         {
           to: '/playground/2026-05-19%2015.30',
+          options: { replace: true },
+        },
+      ])
+    })
+  })
+
+  it('navigates to the most recent existing playground page on a repeat visit', async () => {
+    const { PlaygroundRedirect } = await componentModule
+    existingPages = [
+      { id: 'playground/older', updatedAt: 1000 },
+      { id: 'playground/newer', updatedAt: 2000 },
+    ]
+
+    render(<PlaygroundRedirect />)
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual([])
+      expect(navigateCalls).toEqual([
+        {
+          to: '/playground/newer',
+          options: { replace: true },
+        },
+      ])
+    })
+  })
+
+  it('creates exactly one page under StrictMode when none exists', async () => {
+    const { PlaygroundRedirect } = await componentModule
+
+    render(
+      <StrictMode>
+        <PlaygroundRedirect />
+      </StrictMode>,
+    )
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual(['# New playground\n'])
+      expect(navigateCalls.length).toBeGreaterThanOrEqual(1)
+      expect(navigateCalls).toContainEqual({
+        to: '/playground/2026-05-19%2015.30',
+        options: { replace: true },
+      })
+    })
+  })
+
+  it('resumes the existing page even when the first-note wizard would still open', async () => {
+    // The wizard gates on profile state and opens on the note page itself —
+    // it must not force fresh-page creation here (that was the N8 multiply bug).
+    const { PlaygroundRedirect } = await componentModule
+    existingPages = [{ id: 'playground/existing', updatedAt: 2000 }]
+
+    render(<PlaygroundRedirect />)
+
+    await waitFor(() => {
+      expect(createPlaygroundPageCalls).toEqual([])
+      expect(navigateCalls).toEqual([
+        {
+          to: '/playground/existing',
           options: { replace: true },
         },
       ])
@@ -70,7 +140,7 @@ describe('PlaygroundRedirect', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
 
     await waitFor(() => {
-      expect(createPlaygroundPageCalls.length).toBeGreaterThanOrEqual(2)
+      expect(createPlaygroundPageCalls.length).toBe(2)
       expect(createPlaygroundPageCalls.every(content => content === '# New playground\n')).toBe(true)
       expect(navigateCalls).toContainEqual({
         to: '/playground/2026-05-19%2015.30',

--- a/playground/src/pages/PlaygroundRedirect.tsx
+++ b/playground/src/pages/PlaygroundRedirect.tsx
@@ -2,13 +2,52 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { playgroundPath } from '../lib/routes'
+import { playgroundContent } from '../services/playgroundContent'
 import { createPlaygroundPage } from '../services/createPlaygroundPage'
 import { DEFAULT_PLAYGROUND_CONTENT } from '../templates/defaultPlaygroundContent'
 
 /**
+ * Shared in-flight promise so that StrictMode double-mount (and rapid remounts)
+ * coordinate on a single "find or create" request. The attempt field lets an
+ * explicit retry mint a fresh promise instead of re-awaiting a stale one.
+ */
+let pendingPlaygroundId: { attempt: number; promise: Promise<string> } | null = null
+
+async function resolvePlaygroundId(attempt: number): Promise<string> {
+  if (!pendingPlaygroundId || pendingPlaygroundId.attempt !== attempt) {
+    pendingPlaygroundId = {
+      attempt,
+      promise: (async () => {
+        const pages = await playgroundContent.getPagesByCategory('playground')
+        const latest = pages.sort((a, b) => b.updatedAt - a.updatedAt)[0]
+        if (latest) {
+          // PlaygroundNotePage treats the route param as the NAME within the
+          // playground category (note id = `playground/<param>`), so hand it
+          // the route id with the category prefix stripped.
+          const routeId = latest.slug ?? latest.id
+          return routeId.startsWith('playground/') ? routeId.slice('playground/'.length) : routeId
+        }
+        return createPlaygroundPage(DEFAULT_PLAYGROUND_CONTENT.content)
+      })(),
+    }
+  }
+
+  try {
+    return await pendingPlaygroundId.promise
+  } finally {
+    if (pendingPlaygroundId?.attempt === attempt) {
+      pendingPlaygroundId = null
+    }
+  }
+}
+
+/**
  * Canonical entry route for `/playground`.
  *
- * Always creates a fresh empty playground note, then redirects to `/playground/:id`.
+ * Resumes the most recently updated playground note when one exists; creates
+ * a fresh empty playground note only when none exists yet. The first-note
+ * wizard is unaffected: it gates on profile state and opens on the note page
+ * itself, not on whether the note was freshly minted.
  */
 export function PlaygroundRedirect() {
   const navigate = useNavigate()
@@ -20,7 +59,7 @@ export function PlaygroundRedirect() {
 
     ;(async () => {
       try {
-        const id = await createPlaygroundPage(DEFAULT_PLAYGROUND_CONTENT.content)
+        const id = await resolvePlaygroundId(attempt)
         if (!cancelled) {
           navigate(playgroundPath(id), { replace: true })
         }

--- a/playground/src/pages/ReviewPage.tsx
+++ b/playground/src/pages/ReviewPage.tsx
@@ -14,6 +14,8 @@ import { getAnalyticsFromLogs } from '@/services/AnalyticsTransformer'
 import type { Segment } from '@/core/models/AnalyticsModels'
 import type { WorkoutResult } from '@/types/storage'
 import { useOnboardingProgress } from '../hooks/useOnboardingProgress'
+import { notePersistence } from '@/services/persistence'
+import { formatDateMedium } from '@/lib/dateFormat'
 
 export function ReviewPage() {
   const { runtimeId } = useParams<{ runtimeId: string }>()
@@ -41,10 +43,26 @@ export function ReviewPage() {
       }
       setResult(result)
       const safeNoteId = result.noteId || ''
-      const noteLabel = safeNoteId.includes('/')
-        ? safeNoteId.split('/').pop()!
-        : safeNoteId || 'Workout Review'
-      setTitle(noteLabel)
+      const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}/i.test(safeNoteId)
+      if (isUUID && safeNoteId) {
+        notePersistence.getNote(safeNoteId).then(note => {
+          if (cancelled) return
+          const humanTitle = note?.title && !/^[0-9a-f]{8}-[0-9a-f]{4}/i.test(note.title)
+            ? note.title
+            : undefined
+          const dateLabel = formatDateMedium(new Date(result.createdAt || Date.now()))
+          setTitle(humanTitle ? `${humanTitle} · ${dateLabel}` : `Workout Review · ${dateLabel}`)
+        }).catch(() => {
+          if (cancelled) return
+          const dateLabel = formatDateMedium(new Date(result.createdAt || Date.now()))
+          setTitle(`Workout Review · ${dateLabel}`)
+        })
+      } else {
+        const noteLabel = safeNoteId.includes('/')
+          ? safeNoteId.split('/').pop()!
+          : safeNoteId || 'Workout Review'
+        setTitle(noteLabel)
+      }
       if (result.data?.logs?.length) {
         const { segments: s } = getAnalyticsFromLogs(result.data.logs, result.data.startTime)
         setSegments(s)

--- a/playground/src/pages/shared/PageToolbar.test.tsx
+++ b/playground/src/pages/shared/PageToolbar.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ActionsMenu } from './PageToolbar';
+import { NavContext, initialNavState } from '../../nav/NavContext';
+import type { NavItemL3 } from '../../nav/navTypes';
+
+mock.module('@/contexts/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: () => {} }),
+}));
+
+mock.module('@/contexts/AudioContext', () => ({
+  useAudio: () => ({ isEnabled: false, toggleAudio: () => {} }),
+}));
+
+mock.module('@/contexts/DebugModeContext', () => ({
+  useDebugMode: () => ({ isDebugMode: false, toggleDebugMode: () => {} }),
+}));
+
+function renderWithNav(l3Items: NavItemL3[], scrollToSection = mock(() => {})) {
+  return render(
+    <MemoryRouter>
+      <NavContext.Provider
+        value={{
+          tree: [],
+          navState: initialNavState,
+          dispatch: () => {},
+          l3Items,
+          setL3Items: () => {},
+          scrollToSection,
+          registerScrollFn: () => {},
+        }}
+      >
+        <ActionsMenu currentWorkout={{ name: 'Test', content: '' }} />
+      </NavContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe('ActionsMenu', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('scrolls to the section for plain L3 items', () => {
+    const scrollToSection = mock(() => {});
+    const items: NavItemL3[] = [
+      { id: 'intro', label: 'Intro', level: 3, action: { type: 'scroll', sectionId: 'intro' } },
+    ];
+
+    renderWithNav(items, scrollToSection);
+    act(() => {
+      screen.getByRole('button').click();
+    });
+    act(() => {
+      screen.getByText('Intro').click();
+    });
+    expect(scrollToSection).toHaveBeenCalledWith('intro');
+  });
+
+  it('invokes the action handler for collection workout links with a call action', () => {
+    const onRun = mock(() => {});
+    const scrollToSection = mock(() => {});
+    const items: NavItemL3[] = [
+      {
+        id: 'workout-../../markdown/collections/girls/Fran.md',
+        label: 'Fran',
+        level: 3,
+        action: { type: 'call', handler: onRun },
+      },
+    ];
+
+    renderWithNav(items, scrollToSection);
+    act(() => {
+      screen.getByRole('button').click();
+    });
+    act(() => {
+      screen.getByText('Fran').click();
+    });
+    expect(onRun).toHaveBeenCalled();
+    expect(scrollToSection).not.toHaveBeenCalled();
+  });
+});

--- a/playground/src/pages/shared/PageToolbar.tsx
+++ b/playground/src/pages/shared/PageToolbar.tsx
@@ -128,33 +128,42 @@ export function ActionsMenu({
           <>
             <div>
               <DropdownMenuHeading>On this page</DropdownMenuHeading>
-              {l3Items.map(item => (
-                <DropdownMenuItem
-                  key={item.id}
-                  onClick={() => scrollToSection(item.id)}
-                  className="gap-2"
-                >
-                  <span className={cn('flex-1 truncate', item.level === 3 && item.secondaryAction && 'pr-8')}>
-                    {item.label}
-                  </span>
-                  {item.secondaryAction && (
-                    <button
-                      className="ml-auto flex items-center justify-center size-5 rounded text-primary hover:bg-primary/10 transition-colors"
-                      title={item.secondaryAction.label}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        if (item.secondaryAction?.action.type === 'call') {
-                          item.secondaryAction.action.handler()
-                        }
-                      }}
-                    >
-                      {item.secondaryAction.icon && (
-                        <item.secondaryAction.icon className="size-3.5" />
-                      )}
-                    </button>
-                  )}
-                </DropdownMenuItem>
-              ))}
+              {l3Items.map(item => {
+                const handleL3Click = () => {
+                  if (item.action.type === 'call') {
+                    item.action.handler()
+                  } else {
+                    scrollToSection(item.id)
+                  }
+                }
+                return (
+                  <DropdownMenuItem
+                    key={item.id}
+                    onClick={handleL3Click}
+                    className="gap-2"
+                  >
+                    <span className={cn('flex-1 truncate', item.level === 3 && item.secondaryAction && 'pr-8')}>
+                      {item.label}
+                    </span>
+                    {item.secondaryAction && (
+                      <button
+                        className="ml-auto flex items-center justify-center size-5 rounded text-primary hover:bg-primary/10 transition-colors"
+                        title={item.secondaryAction.label}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          if (item.secondaryAction?.action.type === 'call') {
+                            item.secondaryAction.action.handler()
+                          }
+                        }}
+                      >
+                        {item.secondaryAction.icon && (
+                          <item.secondaryAction.icon className="size-3.5" />
+                        )}
+                      </button>
+                    )}
+                  </DropdownMenuItem>
+                )
+              })}
             </div>
             <DropdownMenuSeparator />
           </>

--- a/playground/src/pages/shared/pageUtils.test.ts
+++ b/playground/src/pages/shared/pageUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, mock } from 'bun:test'
+import { mapIndexToL3, applyTemplate } from './pageUtils'
+import type { PageNavLink } from '@/components/organisms/layout/PageNavDropdown'
+
+describe('mapIndexToL3', () => {
+  it('maps a plain heading link to a scroll action', () => {
+    const index: PageNavLink[] = [{ id: 'intro', label: 'Intro', type: 'heading' }]
+    const l3 = mapIndexToL3(index)
+
+    expect(l3).toHaveLength(1)
+    expect(l3[0].action).toEqual({ type: 'scroll', sectionId: 'intro' })
+    expect(l3[0].secondaryAction).toBeUndefined()
+  })
+
+  it('keeps a heading with a runtime action as a scroll primary action', () => {
+    const onRun = mock(() => {})
+    const index: PageNavLink[] = [{ id: 'warm-up', label: 'Warm Up', type: 'heading', onRun, runIcon: 'play' }]
+    const l3 = mapIndexToL3(index)
+
+    expect(l3[0].action).toEqual({ type: 'scroll', sectionId: 'warm-up' })
+    expect(l3[0].secondaryAction?.action).toEqual({ type: 'call', handler: onRun })
+  })
+
+  it('navigates on primary click for collection workout links with the link icon', () => {
+    const onRun = mock(() => {})
+    const index: PageNavLink[] = [
+      {
+        id: 'workout-../../markdown/collections/girls/Fran.md',
+        label: 'Fran',
+        type: 'wod',
+        onRun,
+        runIcon: 'link',
+      },
+    ]
+    const l3 = mapIndexToL3(index)
+
+    expect(l3[0].action).toEqual({ type: 'call', handler: onRun })
+    expect(l3[0].secondaryAction?.action).toEqual({ type: 'call', handler: onRun })
+  })
+})
+
+describe('applyTemplate', () => {
+  it('removes the $CURSOR token and reports the offset', () => {
+    const result = applyTemplate('Hello $CURSOR world')
+    expect(result.content).toBe('Hello  world')
+    expect(result.cursorOffset).toBe(6)
+  })
+
+  it('returns the full string when no cursor token is present', () => {
+    const result = applyTemplate('Hello world')
+    expect(result.content).toBe('Hello world')
+    expect(result.cursorOffset).toBe(11)
+  })
+})

--- a/playground/src/pages/shared/pageUtils.ts
+++ b/playground/src/pages/shared/pageUtils.ts
@@ -79,7 +79,10 @@ export function mapIndexToL3(index: PageNavLink[]): NavItemL3[] {
     id: link.id,
     label: link.label,
     level: 3 as const,
-    action: { type: 'scroll' as const, sectionId: link.id },
+    action:
+      link.onRun && link.runIcon === 'link'
+        ? { type: 'call' as const, handler: link.onRun }
+        : { type: 'scroll' as const, sectionId: link.id },
     secondaryAction: link.onRun
       ? {
           id: link.id + '-run',

--- a/playground/src/services/createPlaygroundPage.ts
+++ b/playground/src/services/createPlaygroundPage.ts
@@ -1,27 +1,24 @@
 import { formatPlaygroundTimestampId } from '@/lib/playgroundDisplay'
 
-import { journalNotes } from './journalNotes'
-
-const MAX_TIMESTAMP_ID_RETRIES = 10
+import { pageId, playgroundContent } from './playgroundContent'
 
 /**
- * Atomically create a new playground page.
+ * Create a new playground page.
  *
- * Tries `baseName`, then `baseName-1` … `baseName-N`. Each attempt uses
- * IndexedDB `add()` (via `addPage`), which throws a `ConstraintError` if the
- * key already exists — making the check-and-create race-free even when two
- * tabs open simultaneously.
- *
- * Returns the ID that was successfully written.
+ * Writes the composite page (`playground/<timestamp-name>`) — the identity
+ * PlaygroundNotePage actually loads — and returns the route name. Millisecond
+ * timestamp precision plus the in-flight guard in PlaygroundRedirect make
+ * collisions a non-issue; an upsert on collision is acceptable for a scratch
+ * surface.
  */
 export async function createPlaygroundPage(content: string): Promise<string> {
   const baseName = formatPlaygroundTimestampId(Date.now())
-  const note = await journalNotes.create({
-    journalDate: '',
-    title: baseName,
-    rawContent: content,
-    type: 'playground',
-    slug: `playground/${baseName}`,
+  await playgroundContent.savePage({
+    id: pageId('playground', baseName),
+    category: 'playground',
+    name: baseName,
+    content,
+    updatedAt: Date.now(),
   })
-  return note.id
+  return baseName
 }

--- a/playground/src/tour/HomeTour.tsx
+++ b/playground/src/tour/HomeTour.tsx
@@ -21,6 +21,8 @@ import { MacOSChrome } from '../components/atoms/MacOSChrome'
 import { encodeZip } from '../services/encodeZip'
 import { resolveSource } from '../canvas/canvasUtils'
 import { getAnalyticsFromLogs, getAnalyticsFromRuntime } from '@/services/AnalyticsTransformer'
+import { createJournalNoteFromWorkout } from '../services/journalWorkout'
+import { playgroundRecorder } from '../services/resultRecorder'
 import { NextAction } from '@/runtime/actions/stack/NextAction'
 import type { IScriptRuntime } from '@/runtime/contracts/IScriptRuntime'
 import type { ScriptBlock, WorkoutResults } from '@/components/Editor/types'
@@ -170,6 +172,14 @@ function HomeTourInner({ wodFiles, theme, quests, chapters, questLabels }: HomeT
   // ── Session results (playground completion) + scroll-mode analytics ──
   const [session, setSession] = useState<{ segments: Segment[]; results: WorkoutResults } | null>(null)
   const [scrollSegments, setScrollSegments] = useState<Segment[]>([])
+  // Journal-write state for playground completions. Drives the Session
+  // Review title + hint pill so the UI only claims "logged" when it is.
+  const [logState, setLogState] = useState<'logging' | 'logged' | 'failed' | null>(null)
+  // Latest-value mirrors for callbacks with empty dep arrays.
+  const interactiveRef = useRef(interactive)
+  interactiveRef.current = interactive
+  const docRef = useRef(doc)
+  docRef.current = doc
 
   useEffect(() => {
     if (interactive || slice.stage.id !== 'analytics' || session) return
@@ -241,6 +251,7 @@ function HomeTourInner({ wodFiles, theme, quests, chapters, questLabels }: HomeT
   // ── Playground mode transitions ──
   const startRun = useCallback(() => {
     if (!blocksRef.current[0]) return
+    setLogState(null)
     setEntered((prev) => (prev.timer ? prev : { ...prev, timer: true }))
     timerAutoStartRef.current = true
     setInteractive('timer')
@@ -258,10 +269,40 @@ function HomeTourInner({ wodFiles, theme, quests, chapters, questLabels }: HomeT
 
   const handleTimerComplete = useCallback(
     (_blockId: string, results: WorkoutResults) => {
+      const wasPlaygroundRun = interactiveRef.current === 'timer'
       const { segments } = getAnalyticsFromLogs(results.logs ?? [], results.startTime)
       setSession({ segments, results })
       setEntered((prev) => (prev.analytics ? prev : { ...prev, analytics: true }))
       setInteractive((mode) => (mode === 'timer' ? 'analytics' : mode))
+
+      // Persist a real playground run to today's journal — the Session
+      // Review claims "logged from timer", so make it true. The scroll-mode
+      // fast-forward also fires onComplete; that showcase writes nothing.
+      if (!wasPlaygroundRun) return
+      const runBlock = blocksRef.current[0]
+      if (!runBlock) return
+      setLogState('logging')
+      void (async () => {
+        const note = await createJournalNoteFromWorkout({
+          workoutName: 'Welcome workout',
+          category: 'home',
+          sourceNoteLabel: 'welcome-1.md',
+          sourceNotePath: '/',
+          wodContent: docRef.current,
+        })
+        await playgroundRecorder.record({
+          runBlock,
+          blockId: runBlock.id,
+          noteId: note.id,
+          resultId: crypto.randomUUID(),
+          data: results,
+          createdAt: results.endTime ?? Date.now(),
+        })
+        setLogState('logged')
+      })().catch((err) => {
+        console.error('[HomeTour] failed to log session to journal:', err)
+        setLogState('failed')
+      })
     },
     [],
   )
@@ -556,7 +597,13 @@ function HomeTourInner({ wodFiles, theme, quests, chapters, questLabels }: HomeT
                       <Screen visible={activeScreen === 'analytics'}>
                         <TourAnalyticsScreen
                           segments={analyticsSegments}
-                          title="Journal / today · logged from timer"
+                          title={
+                            logState === 'logging'
+                              ? 'Journal / today · logging…'
+                              : logState === 'failed'
+                                ? 'Session Review · not saved to journal'
+                                : 'Journal / today · logged from timer'
+                          }
                         />
                       </Screen>
                     )}
@@ -621,7 +668,11 @@ function HomeTourInner({ wodFiles, theme, quests, chapters, questLabels }: HomeT
               ▶ Playground mode —{' '}
               {interactive === 'timer'
                 ? 'timer running · STOP to log it · tap here to exit'
-                : 'session logged · tap here to return to the tour'}
+                : logState === 'failed'
+                  ? 'session not saved · tap here to return to the tour'
+                  : logState === 'logging'
+                    ? 'logging session… · tap here to return to the tour'
+                    : 'session logged · tap here to return to the tour'}
             </button>
           )}
         </div>

--- a/playground/src/views/JournalListPage.tsx
+++ b/playground/src/views/JournalListPage.tsx
@@ -167,6 +167,7 @@ export function JournalListPage({
   // ── Data loading ──────────────────────────────────────────────────────────
   const [results, setResults] = useState<unknown[]>([])
   const [journalEntries, setJournalEntries] = useState<Map<string, JournalEntrySummary>>(new Map())
+  const [notesTitleMap, setNotesTitleMap] = useState<Map<string, string>>(new Map())
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -193,6 +194,13 @@ export function JournalListPage({
           grouped.set(dateKey, dayEntries)
         }
         const entryMap = new Map<string, JournalEntrySummary>()
+        const titleMap = new Map<string, string>()
+        for (const entry of entries) {
+          if (entry.title && !/^[0-9a-f]{8}-[0-9a-f]{4}/i.test(entry.title)) {
+            titleMap.set(entry.id, entry.title)
+            if (entry.slug) titleMap.set(entry.slug, entry.title)
+          }
+        }
         for (const [dateKey, dayEntries] of grouped) {
           const titles = dayEntries.map(entry => entry.title).filter(Boolean)
           entryMap.set(dateKey, {
@@ -203,6 +211,7 @@ export function JournalListPage({
 
         setResults(rawResults)
         setJournalEntries(entryMap)
+        setNotesTitleMap(titleMap)
       } catch {
         setResults([])
         setJournalEntries(new Map())
@@ -233,11 +242,17 @@ export function JournalListPage({
       const parts = safeNoteId.split('/')
       const lastSegment = parts[parts.length - 1] || safeNoteId
       const isDateSegment = /^\d{4}-\d{2}-\d{2}$/.test(lastSegment)
+      const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}/i.test(lastSegment)
+      const resolvedTitle = notesTitleMap.get(safeNoteId) || notesTitleMap.get(lastSegment)
       const title = isPlayground
         ? 'Playground'
-        : isDateSegment
-          ? (parts[parts.length - 2] || lastSegment)
-          : lastSegment
+        : resolvedTitle
+          ? resolvedTitle
+          : isDateSegment
+            ? (parts[parts.length - 2] || lastSegment)
+            : isUUID
+              ? 'Workout Note'
+              : lastSegment
       return {
         id: r.id,
         type: 'result' as const,
@@ -252,7 +267,7 @@ export function JournalListPage({
       return allItems.filter(item => item.group !== 'playground')
     }
     return allItems
-  }, [results, showPlaygrounds])
+  }, [results, showPlaygrounds, notesTitleMap])
 
   // ── Date keys to display ──────────────────────────────────────────────────
   const todayKey = useMemo(() => localDateKey(new Date()), [])

--- a/playground/src/views/analytics/AnalyticsExplorerPage.test.tsx
+++ b/playground/src/views/analytics/AnalyticsExplorerPage.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { NuqsAdapter } from 'nuqs/adapters/react-router';
+import { parseQuery, type QueryResult } from '@/services/analytics/query';
+
+// CodeMirror cannot run under jsdom; replace the raw code editor with a plain input.
+mock.module('@/components/organisms/editor/WqlQueryField', () => ({
+  WqlQueryField: (props: { value: string; onChange: (value: string) => void }) =>
+    React.createElement('input', {
+      value: props.value,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => props.onChange(e.target.value),
+      'data-testid': 'wql-query-field',
+    }),
+}));
+
+function resultOf(raw: string): QueryResult {
+  return {
+    parsed: parseQuery(raw),
+    series: [],
+    stages: { selected: 0, buckets: 0, aggregated: 0, groups: 0 },
+    matched: [],
+  };
+}
+
+mock.module('@/services/analytics/query', () => ({
+  parseQuery,
+  QueryService: class {},
+  queryService: {
+    runQuery: mock(async (raw: string) => resultOf(raw)),
+    run: mock(async () => resultOf('sum:totalVolume{}')),
+    getFactsByTimeRange: mock(async () => []),
+  },
+}));
+
+import { AnalyticsExplorerPage } from './AnalyticsExplorerPage';
+
+afterEach(cleanup);
+
+function renderPage(initialQuery: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/analytics/explorer?q=${encodeURIComponent(initialQuery)}`]} initialIndex={0}>
+      <NuqsAdapter>
+        <AnalyticsExplorerPage />
+      </NuqsAdapter>
+    </MemoryRouter>,
+  );
+}
+
+describe('AnalyticsExplorerPage', () => {
+  it('updates parsed chips while editing before running the query', async () => {
+    renderPage('');
+
+    // Choose an example query that has a tag filter.
+    const exampleButton = await waitFor(() => screen.getByText('Weekly strength volume'));
+    fireEvent.click(exampleButton);
+
+    // Wait for the initial run to complete and the filter chip to appear.
+    await waitFor(() => expect(screen.queryByText('discipline:strength')).not.toBeNull());
+
+    // Remove the filter using the visual composer; this should not submit a new query.
+    const removeButton = screen.getByText('✕');
+    fireEvent.click(removeButton);
+
+    // The chip should disappear immediately because the anatomy is driven by the live draft.
+    await waitFor(() => expect(screen.queryByText('discipline:strength')).toBeNull());
+  });
+});

--- a/playground/src/views/analytics/AnalyticsExplorerPage.tsx
+++ b/playground/src/views/analytics/AnalyticsExplorerPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQueryState } from 'nuqs';
 import { WqlQueryComposer } from '@/components/organisms/analytics/WqlQueryComposer';
-import { queryService, type QueryResult } from '@/services/analytics/query';
+import { parseQuery, queryService, type QueryResult } from '@/services/analytics/query';
 import { ensureRollupFacts } from '@/services/analytics/rollup';
 import {
   QueryValue,
@@ -49,6 +49,7 @@ export function AnalyticsExplorerPage() {
   const [result, setResult] = useState<QueryResult | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const vocabulary = useExplorerVocabulary();
+  const liveParsed = useMemo(() => parseQuery(draft), [draft]);
 
   useEffect(() => {
     setDraft(q);
@@ -173,8 +174,8 @@ export function AnalyticsExplorerPage() {
             </div>
             {q ? (
               <>
-                <ParsedQueryChips parsed={result?.parsed ?? { raw: q, agg: 'sum', metric: '', filters: [], groupBy: [] }} />
-                {result && <PipelineAnatomy result={result} />}
+                <ParsedQueryChips parsed={result && result.parsed.raw === draft ? result.parsed : liveParsed} />
+                {result && result.parsed.raw === draft && <PipelineAnatomy result={result} />}
               </>
             ) : (
               <div className="text-sm text-muted-foreground">Submit a query to see its anatomy.</div>

--- a/playground/src/views/queriable-list/CollectionWorkoutsList.test.tsx
+++ b/playground/src/views/queriable-list/CollectionWorkoutsList.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test'
+import { getWorkoutPreview } from './CollectionWorkoutsList'
+
+const FRONTMATTER = `---
+tags:
+  - crossfit
+---
+`
+
+const ZOMBIE_FIT = `---
+tags:
+  - parkour
+---
+
+# WOD 34
+
+---
+Category: zombie-fit
+Type: Intervals
+Difficulty: Beginner / Advanced / Expert
+date: 2009-12-01
+original_url: "http://zombiefit.org/2009/11/wod-120109/"
+wayback_url: "http://web.archive.org/web/2/http://zombiefit.org/2009/11/wod-120109/"
+---
+
+## Warm Up
+
+Run 1/4 mile | bike 2 miles | row 500m followed by:
+
+\`\`\`wod
+(2)
+  250m Quadrupedal Movement
+  50 Jumping Jacks
+\`\`\`
+`
+
+describe('getWorkoutPreview', () => {
+  it('returns null for empty content', () => {
+    expect(getWorkoutPreview('')).toBeNull()
+    expect(getWorkoutPreview(undefined)).toBeNull()
+  })
+
+  it('strips ** and __ formatting from the first body line', () => {
+    const content = FRONTMATTER + '\n# 2024 CrossFit Games - Event 5\n\n**Category:** Competition\n**Type:** For Time\n'
+    expect(getWorkoutPreview(content)).toBe('Category: Competition')
+  })
+
+  it('strips stray ** from unbalanced formatting', () => {
+    const content =
+      FRONTMATTER +
+      '\n# 2020 CrossFit Games - Event 4\n\n**Location: CrossFit Ranch, Aromas, California (Finals)\nDate: October 23-25, 2020**\n'
+    expect(getWorkoutPreview(content)).toBe('Location: CrossFit Ranch, Aromas, California (Finals)')
+  })
+
+  it('strips backticks and links from the first body line', () => {
+    const content = FRONTMATTER + '\n# Test\n\nRun `[this link](https://example.com)` now\n'
+    expect(getWorkoutPreview(content)).toBe('Run this link now')
+  })
+
+  it('skips in-body --- frontmatter blocks and returns the first real body line', () => {
+    expect(getWorkoutPreview(ZOMBIE_FIT)).toBe('Run 1/4 mile | bike 2 miles | row 500m followed by:')
+  })
+
+  it('skips heading and code-fence delimiter lines when picking the first body line', () => {
+    const content = FRONTMATTER + '\n# Title\n\nFirst real sentence.\n\n```wod\n(5) burpees\n```\n'
+    expect(getWorkoutPreview(content)).toBe('First real sentence.')
+  })
+})

--- a/playground/src/views/queriable-list/CollectionWorkoutsList.tsx
+++ b/playground/src/views/queriable-list/CollectionWorkoutsList.tsx
@@ -27,15 +27,46 @@ interface CollectionWorkoutsListProps {
   getItemActions?: (item: WorkoutItem) => CollectionWorkoutsListAction[];
 }
 
-function getWorkoutPreview(content?: string): string | null {
+function skipInBodyFrontmatter(lines: string[]): string[] {
+  const result: string[] = []
+  let inBlock = false
+  for (const line of lines) {
+    if (line.trim() === '---') {
+      inBlock = !inBlock
+      continue
+    }
+    if (!inBlock) {
+      result.push(line)
+    }
+  }
+  return result
+}
+
+function stripInlineMarkdown(line: string): string {
+  let text = line
+  // Remove balanced inline formatting pairs.
+  text = text.replace(/\*\*([^*]+)\*\*/g, '$1')
+  text = text.replace(/__([^_]+)__/g, '$1')
+  text = text.replace(/`([^`]+)`/g, '$1')
+  // Convert markdown links to their link text.
+  text = text.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+  // Remove any stray markers left by unbalanced formatting.
+  text = text.replace(/\*\*/g, '')
+  text = text.replace(/__/g, '')
+  text = text.replace(/`/g, '')
+  return text.trim()
+}
+
+export function getWorkoutPreview(content?: string): string | null {
   if (!content) return null;
 
   const stripped = stripFrontmatter(content)
-    .split('\n')
+  const lines = skipInBodyFrontmatter(stripped.split('\n'))
     .map(line => line.trim())
     .filter(line => line.length > 0 && !line.startsWith('#') && !line.startsWith('```'));
 
-  return stripped[0] ?? null;
+  const first = lines[0]
+  return first ? stripInlineMarkdown(first) : null;
 }
 
 export const CollectionWorkoutsList: React.FC<CollectionWorkoutsListProps> = ({

--- a/src/components/atoms/Dialog.tsx
+++ b/src/components/atoms/Dialog.tsx
@@ -55,7 +55,7 @@ export const DialogContent = React.forwardRef<
         <DialogPanel
           ref={ref}
           className={cn(
-            "w-full max-w-md transform overflow-hidden rounded-2xl bg-popover text-popover-foreground p-6 text-left align-middle shadow-xl transition-all border border-border",
+            "relative w-full max-w-md transform overflow-hidden rounded-2xl bg-popover text-popover-foreground p-6 text-left align-middle shadow-xl transition-all border border-border",
             className
           )}
           {...props}

--- a/src/components/molecules/adapters/historyAdapter.test.ts
+++ b/src/components/molecules/adapters/historyAdapter.test.ts
@@ -19,6 +19,20 @@ const baseEntry: HistoryEntry = {
   schemaVersion: 1,
 };
 
+function expectedPlaygroundLabel(timestamp: number): string {
+  const date = new Date(timestamp);
+  const dateStr = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const timeStr = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return `Playground – ${dateStr} ${timeStr}`;
+}
+
 function iconType(item: ReturnType<typeof historyEntryToListItem>) {
   return (item.icon as React.ReactElement).type;
 }
@@ -30,7 +44,7 @@ describe('historyEntryToListItem', () => {
       type: 'playground',
     });
 
-    expect(item.label).toBe('Playground – Apr 27, 2026 2:30 PM');
+    expect(item.label).toBe(expectedPlaygroundLabel(baseEntry.createdAt));
     expect(iconType(item)).toBe(BeakerIcon);
   });
 

--- a/src/components/organisms/analytics/RawPointsTable.tsx
+++ b/src/components/organisms/analytics/RawPointsTable.tsx
@@ -19,6 +19,10 @@ export function RawPointsTable({ matched, unit }: RawPointsTableProps) {
     if (row.origin) tags.push(`origin:${row.origin}`);
     return tags;
   };
+  const fmtDate = (ts: number) => {
+    const d = new Date(ts);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  };
 
   return (
     <div className="bg-card border border-border rounded-lg mt-3">
@@ -45,7 +49,7 @@ export function RawPointsTable({ matched, unit }: RawPointsTableProps) {
               {matched.slice(0, 12).map((p) => (
                 <tr key={p.id} className="border-b border-border/40">
                   <td className="py-1.5 pr-4 text-muted-foreground whitespace-nowrap">
-                    {new Date(p.timestamp).toISOString().slice(0, 10)}
+                    {fmtDate(p.timestamp)}
                   </td>
                   <td className="py-1.5 pr-4 text-primary whitespace-nowrap">{p.metricKey}</td>
                   <td className="py-1.5 pr-4 tabular-nums">

--- a/src/components/organisms/layout/PageNavDropdown.test.tsx
+++ b/src/components/organisms/layout/PageNavDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 
 import { PageNavDropdown } from './PageNavDropdown';
 
@@ -22,4 +22,50 @@ describe('PageNavDropdown', () => {
 
     expect(screen.getByLabelText('Page sections').textContent).toContain('Details');
   });
+
+  it('scrolls to the section on primary click for plain links', () => {
+    const scrollToSection = mock(() => {})
+    render(
+      <PageNavDropdown
+        links={[{ id: 'overview', label: 'Overview', type: 'heading' }]}
+        scrollToSection={scrollToSection}
+      />,
+    )
+
+    act(() => {
+      screen.getByLabelText('Page sections').click()
+    })
+    act(() => {
+      screen.getByRole('menuitem').click()
+    })
+    expect(scrollToSection).toHaveBeenCalledWith('overview')
+  })
+
+  it('navigates on primary click for collection workout links with the link icon', () => {
+    const onRun = mock(() => {})
+    const scrollToSection = mock(() => {})
+    render(
+      <PageNavDropdown
+        links={[
+          {
+            id: 'workout-../../markdown/collections/girls/Fran.md',
+            label: 'Fran',
+            type: 'wod',
+            onRun,
+            runIcon: 'link',
+          },
+        ]}
+        scrollToSection={scrollToSection}
+      />,
+    )
+
+    act(() => {
+      screen.getByLabelText('Page sections').click()
+    })
+    act(() => {
+      screen.getByRole('menuitem').click()
+    })
+    expect(onRun).toHaveBeenCalled()
+    expect(scrollToSection).not.toHaveBeenCalled()
+  })
 });

--- a/src/components/organisms/layout/PageNavDropdown.tsx
+++ b/src/components/organisms/layout/PageNavDropdown.tsx
@@ -75,7 +75,13 @@ export function PageNavDropdown({
         {links.map(link => (
           <DropdownMenuItem
             key={link.id}
-            onClick={() => scrollToSection(link.id)}
+            onClick={() => {
+              if (link.onRun && link.runIcon === 'link') {
+                link.onRun()
+              } else {
+                scrollToSection(link.id)
+              }
+            }}
             className={cn(
               'gap-2',
               link.type === 'wod' && 'pl-2 text-[11px]'

--- a/src/core/analytics/AnalyticsEngine.test.ts
+++ b/src/core/analytics/AnalyticsEngine.test.ts
@@ -98,6 +98,111 @@ describe('AnalyticsEngine', () => {
     expect(results[0].outputType).toBe('analytics');
   });
 
+  describe('live/finalize deduplication', () => {
+    it('finalize returns empty when projections were already emitted live', () => {
+      const engine = new AnalyticsEngine();
+      const summary: ISummaryProcessor = {
+        id: 'sum-dedup',
+        summarize: (_outputs: IOutputStatement[]): ProjectionResult[] => [
+          {
+            name: 'Total Reps',
+            value: 42,
+            unit: 'reps',
+            timeSpan: { started: 0, ended: 1000 },
+            metricType: MetricType.Rep,
+          },
+        ],
+      };
+      engine.addSummaryProcessor(summary);
+
+      const live: IOutputStatement[] = [];
+      engine.setLiveOutputEmitter((o) => live.push(o));
+
+      engine.run(makeSegmentOutput('s1'));
+      expect(live).toHaveLength(1);
+      expect(live[0].outputType).toBe('analytics');
+
+      const finalized = engine.finalize();
+      expect(finalized).toHaveLength(0);
+      expect(live).toHaveLength(1);
+    });
+
+    it('finalize still emits when no live output was emitted', () => {
+      const engine = new AnalyticsEngine();
+      const summary: ISummaryProcessor = {
+        id: 'sum-dedup',
+        summarize: (_outputs: IOutputStatement[]): ProjectionResult[] => [
+          {
+            name: 'Total Reps',
+            value: 42,
+            unit: 'reps',
+            timeSpan: { started: 0, ended: 1000 },
+            metricType: MetricType.Rep,
+          },
+        ],
+      };
+      engine.addSummaryProcessor(summary);
+
+      engine.run(makeSegmentOutput('s1'));
+      const finalized = engine.finalize();
+      expect(finalized).toHaveLength(1);
+      expect(finalized[0].outputType).toBe('analytics');
+    });
+
+    it('run skips the live emission when projections are unchanged (completion block-pop cascade)', () => {
+      const engine = new AnalyticsEngine();
+      const summary: ISummaryProcessor = {
+        id: 'sum-static',
+        summarize: (_outputs: IOutputStatement[]): ProjectionResult[] => [
+          {
+            name: 'Total Reps',
+            value: 75,
+            unit: 'reps',
+            timeSpan: { started: 0, ended: 1000 },
+            metricType: MetricType.Rep,
+          },
+        ],
+      };
+      engine.addSummaryProcessor(summary);
+
+      const live: IOutputStatement[] = [];
+      engine.setLiveOutputEmitter((o) => live.push(o));
+
+      // Several blocks popping at completion each trigger run(); aggregates
+      // don't change between them, so only the first may emit.
+      engine.run(makeSegmentOutput('s1'));
+      engine.run(makeSegmentOutput('s2'));
+      engine.run(makeSegmentOutput('s3'));
+      expect(live).toHaveLength(1);
+    });
+
+    it('run emits again once projections actually change', () => {
+      const engine = new AnalyticsEngine();
+      let reps = 10;
+      const summary: ISummaryProcessor = {
+        id: 'sum-growing',
+        summarize: (_outputs: IOutputStatement[]): ProjectionResult[] => [
+          {
+            name: 'Total Reps',
+            value: reps,
+            unit: 'reps',
+            timeSpan: { started: 0, ended: 1000 },
+            metricType: MetricType.Rep,
+          },
+        ],
+      };
+      engine.addSummaryProcessor(summary);
+
+      const live: IOutputStatement[] = [];
+      engine.setLiveOutputEmitter((o) => live.push(o));
+
+      engine.run(makeSegmentOutput('s1'));
+      reps = 25;
+      engine.run(makeSegmentOutput('s2'));
+      expect(live).toHaveLength(2);
+    });
+  });
+
   describe('processor split behavior', () => {
     it('realtime processors enrich per-segment outputs', () => {
       const engine = new AnalyticsEngine();

--- a/src/core/analytics/AnalyticsEngine.ts
+++ b/src/core/analytics/AnalyticsEngine.ts
@@ -12,6 +12,11 @@ export class AnalyticsEngine implements IAnalyticsEngine {
   private outputHistory: IOutputStatement[] = [];
   /** Emits a live 'analytics' output per segment so the UI updates in real time. */
   private _onLiveOutput?: (output: IOutputStatement) => void;
+  /**
+   * Signature of the last live projection emission. Used by finalize() to avoid
+   * re-emitting the same projections at session end. Timestamps are ignored.
+   */
+  private _lastLiveProjectionSignature?: string;
 
   /** Wire a sink for live analytics outputs (one per segment, as projections update). */
   setLiveOutputEmitter(emit: (output: IOutputStatement) => void): void {
@@ -45,8 +50,17 @@ export class AnalyticsEngine implements IAnalyticsEngine {
       this.outputHistory.push(current);
       if (this._onLiveOutput) {
         const now = Date.now();
-        for (const stmt of this._buildProjectionOutputs(this._runSummaries(), now)) {
-          this._onLiveOutput(stmt);
+        const projections = this._runSummaries();
+        const signature = this._projectionSignature(projections);
+        // Skip emission when the projections carry no new information — e.g.
+        // several blocks popping at completion each trigger run() with
+        // identical aggregates, producing byte-identical same-ms rows.
+        if (signature !== this._lastLiveProjectionSignature) {
+          this._lastLiveProjectionSignature = signature;
+          const liveOutputs = this._buildProjectionOutputs(projections, now);
+          for (const stmt of liveOutputs) {
+            this._onLiveOutput(stmt);
+          }
         }
       }
     }
@@ -55,7 +69,25 @@ export class AnalyticsEngine implements IAnalyticsEngine {
   }
 
   finalize(): IOutputStatement[] {
-    return this._buildProjectionOutputs(this._runSummaries(), Date.now());
+    const projections = this._runSummaries();
+    const outputs = this._buildProjectionOutputs(projections, Date.now());
+    const signature = this._projectionSignature(projections);
+    if (this._lastLiveProjectionSignature !== undefined && this._lastLiveProjectionSignature === signature) {
+      return [];
+    }
+    return outputs;
+  }
+
+  /**
+   * Identity of a projection set for dedupe — which fields make two emission
+   * sets 'the same'. Timestamps are intentionally ignored; display/fact
+   * layers have their own keys (see getAnalyticsFromLogs and
+   * normalizeSummaryFacts).
+   */
+  private _projectionSignature(projections: ProjectionResult[]): string {
+    return JSON.stringify(
+      projections.map((p) => ({ name: p.name, value: p.value, unit: p.unit, metricType: p.metricType })),
+    );
   }
 
   /** Build one 'analytics' OutputStatement per summary projection. */

--- a/src/core/analytics/engines/RepProjectionEngine.ts
+++ b/src/core/analytics/engines/RepProjectionEngine.ts
@@ -18,7 +18,48 @@ export class RepProjectionEngine implements ISummaryProcessor {
   public readonly requiredMetrics = [MetricType.Rep] as const;
 
   summarize(outputs: IOutputStatement[]): ProjectionResult[] {
-    return this.calculateFromWorkout(extractMetrics(outputs));
+    const metrics = extractMetrics(outputs);
+    const overall = this.calculateFromWorkout(metrics);
+    const perEffort = this._runPerEffort(metrics);
+    return [...overall, ...perEffort];
+  }
+
+  private toSlug(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+  }
+
+  private _runPerEffort(metrics: IMetric[]): ProjectionResult[] {
+    const grouped = new Map<string, number>();
+    let currentEffort: string | null = null;
+
+    for (const m of metrics) {
+      if (m.type === MetricType.Effort && typeof m.value === 'string') {
+        currentEffort = m.value;
+        if (!grouped.has(currentEffort)) grouped.set(currentEffort, 0);
+        continue;
+      }
+      if (currentEffort && m.type === MetricType.Rep && typeof m.value === 'number') {
+        grouped.set(currentEffort, (grouped.get(currentEffort) ?? 0) + m.value);
+      }
+    }
+
+    const now = new Date();
+    const results: ProjectionResult[] = [];
+    for (const [effortName, totalReps] of grouped.entries()) {
+      if (totalReps <= 0) continue;
+      results.push({
+        name: 'Total Reps',
+        value: totalReps,
+        unit: 'reps',
+        metricType: MetricType.Rep,
+        timeSpan: new TimeSpan(now.getTime(), now.getTime()),
+        metadata: {
+          exerciseName: effortName,
+          effortSlug: this.toSlug(effortName),
+        },
+      });
+    }
+    return results;
   }
 
   calculateFromWorkout(metrics: IMetric[]): ProjectionResult[] {

--- a/src/core/analytics/engines/RepProjectionEngine.ts
+++ b/src/core/analytics/engines/RepProjectionEngine.ts
@@ -4,7 +4,7 @@ import { ProjectionResult } from '../ProjectionResult';
 import { IMetric, MetricType } from '../../models/Metric';
 import { IOutputStatement } from '../../models/OutputStatement';
 import { TimeSpan } from '../../../runtime/models/TimeSpan';
-
+import { extractEffortData } from '../effortResolution';
 /**
  * RepProjectionEngine - Accumulates total repetitions across the whole workout.
  *
@@ -20,7 +20,7 @@ export class RepProjectionEngine implements ISummaryProcessor {
   summarize(outputs: IOutputStatement[]): ProjectionResult[] {
     const metrics = extractMetrics(outputs);
     const overall = this.calculateFromWorkout(metrics);
-    const perEffort = this._runPerEffort(metrics);
+    const perEffort = this._runPerEffort(outputs);
     return [...overall, ...perEffort];
   }
 
@@ -28,34 +28,52 @@ export class RepProjectionEngine implements ISummaryProcessor {
     return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
   }
 
-  private _runPerEffort(metrics: IMetric[]): ProjectionResult[] {
-    const grouped = new Map<string, number>();
-    let currentEffort: string | null = null;
+  private _runPerEffort(outputs: IOutputStatement[]): ProjectionResult[] {
+    const grouped = new Map<string, { name: string; slug: string; reps: number }>();
 
-    for (const m of metrics) {
-      if (m.type === MetricType.Effort && typeof m.value === 'string') {
-        currentEffort = m.value;
-        if (!grouped.has(currentEffort)) grouped.set(currentEffort, 0);
+    for (const output of outputs) {
+      if (output.outputType !== 'segment') continue;
+      const rawMetrics = output.metrics?.rawMetrics ?? [];
+
+      const effortData = extractEffortData(rawMetrics);
+      const effortMetric = rawMetrics.find(m => m.type === MetricType.Effort && typeof m.value === 'string');
+
+      const effortName = (effortData?.resolved.label || (typeof effortMetric?.value === 'string' ? effortMetric.value : '')).trim();
+      const effortSlug = effortData?.resolved.slug || (effortName ? this.toSlug(effortName) : '');
+
+      if (!effortSlug || effortSlug === 'rest' || effortSlug === 'pause' || effortSlug.startsWith('rest-')) {
         continue;
       }
-      if (currentEffort && m.type === MetricType.Rep && typeof m.value === 'number') {
-        grouped.set(currentEffort, (grouped.get(currentEffort) ?? 0) + m.value);
+
+      let statementReps = 0;
+      for (const m of rawMetrics) {
+        if (m.type === MetricType.Rep && typeof m.value === 'number') {
+          statementReps += m.value;
+        }
+      }
+
+      if (statementReps > 0) {
+        const existing = grouped.get(effortSlug);
+        if (existing) {
+          existing.reps += statementReps;
+        } else {
+          grouped.set(effortSlug, { name: effortName || effortSlug, slug: effortSlug, reps: statementReps });
+        }
       }
     }
 
     const now = new Date();
     const results: ProjectionResult[] = [];
-    for (const [effortName, totalReps] of grouped.entries()) {
-      if (totalReps <= 0) continue;
+    for (const item of grouped.values()) {
       results.push({
         name: 'Total Reps',
-        value: totalReps,
+        value: item.reps,
         unit: 'reps',
         metricType: MetricType.Rep,
         timeSpan: new TimeSpan(now.getTime(), now.getTime()),
         metadata: {
-          exerciseName: effortName,
-          effortSlug: this.toSlug(effortName),
+          exerciseName: item.name,
+          effortSlug: item.slug,
         },
       });
     }

--- a/src/core/analytics/engines/SessionLoadProjectionEngine.test.ts
+++ b/src/core/analytics/engines/SessionLoadProjectionEngine.test.ts
@@ -67,5 +67,25 @@ describe('SessionLoadProjectionEngine', () => {
       expect(results[0].value).toBe(5 * 10); // falls back to the moderate default
       expect(results[0].metadata?.sRPE).toBe(5);
     });
+
+    test('should not double-count root container elapsed and child segment elapsed times', () => {
+      const engine = new SessionLoadProjectionEngine();
+      const rootElapsed = 180_000; // 3 minutes total session duration
+      const childElapsed1 = 60_000; // 1 min round 1
+      const childElapsed2 = 60_000; // 1 min round 2
+      const childElapsed3 = 60_000; // 1 min round 3
+
+      const metrics: IMetric[] = [
+        { type: MetricType.Elapsed, value: childElapsed1, origin: 'runtime' },
+        { type: MetricType.Elapsed, value: childElapsed2, origin: 'runtime' },
+        { type: MetricType.Elapsed, value: childElapsed3, origin: 'runtime' },
+        { type: MetricType.Elapsed, value: rootElapsed, origin: 'runtime' },
+      ];
+
+      const results = engine.calculateFromWorkout(metrics);
+      expect(results).toHaveLength(1);
+      // Should count 3 minutes total (sRPE 5 * 3 min = 15 AU), NOT 6 minutes (30 AU)
+      expect(results[0].value).toBe(15);
+    });
   });
 });

--- a/src/core/analytics/engines/SessionLoadProjectionEngine.ts
+++ b/src/core/analytics/engines/SessionLoadProjectionEngine.ts
@@ -21,7 +21,7 @@ export class SessionLoadProjectionEngine implements ISummaryProcessor {
   public readonly fenceTypes = ['wod', 'log'] as const;
 
   summarize(outputs: IOutputStatement[]): ProjectionResult[] {
-    return this.calculateFromWorkout(extractMetrics(outputs));
+    return this.calculateFromWorkout(extractMetrics(outputs), outputs);
   }
 
   private readonly effortToRpe: Record<string, number> = {
@@ -32,14 +32,47 @@ export class SessionLoadProjectionEngine implements ISummaryProcessor {
     max: 10,
   };
 
-  calculateFromWorkout(metrics: IMetric[]): ProjectionResult[] {
+  calculateFromWorkout(metrics: IMetric[], outputs?: IOutputStatement[]): ProjectionResult[] {
     let totalElapsedMs = 0;
     let maxRpe = 0;
 
-    for (const m of metrics) {
-      if (m.type === MetricType.Elapsed && typeof m.value === 'number') {
-        totalElapsedMs += m.value;
+    // Calculate total session duration from statement hierarchy to prevent double-counting
+    // parent container elapsed metrics (e.g. SessionRoot/root block) with child block elapsed metrics.
+    if (outputs && outputs.length > 0) {
+      const segmentOutputs = outputs.filter(o => o.outputType === 'segment');
+      const rootSegment = segmentOutputs.find(o => o.stackLevel === 0 || o.sourceBlockKey === 'root');
+      const rootElapsed = rootSegment?.metrics.find(m => m.type === MetricType.Elapsed && typeof m.value === 'number');
+
+      if (rootElapsed && typeof rootElapsed.value === 'number') {
+        totalElapsedMs = rootElapsed.value;
+      } else {
+        const leafSegments = segmentOutputs.filter(o => (o.stackLevel ?? 0) > 0);
+        const targetSegments = leafSegments.length > 0 ? leafSegments : segmentOutputs;
+        for (const s of targetSegments) {
+          const m = s.metrics.find(m => m.type === MetricType.Elapsed && typeof m.value === 'number');
+          if (m && typeof m.value === 'number') {
+            totalElapsedMs += m.value;
+          }
+        }
       }
+    } else {
+      // Fallback when outputs array is not provided directly (direct metrics array calls):
+      // Gather all elapsed values. If the max elapsed value equals or exceeds the sum of the rest,
+      // the max value represents the root session duration and should be used to avoid double counting.
+      const elapsedValues: number[] = [];
+      for (const m of metrics) {
+        if (m.type === MetricType.Elapsed && typeof m.value === 'number') {
+          elapsedValues.push(m.value);
+        }
+      }
+      if (elapsedValues.length > 0) {
+        const maxVal = Math.max(...elapsedValues);
+        const restSum = elapsedValues.reduce((a, b) => a + b, 0) - maxVal;
+        totalElapsedMs = (restSum === 0 || maxVal >= restSum) ? maxVal : elapsedValues.reduce((a, b) => a + b, 0);
+      }
+    }
+
+    for (const m of metrics) {
       if (m.type === MetricType.Effort) {
         const effortVal = typeof m.value === 'string' ? m.value.toLowerCase() : null;
         const rpe = effortVal ? (this.effortToRpe[effortVal] ?? 0) : (typeof m.value === 'number' ? m.value : 0);

--- a/src/core/analytics/engines/VolumeProjectionEngine.ts
+++ b/src/core/analytics/engines/VolumeProjectionEngine.ts
@@ -111,6 +111,7 @@ export class VolumeProjectionEngine implements ISummaryProcessor {
       timeSpan: new TimeSpan(now.getTime(), now.getTime()),
       metadata: {
         exerciseName: exerciseName,
+        effortSlug: exerciseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
         totalSets,
         source: 'metrics',
       }

--- a/src/lib/playgroundDisplay.test.ts
+++ b/src/lib/playgroundDisplay.test.ts
@@ -5,20 +5,47 @@ import {
   formatPlaygroundTimestampLabel,
 } from './playgroundDisplay';
 
+function expectedTimestampId(date: Date): string {
+  const pad = (value: number, length = 2) => String(value).padStart(length, '0');
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+    pad(date.getMilliseconds(), 3),
+  ].join('-');
+}
+
+function expectedTimestampLabel(date: Date): string {
+  const dateStr = date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const timeStr = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return `Playground – ${dateStr} ${timeStr}`;
+}
+
 describe('playgroundDisplay', () => {
   const timestamp = Date.UTC(2026, 3, 27, 14, 30, 22, 481);
+  const date = new Date(timestamp);
 
   it('formats timestamp IDs for playground URLs', () => {
-    expect(formatPlaygroundTimestampId(timestamp)).toBe('2026-04-27-14-30-22-481');
+    expect(formatPlaygroundTimestampId(timestamp)).toBe(expectedTimestampId(date));
   });
 
   it('formats playground timestamp labels', () => {
-    expect(formatPlaygroundTimestampLabel(timestamp)).toBe('Playground – Apr 27, 2026 2:30 PM');
+    expect(formatPlaygroundTimestampLabel(timestamp)).toBe(expectedTimestampLabel(date));
   });
 
   it('formats timestamp route IDs as readable playground titles', () => {
     expect(formatPlaygroundPageTitle('2026-04-27-14-30-22-481'))
-      .toBe('Playground – Apr 27, 2026 2:30 PM');
+      .toBe(expectedTimestampLabel(new Date(2026, 3, 27, 14, 30, 22, 481)));
   });
 
   it('hides legacy UUID playground IDs behind a generic title', () => {
@@ -31,6 +58,6 @@ describe('playgroundDisplay', () => {
 
   it('formats timestamp route IDs with collision suffixes as readable titles', () => {
     expect(formatPlaygroundPageTitle('2026-04-27-14-30-22-481-1'))
-      .toBe('Playground – Apr 27, 2026 2:30 PM');
+      .toBe(expectedTimestampLabel(new Date(2026, 3, 27, 14, 30, 22, 481)));
   });
 });

--- a/src/lib/playgroundDisplay.ts
+++ b/src/lib/playgroundDisplay.ts
@@ -7,13 +7,13 @@ export function formatPlaygroundTimestampId(timestamp: number): string {
   const pad = (value: number, length = 2) => String(value).padStart(length, '0');
 
   return [
-    date.getUTCFullYear(),
-    pad(date.getUTCMonth() + 1),
-    pad(date.getUTCDate()),
-    pad(date.getUTCHours()),
-    pad(date.getUTCMinutes()),
-    pad(date.getUTCSeconds()),
-    pad(date.getUTCMilliseconds(), 3),
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds()),
+    pad(date.getMilliseconds(), 3),
   ].join('-');
 }
 
@@ -23,19 +23,17 @@ export function formatPlaygroundTimestampLabel(timestamp: number): string {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
-    timeZone: 'UTC',
   });
   const timeStr = date.toLocaleTimeString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
-    timeZone: 'UTC',
   });
 
   return `Playground – ${dateStr} ${timeStr}`;
 }
 
 function timestampFromMatch(match: RegExpMatchArray): number {
-  return Date.UTC(
+  return new Date(
     Number(match[1]),
     Number(match[2]) - 1,
     Number(match[3]),
@@ -43,7 +41,7 @@ function timestampFromMatch(match: RegExpMatchArray): number {
     Number(match[5]),
     Number(match[6] ?? 0),
     Number(match[7] ?? 0),
-  );
+  ).getTime();
 }
 
 export function formatPlaygroundPageTitle(name: string): string {

--- a/src/panels/page-shells/CanvasPage.test.tsx
+++ b/src/panels/page-shells/CanvasPage.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { CanvasPage } from './CanvasPage';
+import type { PageNavLink } from '@/components/organisms/layout/PageNavDropdown';
+
+let mockActiveId = '';
+const mockSetActiveId = mock((id: string, _opts?: { history?: string }) => {
+  mockActiveId = id;
+});
+
+mock.module('nuqs', () => ({
+  useQueryState: () => [mockActiveId, mockSetActiveId],
+  parseAsStringEnum: () => ({ withDefault: () => 'all' }),
+}));
+
+describe('CanvasPage', () => {
+  beforeEach(() => {
+    mockActiveId = '';
+    mockSetActiveId.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the title and children', () => {
+    render(
+      <CanvasPage title="Test Page" index={[{ id: 'intro', label: 'Intro', type: 'heading' }]} activeSectionId="intro">
+        <div data-testid="content">Hello</div>
+      </CanvasPage>,
+    );
+
+    expect(screen.getByText('Test Page')).toBeTruthy();
+    expect(screen.getByTestId('content')).toBeTruthy();
+  });
+
+  it('invokes onRun on primary sidebar click for collection workout links', () => {
+    const onRun = mock(() => {});
+    const index: PageNavLink[] = [
+      {
+        id: 'workout-../../markdown/collections/girls/Fran.md',
+        label: 'Fran',
+        type: 'wod',
+        onRun,
+        runIcon: 'link',
+      },
+    ];
+
+    render(
+      <CanvasPage title="Collection" index={index} activeSectionId="workout-../../markdown/collections/girls/Fran.md">
+        <div data-testid="content">Collection content</div>
+      </CanvasPage>,
+    );
+
+    act(() => {
+      screen.getByText('Fran').click();
+    });
+    expect(onRun).toHaveBeenCalled();
+  });
+});

--- a/src/panels/page-shells/CanvasPage.tsx
+++ b/src/panels/page-shells/CanvasPage.tsx
@@ -289,7 +289,13 @@ export function CanvasPage({
             {index.map((link) => (
               <div key={link.id} className="flex items-center group -ml-px">
                 <button
-                  onClick={() => scrollToSection(link.id)}
+                  onClick={() => {
+                    if (link.onRun && link.runIcon === 'link') {
+                      link.onRun()
+                    } else {
+                      scrollToSection(link.id)
+                    }
+                  }}
                   className={cn(
                     'flex-1 text-left px-4 py-2 text-sm transition-all border-l',
                     link.type === 'wod'

--- a/src/services/AnalyticsTransformer.test.ts
+++ b/src/services/AnalyticsTransformer.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'bun:test';
-import { getAnalyticsFromRuntime, AnalyticsTransformer, SegmentWithMetadata } from './AnalyticsTransformer';
+import { getAnalyticsFromRuntime, getAnalyticsFromLogs, AnalyticsTransformer, SegmentWithMetadata } from './AnalyticsTransformer';
 import { IScriptRuntime } from '../runtime/contracts/IScriptRuntime';
 import { TimeSpan } from '../runtime/models/TimeSpan';
 import { IOutputStatement, OutputStatementType } from '../core/models/OutputStatement';
+import type { StoredOutputStatement } from '../components/Editor/types';
 import { MetricType, IMetric } from '../core/models/Metric';
 import { hintMetric } from '../core/metrics/hints';
 
-// Helper to create mock output statements
-function createMockOutput(options: {
+// Helper to create mock output statements. Generic so tests can type the
+// result as the plain stored shape (getAnalyticsFromLogs input) or the live
+// IOutputStatement shape; the fabricated object satisfies both structurally.
+function createMockOutput<T = IOutputStatement>(options: {
   id?: number;
   outputType?: OutputStatementType;
   started?: number;
@@ -16,7 +19,7 @@ function createMockOutput(options: {
   stackLevel?: number;
   metrics?: Array<Partial<IMetric> & { type: MetricType | string }>;
   hints?: string[];
-}): IOutputStatement {
+}): T {
   const now = Date.now();
   const timeSpan = new TimeSpan(options.started ?? now, options.ended ?? now + 60000);
   // Hints now travel as Hint metrics within the metric list.
@@ -34,7 +37,7 @@ function createMockOutput(options: {
     sourceStatementId: undefined,
     meta: { line: 0, columnStart: 0, columnEnd: 0, startOffset: 0, endOffset: 0, length: 0, raw: '' },
     isLeaf: true,
-  } as unknown as IOutputStatement;
+  } as unknown as T;
 }
 
 describe('AnalyticsTransformer', () => {
@@ -314,6 +317,73 @@ describe('AnalyticsTransformer', () => {
 
         expect(transformer.isFromStrategy(segment, 'TimeBoundRoundsStrategy')).toBe(true);
         expect(transformer.isFromStrategy(segment, 'IntervalLogicStrategy')).toBe(false);
+      });
+    });
+
+    describe('getAnalyticsFromLogs', () => {
+      it('drops duplicate analytics outputs with identical label/value/unit/timeSpan but keeps legitimate progressions', () => {
+        const startTime = Date.now();
+        const outputs: StoredOutputStatement[] = [
+          createMockOutput<StoredOutputStatement>({
+            id: 1,
+            outputType: 'segment',
+            started: startTime,
+            ended: startTime + 60000,
+            metrics: [{ type: MetricType.Effort, value: 'Work', image: 'Work' }],
+          }),
+          // Live + finalize pair from the legacy write path: identical values,
+          // timestamps a few hundred ms apart inside the same second.
+          createMockOutput<StoredOutputStatement>({
+            id: 2,
+            outputType: 'analytics',
+            started: startTime + 60000,
+            ended: startTime + 60000,
+            metrics: [
+              { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+              { type: MetricType.Rep, value: 42, unit: 'reps', image: '42 reps' },
+            ],
+          }),
+          createMockOutput<StoredOutputStatement>({
+            id: 3,
+            outputType: 'analytics',
+            started: startTime + 60300,
+            ended: startTime + 60300,
+            metrics: [
+              { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+              { type: MetricType.Rep, value: 42, unit: 'reps', image: '42 reps' },
+            ],
+          }),
+          // Legitimate progression: same label, new value, seconds later.
+          createMockOutput<StoredOutputStatement>({
+            id: 4,
+            outputType: 'analytics',
+            started: startTime + 90000,
+            ended: startTime + 90000,
+            metrics: [
+              { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+              { type: MetricType.Rep, value: 43, unit: 'reps', image: '43 reps' },
+            ],
+          }),
+          // Legitimate repeat: same value as id 2/3 but seconds apart (per-round row).
+          createMockOutput<StoredOutputStatement>({
+            id: 5,
+            outputType: 'analytics',
+            started: startTime + 120000,
+            ended: startTime + 120000,
+            metrics: [
+              { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+              { type: MetricType.Rep, value: 42, unit: 'reps', image: '42 reps' },
+            ],
+          }),
+        ];
+
+        const result = getAnalyticsFromLogs(outputs);
+
+        expect(result.segments).toHaveLength(4);
+        const analyticsSegments = result.segments.filter(s => s.context?.outputType === 'analytics');
+        expect(analyticsSegments).toHaveLength(3);
+        expect(analyticsSegments.filter(s => s.metric.reps === 42)).toHaveLength(2);
+        expect(analyticsSegments.some(s => s.metric.reps === 43)).toBe(true);
       });
     });
   });

--- a/src/services/AnalyticsTransformer.ts
+++ b/src/services/AnalyticsTransformer.ts
@@ -333,8 +333,36 @@ export function getAnalyticsFromLogs(outputs: StoredOutputStatement[], workoutSt
     o.outputType === 'analytics' ||
     o.outputType === 'milestone'
   );
-  
-  const segments = transformer.fromOutputStatements(filteredOutputs, workoutStartTime, now);
+
+  // Drop duplicate 'analytics' outputs: same (label, value, unit) within the
+  // same second. The pre-dedupe live+finalize pair was stamped with distinct
+  // Date.now() values inside one second, so an exact-ms key misses it; a 1s
+  // window catches it while preserving legitimate progressions (same value
+  // recurring across rounds, seconds apart). Keep the last occurrence.
+  // Fact-row identity is a separate contract — see normalizeSummaryFacts
+  // (metricKey, keep-last) and AnalyticsEngine's emission signature.
+  const lastKeptByKey = new Map<string, number>();
+  const dedupedOutputs: StoredOutputStatement[] = [];
+  for (let i = filteredOutputs.length - 1; i >= 0; i--) {
+    const o = filteredOutputs[i];
+    if (o.outputType === 'analytics') {
+      const label = o.metrics.find(m => m.type === MetricType.Label);
+      const value = o.metrics.find(m => m.type !== MetricType.Label && typeof m.value === 'number');
+      if (label && value) {
+        const key = [
+          String(label.value ?? label.image ?? ''),
+          String(value.value),
+          value.unit ?? '',
+        ].join('|');
+        const kept = lastKeptByKey.get(key);
+        if (kept !== undefined && Math.abs(kept - o.timeSpan.started) < 1000) continue;
+        lastKeptByKey.set(key, o.timeSpan.started);
+      }
+    }
+    dedupedOutputs.unshift(o);
+  }
+
+  const segments = transformer.fromOutputStatements(dedupedOutputs, workoutStartTime, now);
 
   if (segments.length === 0) {
     return { segments: [], groups: [] };

--- a/src/services/analytics/query/QueryService.ts
+++ b/src/services/analytics/query/QueryService.ts
@@ -169,8 +169,20 @@ export class QueryService {
       }));
     }
 
-    const matched = candidates.filter(row => matchesFilters(row, parsed.filters, noteTags));
+    let matched = candidates.filter(row => matchesFilters(row, parsed.filters, noteTags));
 
+    // Filter per-effort vs un-attributed overall summary rows to avoid double-counting
+    if (parsed.groupBy.includes('effort') || parsed.filters.some(f => f.key === 'effort')) {
+      const hasPerEffortRows = matched.some(r => r.effortSlug !== undefined);
+      if (hasPerEffortRows) {
+        matched = matched.filter(r => r.effortSlug !== undefined);
+      }
+    } else {
+      const hasOverallRow = matched.some(r => r.effortSlug === undefined);
+      if (hasOverallRow) {
+        matched = matched.filter(r => r.effortSlug === undefined);
+      }
+    }
     // ── Stage 2: BUCKET — a time dim wins over rollup; neither → one bucket.
     const timeDim = parsed.groupBy.find((d) => d === 'day' || d === 'week');
     const tagDims = parsed.groupBy.filter((d) => d !== 'day' && d !== 'week');

--- a/src/services/analytics/query/QueryService.ts
+++ b/src/services/analytics/query/QueryService.ts
@@ -20,6 +20,10 @@ import { parseQuery, type Aggregator, type ParsedQuery, type Series, type Series
 
 const DAY = 86_400_000;
 
+function localDateString(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
 /** Store surface the Query Service needs — injectable for tests. */
 export interface FactQueryStore {
   getFactsByMetric(metricKey: string): Promise<AnalyticsDataPoint[]>;
@@ -97,7 +101,7 @@ function matchesFilters(row: AnalyticsDataPoint, filters: TagFilter[], noteTags:
 
 /** Dimension value for grouping; virtual time dims bucket the canonical time. */
 function dimValue(row: AnalyticsDataPoint, dim: string, noteTags: ReadonlyMap<string, readonly string[]>): string {
-  if (dim === 'day') return new Date(Math.floor(row.timestamp / DAY) * DAY).toISOString().slice(0, 10);
+  if (dim === 'day') return localDateString(row.timestamp);
   if (dim === 'week') {
     const d = new Date(row.timestamp);
     const monday = new Date(row.timestamp - ((d.getDay() + 6) % 7) * DAY);

--- a/src/services/analytics/rollup/workloadRollup.ts
+++ b/src/services/analytics/rollup/workloadRollup.ts
@@ -18,9 +18,10 @@
 
 export const DAY = 86_400_000;
 
-/** UTC day bucket for a canonical timestamp. */
+/** Local day bucket for a canonical timestamp. */
 export function dayBucket(ts: number): number {
-  return Math.floor(ts / DAY);
+  const d = new Date(ts);
+  return Math.floor(new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime() / DAY);
 }
 
 /** The three Rollup Fact metric definitions (Canonical Metric Keys are `calc.<target>`). */

--- a/src/services/analytics/workoutDerivation.test.ts
+++ b/src/services/analytics/workoutDerivation.test.ts
@@ -268,4 +268,41 @@ describe('normalizeSummaryFacts', () => {
 
     expect(points[0].timestamp).toBe(T0);
   });
+
+  it('deduplicates duplicate analytics outputs by metricKey, keeping the last occurrence', () => {
+    const points = normalizeSummaryFacts([
+      {
+        outputType: 'analytics',
+        timeSpan: { started: T0, ended: T0 },
+        metrics: [
+          { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+          { type: MetricType.Rep, value: 42, unit: 'reps' },
+        ],
+      },
+      {
+        outputType: 'analytics',
+        timeSpan: { started: T0 + 1000, ended: T0 + 1000 },
+        metrics: [
+          { type: MetricType.Label, value: 'Total Reps', image: 'Total Reps' },
+          { type: MetricType.Rep, value: 90, unit: 'reps' },
+        ],
+      },
+      {
+        outputType: 'analytics',
+        timeSpan: { started: T0, ended: T0 },
+        metrics: [
+          { type: MetricType.Label, value: 'Training Load', image: 'Training Load' },
+          { type: MetricType.Load, value: 100, unit: 'au' },
+        ],
+      },
+    ], { noteId: 'n1', resultId: 'r1' });
+
+    expect(points).toHaveLength(2);
+    const totalReps = points.find(p => p.metricKey === 'totalReps');
+    expect(totalReps).toBeDefined();
+    expect(totalReps!.value).toBe(90);
+    const trainingLoad = points.find(p => p.metricKey === 'trainingLoad');
+    expect(trainingLoad).toBeDefined();
+    expect(trainingLoad!.value).toBe(100);
+  });
 });

--- a/src/services/analytics/workoutDerivation.ts
+++ b/src/services/analytics/workoutDerivation.ts
@@ -191,7 +191,7 @@ export function normalizeSummaryFacts(
   identity: SummaryFactIdentity,
 ): AnalyticsDataPoint[] {
   const now = Date.now();
-  const rows: AnalyticsDataPoint[] = [];
+  const rowsByKey = new Map<string, AnalyticsDataPoint>();
 
   for (const output of logs) {
     if (output.outputType !== 'analytics') continue;
@@ -207,7 +207,7 @@ export function normalizeSummaryFacts(
     const discipline = metadataString(value.metadata, 'effortDiscipline');
     const intensityTier = metadataString(value.metadata, 'effortIntensityTier');
 
-    rows.push({
+    rowsByKey.set(metricKey, {
       id: `${identity.resultId}-${metricKey}-${now}`,
       noteId: identity.noteId,
       blockContentId: identity.blockContentId,
@@ -232,5 +232,5 @@ export function normalizeSummaryFacts(
     });
   }
 
-  return rows;
+  return Array.from(rowsByKey.values());
 }

--- a/src/services/analytics/workoutDerivation.ts
+++ b/src/services/analytics/workoutDerivation.ts
@@ -207,8 +207,10 @@ export function normalizeSummaryFacts(
     const discipline = metadataString(value.metadata, 'effortDiscipline');
     const intensityTier = metadataString(value.metadata, 'effortIntensityTier');
 
-    rowsByKey.set(metricKey, {
-      id: `${identity.resultId}-${metricKey}-${now}`,
+    const rowKey = effortSlug ? `${metricKey}:${effortSlug}` : metricKey;
+
+    rowsByKey.set(rowKey, {
+      id: `${identity.resultId}-${rowKey}-${now}`,
       noteId: identity.noteId,
       blockContentId: identity.blockContentId,
       origin: identity.origin,

--- a/src/services/persistence/IndexedDBNotePersistence.ts
+++ b/src/services/persistence/IndexedDBNotePersistence.ts
@@ -143,7 +143,8 @@ export class IndexedDBNotePersistence implements INotePersistence {
       if (mutation.workoutResult) {
         const id = this.locatorToId(locator);
         const now = Date.now();
-        note = { id, title: id, createdAt: now, type: mutation.noteType ?? mutation.metadata?.type };
+        const fallbackTitle = mutation.metadata?.title ?? (id.startsWith('journal/') ? 'Journal Note' : 'Workout Note');
+        note = { id, title: fallbackTitle, createdAt: now, type: mutation.noteType ?? mutation.metadata?.type };
         await this.storage.saveNote(note);
       } else {
         throw new NotePersistenceError('NOTE_NOT_FOUND', `Note not found: ${this.describeLocator(locator)}`);


### PR DESCRIPTION
fix: resolve 8 dogfood round-3 issues (analytics dupes, timezone, playground resume, collections nav, shell UX)

N9  — AnalyticsEngine: skip live/finalize projection emissions whose
      signature (name+value+unit+type, timestamps ignored) is unchanged;
      read-side dedupe in getAnalyticsFromLogs (1s window) and
      normalizeSummaryFacts (metricKey, keep-last) for legacy rows.
#5  — playgroundDisplay: playground ids/labels/parse now local time,
      matching journal date semantics (was UTC).
N8  — PlaygroundRedirect resumes the most-recent playground instead of
      minting an orphan per visit; createPlaygroundPage writes the
      composite playground/<ts> page the note page actually loads.
R3-C — collection index links with onRun navigate on primary click
      (CanvasPage, PageNavDropdown, PageToolbar) instead of scrolling
      to a broken workout-<glob-key> anchor.
R3-D — getWorkoutPreview strips inline markdown and skips in-body
      frontmatter delimiter blocks.
R3-E — explorer anatomy panel live-parses the draft query; telemetry
      shows only for the last-run query.
#7  — DocumentTitleSync: route-level tab titles; /effort/:slug and
      /playground/:id leaf writers exempt; brand unified to Wod.Wiki.
#8  — FirstNoteWizard gains a real ✕ Close button; DialogPanel made
      relative for stacking; modal/inert semantics unchanged.

Verified: tsc baseline-diff clean; src suite 2894 pass; playground
isolated suite green except two pre-existing failures; browser smoke
for all eight fixes (journal logging, explorer facts, effort recents,
collection nav, titles, wizard, playground resume, deduped logs).